### PR TITLE
Feat: optimize in memory log search with trie data-structure

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -41,14 +41,14 @@
         "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.1",
         "tw-animate-css": "^1.3.5",
-        "zod": "^3.25.74"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4.1.11",
         "@tanstack/react-query-devtools": "^5.81.5",
         "@types/event-source-polyfill": "^1.0.5",
-        "@types/node": "^24.0.10",
+        "@types/node": "^24.0.11",
         "@types/react": "19.1.8",
         "@types/react-dom": "^19.1.6",
         "@types/react-window": "^1.8.8",
@@ -2407,9 +2407,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "version": "24.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.11.tgz",
+      "integrity": "sha512-CJV8eqrYnwQJGMrvcRhQmZfpyniDavB+7nAZYJc6w99hFYJyFN3INV1/2W3QfQrqM36WTLrijJ1fxxvGBmCSxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7490,9 +7490,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.74",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.74.tgz",
-      "integrity": "sha512-J8poo92VuhKjNknViHRAIuuN6li/EwFbAC8OedzI8uxpEPGiXHGQu9wemIAioIpqgfB4SySaJhdk0mH5Y4ICBg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -44,14 +44,14 @@
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.3.5",
-    "zod": "^3.25.74"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4.1.11",
     "@tanstack/react-query-devtools": "^5.81.5",
     "@types/event-source-polyfill": "^1.0.5",
-    "@types/node": "^24.0.10",
+    "@types/node": "^24.0.11",
     "@types/react": "19.1.8",
     "@types/react-dom": "^19.1.6",
     "@types/react-window": "^1.8.8",

--- a/dashboard/src/lib/trie.ts
+++ b/dashboard/src/lib/trie.ts
@@ -1,0 +1,91 @@
+class TrieNode {
+    children: Map<string, TrieNode>;
+    // Each element in 'occurrences' marks the start of a suffix
+    // that begins at this node.
+    // It stores the original line index and the start index of this suffix within that line.
+    occurrences: Array<{ lineIndex: number; originalStartIndex: number }>;
+
+    constructor() {
+        this.children = new Map();
+        this.occurrences = [];
+    }
+}
+
+export class Trie {
+    root: TrieNode;
+
+    constructor() {
+        this.root = new TrieNode();
+    }
+
+    // Inserts all suffixes of a line into the Trie
+    insert(line: string, lineIndex: number): void {
+        const lowerLine = line.toLowerCase(); // Normalize to lowercase
+        for (let i = 0; i < lowerLine.length; i++) {
+            let node = this.root;
+            // For each suffix starting at index i
+            for (let j = i; j < lowerLine.length; j++) {
+                const char = lowerLine[j];
+                if (!node.children.has(char)) {
+                    node.children.set(char, new TrieNode());
+                }
+                node = node.children.get(char)!;
+            }
+            // Mark the end of this suffix (which is also a node in the Trie path)
+            // and store its original line index and starting position in the original line.
+            node.occurrences.push({ lineIndex, originalStartIndex: i });
+        }
+    }
+
+    // Searches for a query string (substring) in the Trie
+    search(query: string): Array<{ lineIndex: number; startIndex: number; endIndex: number }> {
+        const results: Array<{ lineIndex: number; startIndex: number; endIndex: number }> = [];
+        if (!query) {
+            return results;
+        }
+        const lowerQuery = query.toLowerCase(); // Normalize query to lowercase
+
+        let node = this.root;
+        // Traverse the Trie for the query string
+        for (const char of lowerQuery) {
+            if (!node.children.has(char)) {
+                return results; // Query string not found as a path in the Trie
+            }
+            node = node.children.get(char)!;
+        }
+
+        // If we reached this point, the 'node' represents the Trie node
+        // corresponding to the end of the query string.
+        // All suffixes that start with this query string will have passed through this node.
+        // We need to collect all occurrences from this node downwards,
+        // as any path from this node represents a string that starts with the query.
+
+        this._collectMatches(node, lowerQuery.length, results);
+
+        return results;
+    }
+
+    // Helper function to collect all occurrences from a given node and its descendants.
+    // All these occurrences started with the query string.
+    private _collectMatches(
+        node: TrieNode,
+        queryLength: number,
+        results: Array<{ lineIndex: number; startIndex: number; endIndex: number }>
+    ): void {
+        // Add all occurrences stored at the current node
+        // These are suffixes that exactly match the query (or query is a prefix of them,
+        // and this node is where that prefix path ends)
+        for (const occurrence of node.occurrences) {
+            results.push({
+                lineIndex: occurrence.lineIndex,
+                startIndex: occurrence.originalStartIndex, // This is the start of the query in the original line
+                endIndex: occurrence.originalStartIndex + queryLength,
+            });
+        }
+
+        // Recursively visit all children to find suffixes that *contain* the query as a prefix
+        for (const childNode of node.children.values()) {
+            this._collectMatches(childNode, queryLength, results);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Implement Trie for log searching in LogsViewer.

- Create Trie data structure in `lib/trie.ts`.
- Integrate Trie into `LogsViewer` component:
  - Build the Trie when logs change.
  - Use Trie for searching log messages, replacing the previous `indexOf` approach.
- This aims to provide faster search performance for large log sets, especially for repeated searches, at the cost of increased initial build time and memory usage for the Trie itself.
- Search remains case-insensitive and highlights all occurrences.
- Navigation between search results is preserved.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes