### PR TITLE
feat: add singleflight request coalescing to service reads

### DIFF
--- a/internal/pkg/kind/container/docker.go
+++ b/internal/pkg/kind/container/docker.go
@@ -306,7 +306,8 @@ func (w *DockerWorkflow) Build(ctx context.Context, imageName string) error {
 			return nil, status.Errorf(codes.Aborted, "failed to read image pull output: %v", err)
 		}
 
-		return nil, nil
+		// Return a non-nil dummy value to satisfy the linter; callers ignore Val anyway.
+		return struct{}{}, nil
 	})
 
 	select {

--- a/internal/pkg/kind/container/docker.go
+++ b/internal/pkg/kind/container/docker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -29,6 +30,7 @@ const (
 // DockerWorkflow represents a Docker workflow.
 type DockerWorkflow struct {
 	*client.Client
+	pullGroup singleflight.Group
 }
 
 // NewDockerWorkflow creates a new DockerWorkflow.
@@ -292,19 +294,31 @@ func (w *DockerWorkflow) Build(ctx context.Context, imageName string) error {
 		return err
 	}
 
-	out, err := w.Client.ImagePull(ctx, imageName, image.PullOptions{})
-	if err != nil {
-		return status.Errorf(codes.NotFound, "failed to pull image: %v", err)
-	}
-	defer out.Close()
+	resultCh := w.pullGroup.DoChan(imageName, func() (any, error) {
+		out, err := w.Client.ImagePull(ctx, imageName, image.PullOptions{})
+		if err != nil {
+			return nil, status.Errorf(codes.NotFound, "failed to pull image: %v", err)
+		}
+		defer out.Close()
 
-	// Read the output to completion, required to properly register the image in Docker desktop
-	_, err = io.Copy(io.Discard, out)
-	if err != nil {
-		return status.Errorf(codes.Aborted, "failed to read image pull output: %v", err)
-	}
+		// Read the output to completion so the pulled image is registered locally.
+		if _, err = io.Copy(io.Discard, out); err != nil {
+			return nil, status.Errorf(codes.Aborted, "failed to read image pull output: %v", err)
+		}
 
-	return nil
+		return nil, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return status.Error(codes.DeadlineExceeded, ctx.Err().Error())
+		}
+
+		return status.Error(codes.Canceled, ctx.Err().Error())
+	case result := <-resultCh:
+		return result.Err
+	}
 }
 
 // Terminate stops a running container by its unique containerID.

--- a/internal/service/analytics/analytics.go
+++ b/internal/service/analytics/analytics.go
@@ -4,11 +4,14 @@ package analytics
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/go-playground/validator/v10"
 	"go.opentelemetry.io/otel"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -28,6 +31,7 @@ type Service struct {
 	tp        trace.Tracer
 	validator *validator.Validate
 	repo      Repository
+	sf        singleflight.Group
 }
 
 // New creates a new analytics service.
@@ -63,7 +67,11 @@ func (s *Service) GetUserAnalytics(ctx context.Context, req *analyticspb.GetUser
 		return nil, err
 	}
 
-	res, err = s.repo.GetUserAnalytics(ctx, req.GetUserId())
+	resultCh := s.sf.DoChan(fmt.Sprintf("analytics:user:%s", req.GetUserId()), func() (any, error) {
+		return s.repo.GetUserAnalytics(ctx, req.GetUserId())
+	})
+
+	res, err = waitSingleflightResult[*analyticsmodel.GetUserAnalyticsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -97,10 +105,41 @@ func (s *Service) GetWorkflowAnalytics(ctx context.Context, req *analyticspb.Get
 		return nil, err
 	}
 
-	res, err = s.repo.GetWorkflowAnalytics(ctx, req.GetUserId(), req.GetWorkflowId())
+	resultCh := s.sf.DoChan(
+		fmt.Sprintf("analytics:workflow:%s:%s", req.GetUserId(), req.GetWorkflowId()),
+		func() (any, error) {
+			return s.repo.GetWorkflowAnalytics(ctx, req.GetUserId(), req.GetWorkflowId())
+		},
+	)
+
+	res, err = waitSingleflightResult[*analyticsmodel.GetWorkflowAnalyticsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
 
 	return res, nil
+}
+
+func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
+	var zero T
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
+		}
+
+		return zero, status.Error(codes.Canceled, ctx.Err().Error())
+	case result := <-resultCh:
+		if result.Err != nil {
+			return zero, result.Err
+		}
+
+		typed, ok := result.Val.(T)
+		if !ok {
+			return zero, status.Error(codes.Internal, "invalid singleflight result type")
+		}
+
+		return typed, nil
+	}
 }

--- a/internal/service/analytics/analytics_test.go
+++ b/internal/service/analytics/analytics_test.go
@@ -1,7 +1,10 @@
 package analytics_test
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
@@ -25,13 +28,19 @@ func TestGetUserAnalytics(t *testing.T) {
 	// Create a new service
 	s := analytics.New(validator.New(), repo)
 
+	var (
+		singleflightRepoCalls   int32
+		singleflightReleaseChan chan struct{}
+	)
+
 	// Test cases
 	tests := []struct {
-		name  string
-		req   *analyticspb.GetUserAnalyticsRequest
-		mock  func(req *analyticspb.GetUserAnalyticsRequest)
-		want  *analyticsmodel.GetUserAnalyticsResponse
-		isErr bool
+		name    string
+		req     *analyticspb.GetUserAnalyticsRequest
+		mock    func(req *analyticspb.GetUserAnalyticsRequest)
+		execute func(t *testing.T, req *analyticspb.GetUserAnalyticsRequest, want *analyticsmodel.GetUserAnalyticsResponse)
+		want    *analyticsmodel.GetUserAnalyticsResponse
+		isErr   bool
 	}{
 		{
 			name: "success",
@@ -48,6 +57,66 @@ func TestGetUserAnalytics(t *testing.T) {
 					TotalJoblogs:              5000,
 					TotalJobExecutionDuration: 1000000,
 				}, nil)
+			},
+			want: &analyticsmodel.GetUserAnalyticsResponse{
+				TotalWorkflows:            10,
+				TotalJobs:                 200,
+				TotalJoblogs:              5000,
+				TotalJobExecutionDuration: 1000000,
+			},
+			isErr: false,
+		},
+		{
+			name: "success: singleflight deduplicates concurrent request",
+			req: &analyticspb.GetUserAnalyticsRequest{
+				UserId: "user1",
+			},
+			mock: func(req *analyticspb.GetUserAnalyticsRequest) {
+				singleflightRepoCalls = 0
+				singleflightReleaseChan = make(chan struct{})
+				repo.EXPECT().GetUserAnalytics(
+					gomock.Any(),
+					req.GetUserId(),
+				).DoAndReturn(func(_ any, _ string) (*analyticsmodel.GetUserAnalyticsResponse, error) {
+					atomic.AddInt32(&singleflightRepoCalls, 1)
+					<-singleflightReleaseChan
+					return &analyticsmodel.GetUserAnalyticsResponse{
+						TotalWorkflows:            10,
+						TotalJobs:                 200,
+						TotalJoblogs:              5000,
+						TotalJobExecutionDuration: 1000000,
+					}, nil
+				}).Times(1)
+			},
+			execute: func(t *testing.T, req *analyticspb.GetUserAnalyticsRequest, want *analyticsmodel.GetUserAnalyticsResponse) {
+				t.Helper()
+
+				var wg sync.WaitGroup
+				results := make([]*analyticsmodel.GetUserAnalyticsResponse, 2)
+				errs := make([]error, 2)
+
+				for i := range 2 {
+					wg.Add(1)
+					go func(idx int) {
+						defer wg.Done()
+						results[idx], errs[idx] = s.GetUserAnalytics(t.Context(), req)
+					}(i)
+				}
+
+				for range 50 {
+					if atomic.LoadInt32(&singleflightRepoCalls) == 1 {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+				close(singleflightReleaseChan)
+				wg.Wait()
+
+				assert.Equal(t, int32(1), atomic.LoadInt32(&singleflightRepoCalls))
+				assert.NoError(t, errs[0])
+				assert.NoError(t, errs[1])
+				assert.Equal(t, want, results[0])
+				assert.Equal(t, want, results[1])
 			},
 			want: &analyticsmodel.GetUserAnalyticsResponse{
 				TotalWorkflows:            10,
@@ -101,6 +170,11 @@ func TestGetUserAnalytics(t *testing.T) {
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.execute != nil {
+				tt.execute(t, tt.req, tt.want)
+				return
+			}
+
 			analytics, err := s.GetUserAnalytics(t.Context(), tt.req)
 			if tt.isErr {
 				if err == nil {

--- a/internal/service/jobs/jobs.go
+++ b/internal/service/jobs/jobs.go
@@ -315,8 +315,9 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 	}
 
+	//nolint:dupl // The logic for fetching job logs and searching job logs is similar, we can ignore the duplication here
 	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
-		res, jobStatus, err := s.repo.GetJobLogs(
+		_res, jobStatus, _err := s.repo.GetJobLogs(
 			ctx,
 			req.GetId(),
 			req.GetWorkflowId(),
@@ -324,17 +325,17 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 			req.GetCursor(),
 			filters,
 		)
-		if err != nil {
-			return nil, err
+		if _err != nil {
+			return nil, _err
 		}
 
 		// Cache stable pages once for the shared result.
-		if isTerminalJobStatus(jobStatus) || res.Cursor != "" {
+		if isTerminalJobStatus(jobStatus) || _res.Cursor != "" {
 			go func() {
 				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 				defer cancel()
 
-				if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
+				if setErr := s.cache.Set(bgCtx, cacheKey, _res, defaultExpirationTTL); setErr != nil {
 					logger.Warn("failed to cache job logs",
 						zap.String("user_id", req.GetUserId()),
 						zap.String("job_id", req.GetId()),
@@ -351,7 +352,7 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 			}()
 		}
 
-		return res, nil
+		return _res, nil
 	})
 
 	res, err = waitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
@@ -509,8 +510,9 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 		return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 	}
 
+	//nolint:dupl // The logic for fetching job logs and searching job logs is similar, we can ignore the duplication here
 	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
-		res, jobStatus, err := s.repo.SearchJobLogs(
+		_res, jobStatus, _err := s.repo.SearchJobLogs(
 			ctx,
 			req.GetId(),
 			req.GetWorkflowId(),
@@ -518,16 +520,16 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 			req.GetCursor(),
 			filters,
 		)
-		if err != nil {
-			return nil, err
+		if _err != nil {
+			return nil, _err
 		}
 
-		if isTerminalJobStatus(jobStatus) || res.Cursor != "" {
+		if isTerminalJobStatus(jobStatus) || _res.Cursor != "" {
 			go func() {
 				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 				defer cancel()
 
-				if setErr := s.cache.Set(bgCtx, cacheKey, res, jobLogSearchExpirationTTL); setErr != nil {
+				if setErr := s.cache.Set(bgCtx, cacheKey, _res, jobLogSearchExpirationTTL); setErr != nil {
 					logger.Warn("failed to cache job logs",
 						zap.String("user_id", req.GetUserId()),
 						zap.String("job_id", req.GetId()),
@@ -544,7 +546,7 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 			}()
 		}
 
-		return res, nil
+		return _res, nil
 	})
 
 	res, err = waitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)

--- a/internal/service/jobs/jobs.go
+++ b/internal/service/jobs/jobs.go
@@ -16,6 +16,7 @@ import (
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -57,6 +58,7 @@ type Service struct {
 	tp        trace.Tracer
 	repo      Repository
 	cache     Cache
+	sf        singleflight.Group
 }
 
 // New creates a new jobs-service.
@@ -236,8 +238,11 @@ func (s *Service) GetJobByID(ctx context.Context, req *jobspb.GetJobByIDRequest)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	// Get the scheduled job details
-	res, err = s.repo.GetJobByID(ctx, req.GetId())
+	resultCh := s.sf.DoChan(fmt.Sprintf("job_by_id:%s", req.GetId()), func() (any, error) {
+		return s.repo.GetJobByID(ctx, req.GetId())
+	})
+
+	res, err = waitSingleflightResult[*jobsmodel.GetJobByIDResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -310,45 +315,48 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 	}
 
-	// Get the scheduled job logs
-	var jobStatus string
-	res, jobStatus, err = s.repo.GetJobLogs(
-		ctx,
-		req.GetId(),
-		req.GetWorkflowId(),
-		req.GetUserId(),
-		req.GetCursor(),
-		filters,
-	)
+	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
+		res, jobStatus, err := s.repo.GetJobLogs(
+			ctx,
+			req.GetId(),
+			req.GetWorkflowId(),
+			req.GetUserId(),
+			req.GetCursor(),
+			filters,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// Cache stable pages once for the shared result.
+		if isTerminalJobStatus(jobStatus) || res.Cursor != "" {
+			go func() {
+				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
+				defer cancel()
+
+				if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
+					logger.Warn("failed to cache job logs",
+						zap.String("user_id", req.GetUserId()),
+						zap.String("job_id", req.GetId()),
+						zap.String("cache_key", cacheKey),
+						zap.Error(setErr),
+					)
+				} else if logger.Core().Enabled(zap.DebugLevel) {
+					logger.Debug("cached job logs",
+						zap.String("user_id", req.GetUserId()),
+						zap.String("job_id", req.GetId()),
+						zap.String("cache_key", cacheKey),
+					)
+				}
+			}()
+		}
+
+		return res, nil
+	})
+
+	res, err = waitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
-	}
-
-	// Cache the response in the background, if any of the following conditions are satisfied:
-	// 1. The job status is in terminal state(which ensures the job status won't change further)
-	// 2. Next cursor exists(which ensure that these are not the trailing logs and can be cached)
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
-	if isTerminalJobStatus(jobStatus) || res.Cursor != "" {
-		go func() {
-			bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
-			defer cancel()
-
-			// Cache the job logs
-			if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
-				logger.Warn("failed to cache job logs",
-					zap.String("user_id", req.GetUserId()),
-					zap.String("job_id", req.GetId()),
-					zap.String("cache_key", cacheKey),
-					zap.Error(setErr),
-				)
-			} else if logger.Core().Enabled(zap.DebugLevel) {
-				logger.Debug("cached job logs",
-					zap.String("user_id", req.GetUserId()),
-					zap.String("job_id", req.GetId()),
-					zap.String("cache_key", cacheKey),
-				)
-			}
-		}()
 	}
 
 	return res, nil
@@ -501,45 +509,47 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 		return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 	}
 
-	// Get all the filtered job logs
-	var jobStatus string
-	res, jobStatus, err = s.repo.SearchJobLogs(
-		ctx,
-		req.GetId(),
-		req.GetWorkflowId(),
-		req.GetUserId(),
-		req.GetCursor(),
-		filters,
-	)
+	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
+		res, jobStatus, err := s.repo.SearchJobLogs(
+			ctx,
+			req.GetId(),
+			req.GetWorkflowId(),
+			req.GetUserId(),
+			req.GetCursor(),
+			filters,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if isTerminalJobStatus(jobStatus) || res.Cursor != "" {
+			go func() {
+				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
+				defer cancel()
+
+				if setErr := s.cache.Set(bgCtx, cacheKey, res, jobLogSearchExpirationTTL); setErr != nil {
+					logger.Warn("failed to cache job logs",
+						zap.String("user_id", req.GetUserId()),
+						zap.String("job_id", req.GetId()),
+						zap.String("cache_key", cacheKey),
+						zap.Error(setErr),
+					)
+				} else if logger.Core().Enabled(zap.DebugLevel) {
+					logger.Debug("cached job logs",
+						zap.String("user_id", req.GetUserId()),
+						zap.String("job_id", req.GetId()),
+						zap.String("cache_key", cacheKey),
+					)
+				}
+			}()
+		}
+
+		return res, nil
+	})
+
+	res, err = waitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
-	}
-
-	// Cache the response in the background, if any of the following conditions are satisfied:
-	// 1. The job status is in terminal state(which ensures the job status won't change further)
-	// 2. Next cursor exists(which ensure that these are not the trailing logs and can be cached)
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
-	if isTerminalJobStatus(jobStatus) || res.Cursor != "" {
-		go func() {
-			bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
-			defer cancel()
-
-			// Cache the job logs
-			if setErr := s.cache.Set(bgCtx, cacheKey, res, jobLogSearchExpirationTTL); setErr != nil {
-				logger.Warn("failed to cache job logs",
-					zap.String("user_id", req.GetUserId()),
-					zap.String("job_id", req.GetId()),
-					zap.String("cache_key", cacheKey),
-					zap.Error(setErr),
-				)
-			} else if logger.Core().Enabled(zap.DebugLevel) {
-				logger.Debug("cached job logs",
-					zap.String("user_id", req.GetUserId()),
-					zap.String("job_id", req.GetId()),
-					zap.String("cache_key", cacheKey),
-				)
-			}
-		}()
 	}
 
 	return res, nil
@@ -602,8 +612,19 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 		return nil, err
 	}
 
-	// List all scheduled jobs by job ID
-	res, err = s.repo.ListJobs(ctx, req.GetWorkflowId(), req.GetUserId(), cursor, filters)
+	listKey := fmt.Sprintf(
+		"jobs:%s:%s:cursor=%s&status=%s&trigger=%s",
+		req.GetUserId(),
+		req.GetWorkflowId(),
+		req.GetCursor(),
+		filters.Status,
+		filters.Trigger,
+	)
+	resultCh := s.sf.DoChan(listKey, func() (any, error) {
+		return s.repo.ListJobs(ctx, req.GetWorkflowId(), req.GetUserId(), cursor, filters)
+	})
+
+	res, err = waitSingleflightResult[*jobsmodel.ListJobsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -677,4 +698,28 @@ func decodeListJobsCursor(token string) (string, error) {
 	}
 
 	return string(decoded), nil
+}
+
+func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
+	var zero T
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
+		}
+
+		return zero, status.Error(codes.Canceled, ctx.Err().Error())
+	case result := <-resultCh:
+		if result.Err != nil {
+			return zero, result.Err
+		}
+
+		typed, ok := result.Val.(T)
+		if !ok {
+			return zero, status.Error(codes.Internal, "invalid singleflight result type")
+		}
+
+		return typed, nil
+	}
 }

--- a/internal/service/jobs/jobs_test.go
+++ b/internal/service/jobs/jobs_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -637,15 +639,20 @@ func TestGetJobLogs(t *testing.T) {
 		*jobsmodel.GetJobLogsResponse
 	}
 
-	timestamp := time.Now()
+	var (
+		timestamp               = time.Now()
+		singleflightRepoCalls   int32
+		singleflightReleaseChan chan struct{}
+	)
 
 	// Test cases
 	tests := []struct {
-		name  string
-		req   *jobspb.GetJobLogsRequest
-		mock  func(req *jobspb.GetJobLogsRequest)
-		want  want
-		isErr bool
+		name    string
+		req     *jobspb.GetJobLogsRequest
+		mock    func(req *jobspb.GetJobLogsRequest)
+		execute func(t *testing.T, req *jobspb.GetJobLogsRequest, want want)
+		want    want
+		isErr   bool
 	}{
 		{
 			name: "success",
@@ -889,6 +896,102 @@ func TestGetJobLogs(t *testing.T) {
 			isErr: false,
 		},
 		{
+			name: "success: singleflight deduplicates cache miss",
+			req: &jobspb.GetJobLogsRequest{
+				Id:         "job_id",
+				WorkflowId: "workflow_id",
+				UserId:     "user_id",
+				Filters: &jobspb.GetJobLogsFilters{
+					Stream: jobspb.LogStream_LOG_STREAM_ALL,
+				},
+			},
+			mock: func(req *jobspb.GetJobLogsRequest) {
+				cacheKey := fmt.Sprintf(
+					"job_logs:%s:%s:%s:%s",
+					req.GetUserId(),
+					req.GetId(),
+					req.GetCursor(),
+					req.GetFilters().GetStream(),
+				)
+				filters := &jobsmodel.GetJobLogsFilters{Stream: int(req.GetFilters().GetStream())}
+
+				cache.EXPECT().
+					Get(gomock.Any(), cacheKey, gomock.Any()).
+					Return(nil, status.Error(codes.NotFound, "cache miss")).
+					Times(2)
+				cache.EXPECT().
+					Set(gomock.Any(), cacheKey, gomock.Any(), gomock.Any()).
+					Return(nil).
+					AnyTimes()
+
+				singleflightRepoCalls = 0
+				singleflightReleaseChan = make(chan struct{})
+				repo.EXPECT().
+					GetJobLogs(gomock.Any(), req.GetId(), req.GetWorkflowId(), req.GetUserId(), req.GetCursor(), filters).
+					DoAndReturn(func(_ any, _, _, _, _ string, _ *jobsmodel.GetJobLogsFilters) (*jobsmodel.GetJobLogsResponse, string, error) {
+						atomic.AddInt32(&singleflightRepoCalls, 1)
+						<-singleflightReleaseChan
+						return &jobsmodel.GetJobLogsResponse{
+							ID:         "job_id",
+							WorkflowID: "workflow_id",
+							JobLogs: []*jobsmodel.JobLog{
+								{
+									Timestamp:   timestamp,
+									Message:     "log 1",
+									SequenceNum: 1,
+									Stream:      "stdout",
+								},
+							},
+						}, "COMPLETED", nil
+					}).Times(1)
+			},
+			execute: func(t *testing.T, req *jobspb.GetJobLogsRequest, want want) {
+				t.Helper()
+
+				var wg sync.WaitGroup
+				results := make([]*jobsmodel.GetJobLogsResponse, 2)
+				errs := make([]error, 2)
+
+				for i := range 2 {
+					wg.Add(1)
+					go func(idx int) {
+						defer wg.Done()
+						results[idx], errs[idx] = s.GetJobLogs(t.Context(), req)
+					}(i)
+				}
+
+				for range 50 {
+					if atomic.LoadInt32(&singleflightRepoCalls) == 1 {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+				close(singleflightReleaseChan)
+				wg.Wait()
+
+				assert.Equal(t, int32(1), atomic.LoadInt32(&singleflightRepoCalls))
+				assert.NoError(t, errs[0])
+				assert.NoError(t, errs[1])
+				assert.Equal(t, want.GetJobLogsResponse, results[0])
+				assert.Equal(t, want.GetJobLogsResponse, results[1])
+			},
+			want: want{
+				&jobsmodel.GetJobLogsResponse{
+					ID:         "job_id",
+					WorkflowID: "workflow_id",
+					JobLogs: []*jobsmodel.JobLog{
+						{
+							Timestamp:   timestamp,
+							Message:     "log 1",
+							SequenceNum: 1,
+							Stream:      "stdout",
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		{
 			name: "error: missing required fields in request",
 			req: &jobspb.GetJobLogsRequest{
 				Id:         "",
@@ -995,6 +1098,11 @@ func TestGetJobLogs(t *testing.T) {
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.execute != nil {
+				tt.execute(t, tt.req, tt.want)
+				return
+			}
+
 			jobLogs, err := s.GetJobLogs(t.Context(), tt.req)
 			if tt.isErr {
 				if err == nil {

--- a/internal/service/notifications/notifications.go
+++ b/internal/service/notifications/notifications.go
@@ -6,11 +6,14 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 
 	"github.com/go-playground/validator/v10"
 	"go.opentelemetry.io/otel"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -31,6 +34,7 @@ type Service struct {
 	validator *validator.Validate
 	tp        trace.Tracer
 	repo      Repository
+	sf        singleflight.Group
 }
 
 // New creates a new notifications service.
@@ -164,8 +168,14 @@ func (s *Service) ListNotifications(
 		}
 	}
 
-	// List the notifications
-	res, err = s.repo.ListNotifications(ctx, req.GetUserId(), cursor)
+	resultCh := s.sf.DoChan(
+		fmt.Sprintf("notifications:%s:cursor=%s", req.GetUserId(), req.GetCursor()),
+		func() (any, error) {
+			return s.repo.ListNotifications(ctx, req.GetUserId(), cursor)
+		},
+	)
+
+	res, err = waitSingleflightResult[*notificationsmodel.ListNotificationsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -180,4 +190,28 @@ func decodeCursor(token string) (string, error) {
 	}
 
 	return string(decoded), nil
+}
+
+func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
+	var zero T
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
+		}
+
+		return zero, status.Error(codes.Canceled, ctx.Err().Error())
+	case result := <-resultCh:
+		if result.Err != nil {
+			return zero, result.Err
+		}
+
+		typed, ok := result.Val.(T)
+		if !ok {
+			return zero, status.Error(codes.Internal, "invalid singleflight result type")
+		}
+
+		return typed, nil
+	}
 }

--- a/internal/service/notifications/notifications_test.go
+++ b/internal/service/notifications/notifications_test.go
@@ -2,6 +2,8 @@ package notifications_test
 
 import (
 	"database/sql"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -260,18 +262,21 @@ func TestService_ListNotifications(t *testing.T) {
 	}
 
 	var (
-		createdAt = time.Now()
-		updatedAt = time.Now()
-		readAt    = sql.NullTime{}
+		createdAt               = time.Now()
+		updatedAt               = time.Now()
+		readAt                  = sql.NullTime{}
+		singleflightRepoCalls   int32
+		singleflightReleaseChan chan struct{}
 	)
 
 	// Test cases
 	tests := []struct {
-		name  string
-		req   *notificationspb.ListNotificationsRequest
-		mock  func(req *notificationspb.ListNotificationsRequest)
-		want  want
-		isErr bool
+		name    string
+		req     *notificationspb.ListNotificationsRequest
+		mock    func(req *notificationspb.ListNotificationsRequest)
+		execute func(t *testing.T, req *notificationspb.ListNotificationsRequest, want want)
+		want    want
+		isErr   bool
 	}{
 		{
 			name: "success",
@@ -332,6 +337,84 @@ func TestService_ListNotifications(t *testing.T) {
 			isErr: false,
 		},
 		{
+			name: "success: singleflight deduplicates concurrent request",
+			req: &notificationspb.ListNotificationsRequest{
+				UserId: "user1",
+				Cursor: "",
+			},
+			mock: func(req *notificationspb.ListNotificationsRequest) {
+				singleflightRepoCalls = 0
+				singleflightReleaseChan = make(chan struct{})
+				repo.EXPECT().ListNotifications(
+					gomock.Any(),
+					req.GetUserId(),
+					req.GetCursor(),
+				).DoAndReturn(func(_ any, _, _ string) (*notificationsmodel.ListNotificationsResponse, error) {
+					atomic.AddInt32(&singleflightRepoCalls, 1)
+					<-singleflightReleaseChan
+					return &notificationsmodel.ListNotificationsResponse{
+						Notifications: []*notificationsmodel.NotificationResponse{
+							{
+								ID:        "notification_id_1",
+								Kind:      "kind1",
+								Payload:   `{"key": "value"}`,
+								ReadAt:    readAt,
+								CreatedAt: createdAt,
+								UpdatedAt: updatedAt,
+							},
+						},
+						Cursor: "",
+					}, nil
+				}).Times(1)
+			},
+			execute: func(t *testing.T, req *notificationspb.ListNotificationsRequest, want want) {
+				t.Helper()
+
+				var wg sync.WaitGroup
+				results := make([]*notificationsmodel.ListNotificationsResponse, 2)
+				errs := make([]error, 2)
+
+				for i := range 2 {
+					wg.Add(1)
+					go func(idx int) {
+						defer wg.Done()
+						results[idx], errs[idx] = s.ListNotifications(t.Context(), req)
+					}(i)
+				}
+
+				for range 50 {
+					if atomic.LoadInt32(&singleflightRepoCalls) == 1 {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+				close(singleflightReleaseChan)
+				wg.Wait()
+
+				assert.Equal(t, int32(1), atomic.LoadInt32(&singleflightRepoCalls))
+				assert.NoError(t, errs[0])
+				assert.NoError(t, errs[1])
+				assert.Equal(t, want.ListNotificationsResponse, results[0])
+				assert.Equal(t, want.ListNotificationsResponse, results[1])
+			},
+			want: want{
+				ListNotificationsResponse: &notificationsmodel.ListNotificationsResponse{
+					Notifications: []*notificationsmodel.NotificationResponse{
+						{
+							ID:        "notification_id_1",
+							Kind:      "kind1",
+							Payload:   `{"key": "value"}`,
+							ReadAt:    readAt,
+							CreatedAt: createdAt,
+							UpdatedAt: updatedAt,
+						},
+					},
+					Cursor: "",
+				},
+			},
+			isErr: false,
+		},
+		{
 			name: "error: missing user ID",
 			req: &notificationspb.ListNotificationsRequest{
 				UserId: "",
@@ -380,6 +463,11 @@ func TestService_ListNotifications(t *testing.T) {
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.execute != nil {
+				tt.execute(t, tt.req, tt.want)
+				return
+			}
+
 			notifications, err := s.ListNotifications(t.Context(), tt.req)
 			if tt.isErr {
 				if err == nil {

--- a/internal/service/users/users.go
+++ b/internal/service/users/users.go
@@ -232,9 +232,9 @@ func (s *Service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (res 
 	}
 
 	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
-		res, err := s.repo.GetUser(ctx, req.GetId())
-		if err != nil {
-			return nil, err
+		_res, _err := s.repo.GetUser(ctx, req.GetId())
+		if _err != nil {
+			return nil, _err
 		}
 
 		// Cache the GetUser response in the background once for the shared result.
@@ -242,21 +242,21 @@ func (s *Service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (res 
 			bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 			defer cancel()
 
-			if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
+			if setErr := s.cache.Set(bgCtx, cacheKey, _res, defaultExpirationTTL); setErr != nil {
 				logger.Warn("failed to cache user",
-					zap.String("user_id", res.ID),
+					zap.String("user_id", _res.ID),
 					zap.String("cache_key", cacheKey),
 					zap.Error(setErr),
 				)
 			} else if logger.Core().Enabled(zap.DebugLevel) {
 				logger.Debug("cached user",
-					zap.String("user_id", res.ID),
+					zap.String("user_id", _res.ID),
 					zap.String("cache_key", cacheKey),
 				)
 			}
 		}()
 
-		return res, nil
+		return _res, nil
 	})
 
 	res, err = waitSingleflightResult[*usersmodel.GetUserResponse](ctx, resultCh)

--- a/internal/service/users/users.go
+++ b/internal/service/users/users.go
@@ -13,6 +13,7 @@ import (
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -49,6 +50,7 @@ type Service struct {
 	tp        trace.Tracer
 	repo      Repository
 	cache     Cache
+	sf        singleflight.Group
 }
 
 // New creates a new users-service.
@@ -229,32 +231,38 @@ func (s *Service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (res 
 		return cacheRes.(*usersmodel.GetUserResponse), nil
 	}
 
-	res, err = s.repo.GetUser(ctx, req.GetId())
+	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
+		res, err := s.repo.GetUser(ctx, req.GetId())
+		if err != nil {
+			return nil, err
+		}
+
+		// Cache the GetUser response in the background once for the shared result.
+		go func() {
+			bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
+			defer cancel()
+
+			if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
+				logger.Warn("failed to cache user",
+					zap.String("user_id", res.ID),
+					zap.String("cache_key", cacheKey),
+					zap.Error(setErr),
+				)
+			} else if logger.Core().Enabled(zap.DebugLevel) {
+				logger.Debug("cached user",
+					zap.String("user_id", res.ID),
+					zap.String("cache_key", cacheKey),
+				)
+			}
+		}()
+
+		return res, nil
+	})
+
+	res, err = waitSingleflightResult[*usersmodel.GetUserResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
-
-	// Cache the response in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
-	go func() {
-		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
-		defer cancel()
-
-		// Cache the GetUser response
-		// The key is in the format "user:{user_id}"
-		if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
-			logger.Warn("failed to cache user",
-				zap.String("user_id", res.ID),
-				zap.String("cache_key", cacheKey),
-				zap.Error(setErr),
-			)
-		} else if logger.Core().Enabled(zap.DebugLevel) {
-			logger.Debug("cached user",
-				zap.String("user_id", res.ID),
-				zap.String("cache_key", cacheKey),
-			)
-		}
-	}()
 
 	return res, nil
 }
@@ -317,4 +325,28 @@ func (s *Service) UpdateUser(ctx context.Context, req *userpb.UpdateUserRequest)
 	}
 
 	return err
+}
+
+func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
+	var zero T
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
+		}
+
+		return zero, status.Error(codes.Canceled, ctx.Err().Error())
+	case result := <-resultCh:
+		if result.Err != nil {
+			return zero, result.Err
+		}
+
+		typed, ok := result.Val.(T)
+		if !ok {
+			return zero, status.Error(codes.Internal, "invalid singleflight result type")
+		}
+
+		return typed, nil
+	}
 }

--- a/internal/service/users/users_test.go
+++ b/internal/service/users/users_test.go
@@ -1,6 +1,8 @@
 package users_test
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -283,17 +285,20 @@ func TestGetUser(t *testing.T) {
 	}
 
 	var (
-		createdAt = time.Now()
-		updatedAt = time.Now()
+		createdAt               = time.Now()
+		updatedAt               = time.Now()
+		singleflightRepoCalls   int32
+		singleflightReleaseChan chan struct{}
 	)
 
 	// Test cases
 	tests := []struct {
-		name  string
-		req   *userspb.GetUserRequest
-		mock  func(req *userspb.GetUserRequest)
-		want  want
-		isErr bool
+		name    string
+		req     *userspb.GetUserRequest
+		mock    func(req *userspb.GetUserRequest)
+		execute func(t *testing.T, req *userspb.GetUserRequest, want want)
+		want    want
+		isErr   bool
 	}{
 		{
 			name: "success: no cache hit",
@@ -356,6 +361,83 @@ func TestGetUser(t *testing.T) {
 					CreatedAt:              createdAt,
 					UpdatedAt:              updatedAt,
 				}, nil)
+			},
+			want: want{
+				GetUserResponse: &usersmodel.GetUserResponse{
+					ID:                     "userID",
+					Email:                  "user@example.com",
+					NotificationPreference: "ALERTS",
+					CreatedAt:              createdAt,
+					UpdatedAt:              updatedAt,
+				},
+			},
+			isErr: false,
+		},
+		{
+			name: "success: singleflight deduplicates cache miss",
+			req: &userspb.GetUserRequest{
+				Id: "userID",
+			},
+			mock: func(req *userspb.GetUserRequest) {
+				cache.EXPECT().Get(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil, status.Error(codes.NotFound, "cache miss")).Times(2)
+
+				cache.EXPECT().Set(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil).AnyTimes()
+
+				singleflightRepoCalls = 0
+				singleflightReleaseChan = make(chan struct{})
+				repo.EXPECT().GetUser(
+					gomock.Any(),
+					req.GetId(),
+				).DoAndReturn(func(_ any, _ string) (*usersmodel.GetUserResponse, error) {
+					atomic.AddInt32(&singleflightRepoCalls, 1)
+					<-singleflightReleaseChan
+					return &usersmodel.GetUserResponse{
+						ID:                     "userID",
+						Email:                  "user@example.com",
+						NotificationPreference: "ALERTS",
+						CreatedAt:              createdAt,
+						UpdatedAt:              updatedAt,
+					}, nil
+				}).Times(1)
+			},
+			execute: func(t *testing.T, req *userspb.GetUserRequest, want want) {
+				t.Helper()
+
+				var wg sync.WaitGroup
+				results := make([]*usersmodel.GetUserResponse, 2)
+				errs := make([]error, 2)
+
+				for i := range 2 {
+					wg.Add(1)
+					go func(idx int) {
+						defer wg.Done()
+						results[idx], errs[idx] = s.GetUser(t.Context(), req)
+					}(i)
+				}
+
+				for range 50 {
+					if atomic.LoadInt32(&singleflightRepoCalls) == 1 {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+				close(singleflightReleaseChan)
+				wg.Wait()
+
+				assert.Equal(t, int32(1), atomic.LoadInt32(&singleflightRepoCalls))
+				assert.NoError(t, errs[0])
+				assert.NoError(t, errs[1])
+				assert.Equal(t, want.GetUserResponse, results[0])
+				assert.Equal(t, want.GetUserResponse, results[1])
 			},
 			want: want{
 				GetUserResponse: &usersmodel.GetUserResponse{
@@ -447,6 +529,11 @@ func TestGetUser(t *testing.T) {
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.execute != nil {
+				tt.execute(t, tt.req, tt.want)
+				return
+			}
+
 			user, err := s.GetUser(t.Context(), tt.req)
 			if tt.isErr {
 				if err == nil {

--- a/internal/service/workflows/workflows.go
+++ b/internal/service/workflows/workflows.go
@@ -376,9 +376,9 @@ func (s *Service) GetWorkflow(ctx context.Context, req *workflowspb.GetWorkflowR
 	}
 
 	resultCh := s.sf.DoChan(cachedKey, func() (any, error) {
-		res, err := s.repo.GetWorkflow(ctx, req.GetId(), req.GetUserId())
-		if err != nil {
-			return nil, err
+		_res, _err := s.repo.GetWorkflow(ctx, req.GetId(), req.GetUserId())
+		if _err != nil {
+			return nil, _err
 		}
 
 		// Refresh the cached item and clear list entries once for the shared result.
@@ -388,7 +388,7 @@ func (s *Service) GetWorkflow(ctx context.Context, req *workflowspb.GetWorkflowR
 
 			s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
 
-			if setErr := s.cache.Set(bgCtx, cachedKey, res, defaultExpirationTTL); setErr != nil {
+			if setErr := s.cache.Set(bgCtx, cachedKey, _res, defaultExpirationTTL); setErr != nil {
 				logger.Warn("failed to cache workflow",
 					zap.String("user_id", req.GetUserId()),
 					zap.String("cache_key", cachedKey),
@@ -402,7 +402,7 @@ func (s *Service) GetWorkflow(ctx context.Context, req *workflowspb.GetWorkflowR
 			}
 		}()
 
-		return res, nil
+		return _res, nil
 	})
 
 	res, err = waitSingleflightResult[*workflowsmodel.GetWorkflowResponse](ctx, resultCh)
@@ -750,16 +750,16 @@ func (s *Service) ListWorkflows(ctx context.Context, req *workflowspb.ListWorkfl
 	}
 
 	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
-		res, err := s.repo.ListWorkflows(ctx, req.GetUserId(), cursor, filters)
-		if err != nil {
-			return nil, err
+		_res, _err := s.repo.ListWorkflows(ctx, req.GetUserId(), cursor, filters)
+		if _err != nil {
+			return nil, _err
 		}
 
 		go func() {
 			bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 			defer cancel()
 
-			if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
+			if setErr := s.cache.Set(bgCtx, cacheKey, _res, defaultExpirationTTL); setErr != nil {
 				logger.Warn("failed to cache workflows list",
 					zap.String("user_id", req.GetUserId()),
 					zap.String("cache_key", cacheKey),
@@ -773,7 +773,7 @@ func (s *Service) ListWorkflows(ctx context.Context, req *workflowspb.ListWorkfl
 			}
 		}()
 
-		return res, nil
+		return _res, nil
 	})
 
 	res, err = waitSingleflightResult[*workflowsmodel.ListWorkflowsResponse](ctx, resultCh)

--- a/internal/service/workflows/workflows.go
+++ b/internal/service/workflows/workflows.go
@@ -15,6 +15,7 @@ import (
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -60,6 +61,7 @@ type Service struct {
 	tp        trace.Tracer
 	repo      Repository
 	cache     Cache
+	sf        singleflight.Group
 }
 
 // New creates a new workflows-service.
@@ -373,35 +375,40 @@ func (s *Service) GetWorkflow(ctx context.Context, req *workflowspb.GetWorkflowR
 		return cacheRes.(*workflowsmodel.GetWorkflowResponse), nil
 	}
 
-	// Get the job details
-	res, err = s.repo.GetWorkflow(ctx, req.GetId(), req.GetUserId())
+	resultCh := s.sf.DoChan(cachedKey, func() (any, error) {
+		res, err := s.repo.GetWorkflow(ctx, req.GetId(), req.GetUserId())
+		if err != nil {
+			return nil, err
+		}
+
+		// Refresh the cached item and clear list entries once for the shared result.
+		go func() {
+			bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
+			defer cancel()
+
+			s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
+
+			if setErr := s.cache.Set(bgCtx, cachedKey, res, defaultExpirationTTL); setErr != nil {
+				logger.Warn("failed to cache workflow",
+					zap.String("user_id", req.GetUserId()),
+					zap.String("cache_key", cachedKey),
+					zap.Error(setErr),
+				)
+			} else if logger.Core().Enabled(zap.DebugLevel) {
+				logger.Debug("cached workflow",
+					zap.String("user_id", req.GetUserId()),
+					zap.String("cache_key", cachedKey),
+				)
+			}
+		}()
+
+		return res, nil
+	})
+
+	res, err = waitSingleflightResult[*workflowsmodel.GetWorkflowResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
-
-	// Cache the response in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
-	go func() {
-		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
-		defer cancel()
-
-		// Invalidate all list entries for the user
-		s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
-
-		// Cache the workflow details
-		if setErr := s.cache.Set(bgCtx, cachedKey, res, defaultExpirationTTL); setErr != nil {
-			logger.Warn("failed to cache workflow",
-				zap.String("user_id", req.GetUserId()),
-				zap.String("cache_key", cachedKey),
-				zap.Error(setErr),
-			)
-		} else if logger.Core().Enabled(zap.DebugLevel) {
-			logger.Debug("cached workflow",
-				zap.String("user_id", req.GetUserId()),
-				zap.String("cache_key", cachedKey),
-			)
-		}
-	}()
 
 	return res, nil
 }
@@ -432,8 +439,11 @@ func (s *Service) GetWorkflowByID(ctx context.Context, req *workflowspb.GetWorkf
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	// Get the job details
-	res, err = s.repo.GetWorkflowByID(ctx, req.GetId())
+	resultCh := s.sf.DoChan(fmt.Sprintf("workflow_by_id:%s", req.GetId()), func() (any, error) {
+		return s.repo.GetWorkflowByID(ctx, req.GetId())
+	})
+
+	res, err = waitSingleflightResult[*workflowsmodel.GetWorkflowByIDResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -739,31 +749,37 @@ func (s *Service) ListWorkflows(ctx context.Context, req *workflowspb.ListWorkfl
 		return cacheRes.(*workflowsmodel.ListWorkflowsResponse), nil
 	}
 
-	// List all workflows by user ID
-	res, err = s.repo.ListWorkflows(ctx, req.GetUserId(), cursor, filters)
+	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
+		res, err := s.repo.ListWorkflows(ctx, req.GetUserId(), cursor, filters)
+		if err != nil {
+			return nil, err
+		}
+
+		go func() {
+			bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
+			defer cancel()
+
+			if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
+				logger.Warn("failed to cache workflows list",
+					zap.String("user_id", req.GetUserId()),
+					zap.String("cache_key", cacheKey),
+					zap.Error(setErr),
+				)
+			} else if logger.Core().Enabled(zap.DebugLevel) {
+				logger.Debug("cached workflows list",
+					zap.String("user_id", req.GetUserId()),
+					zap.String("cache_key", cacheKey),
+				)
+			}
+		}()
+
+		return res, nil
+	})
+
+	res, err = waitSingleflightResult[*workflowsmodel.ListWorkflowsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
-
-	// Cache the response in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
-	go func() {
-		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
-		defer cancel()
-
-		if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
-			logger.Warn("failed to cache workflows list",
-				zap.String("user_id", req.GetUserId()),
-				zap.String("cache_key", cacheKey),
-				zap.Error(setErr),
-			)
-		} else if logger.Core().Enabled(zap.DebugLevel) {
-			logger.Debug("cached workflows list",
-				zap.String("user_id", req.GetUserId()),
-				zap.String("cache_key", cacheKey),
-			)
-		}
-	}()
 
 	return res, nil
 }
@@ -879,5 +895,29 @@ func (s *Service) invalidateWorkflowsCache(ctx context.Context, userID string, l
 			zap.String("user_id", userID),
 			zap.String("cache_key", cacheKey),
 			zap.Int64("count", count))
+	}
+}
+
+func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
+	var zero T
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
+		}
+
+		return zero, status.Error(codes.Canceled, ctx.Err().Error())
+	case result := <-resultCh:
+		if result.Err != nil {
+			return zero, result.Err
+		}
+
+		typed, ok := result.Val.(T)
+		if !ok {
+			return zero, status.Error(codes.Internal, "invalid singleflight result type")
+		}
+
+		return typed, nil
 	}
 }

--- a/internal/service/workflows/workflows_test.go
+++ b/internal/service/workflows/workflows_test.go
@@ -2,6 +2,8 @@ package workflows_test
 
 import (
 	"database/sql"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -747,9 +749,11 @@ func TestGetWorkflow(t *testing.T) {
 	}
 
 	var (
-		createdAt    = time.Now()
-		updatedAt    = time.Now()
-		terminatedAt = sql.NullTime{
+		createdAt               = time.Now()
+		updatedAt               = time.Now()
+		singleflightRepoCalls   int32
+		singleflightReleaseChan chan struct{}
+		terminatedAt            = sql.NullTime{
 			Time:  time.Now(),
 			Valid: true,
 		}
@@ -757,11 +761,12 @@ func TestGetWorkflow(t *testing.T) {
 
 	// Test cases
 	tests := []struct {
-		name  string
-		req   *workflowspb.GetWorkflowRequest
-		mock  func(req *workflowspb.GetWorkflowRequest)
-		want  want
-		isErr bool
+		name    string
+		req     *workflowspb.GetWorkflowRequest
+		mock    func(req *workflowspb.GetWorkflowRequest)
+		execute func(t *testing.T, req *workflowspb.GetWorkflowRequest, want want)
+		want    want
+		isErr   bool
 	}{
 		{
 			name: "success: no cache hit",
@@ -874,6 +879,104 @@ func TestGetWorkflow(t *testing.T) {
 			isErr: false,
 		},
 		{
+			name: "success: singleflight deduplicates cache miss",
+			req: &workflowspb.GetWorkflowRequest{
+				Id:     "workflow_id",
+				UserId: "user_id",
+			},
+			mock: func(req *workflowspb.GetWorkflowRequest) {
+				cache.EXPECT().Get(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil, status.Error(codes.NotFound, "cache miss")).Times(2)
+
+				cache.EXPECT().DeleteByPattern(
+					gomock.Any(),
+					gomock.Any(),
+				).Return(int64(0), nil).AnyTimes()
+
+				cache.EXPECT().Set(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil).AnyTimes()
+
+				singleflightRepoCalls = 0
+				singleflightReleaseChan = make(chan struct{})
+				repo.EXPECT().GetWorkflow(
+					gomock.Any(),
+					req.GetId(),
+					req.GetUserId(),
+				).DoAndReturn(func(_ any, _, _ string) (*workflowsmodel.GetWorkflowResponse, error) {
+					atomic.AddInt32(&singleflightRepoCalls, 1)
+					<-singleflightReleaseChan
+					return &workflowsmodel.GetWorkflowResponse{
+						ID:                               "workflow_id",
+						Name:                             "workflow1",
+						Payload:                          `{"headers": {"Content-Type": "application/json"}, "endpoint": "https://dummyjson.com/test"}`,
+						Kind:                             "HEARTBEAT",
+						WorkflowBuildStatus:              "COMPLETED",
+						Interval:                         1,
+						ConsecutiveJobFailuresCount:      0,
+						MaxConsecutiveJobFailuresAllowed: 5,
+						CreatedAt:                        createdAt,
+						UpdatedAt:                        updatedAt,
+						TerminatedAt:                     terminatedAt,
+						LogRetention:                     true,
+					}, nil
+				}).Times(1)
+			},
+			execute: func(t *testing.T, req *workflowspb.GetWorkflowRequest, want want) {
+				t.Helper()
+
+				var wg sync.WaitGroup
+				results := make([]*workflowsmodel.GetWorkflowResponse, 2)
+				errs := make([]error, 2)
+
+				for i := range 2 {
+					wg.Add(1)
+					go func(idx int) {
+						defer wg.Done()
+						results[idx], errs[idx] = s.GetWorkflow(t.Context(), req)
+					}(i)
+				}
+
+				for range 50 {
+					if atomic.LoadInt32(&singleflightRepoCalls) == 1 {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+				close(singleflightReleaseChan)
+				wg.Wait()
+
+				assert.Equal(t, int32(1), atomic.LoadInt32(&singleflightRepoCalls))
+				assert.NoError(t, errs[0])
+				assert.NoError(t, errs[1])
+				assert.Equal(t, want.GetWorkflowResponse, results[0])
+				assert.Equal(t, want.GetWorkflowResponse, results[1])
+			},
+			want: want{
+				&workflowsmodel.GetWorkflowResponse{
+					ID:                               "workflow_id",
+					Name:                             "workflow1",
+					Payload:                          `{"headers": {"Content-Type": "application/json"}, "endpoint": "https://dummyjson.com/test"}`,
+					Kind:                             "HEARTBEAT",
+					WorkflowBuildStatus:              "COMPLETED",
+					Interval:                         1,
+					ConsecutiveJobFailuresCount:      0,
+					MaxConsecutiveJobFailuresAllowed: 5,
+					CreatedAt:                        createdAt,
+					UpdatedAt:                        updatedAt,
+					TerminatedAt:                     terminatedAt,
+					LogRetention:                     true,
+				},
+			},
+			isErr: false,
+		},
+		{
 			name: "error: missing required fields in request",
 			req: &workflowspb.GetWorkflowRequest{
 				Id:     "",
@@ -959,6 +1062,11 @@ func TestGetWorkflow(t *testing.T) {
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.execute != nil {
+				tt.execute(t, tt.req, tt.want)
+				return
+			}
+
 			workflow, err := s.GetWorkflow(t.Context(), tt.req)
 			if tt.isErr {
 				if err == nil {


### PR DESCRIPTION
## Summary
This change adds in-process request coalescing with singleflight across the main read-heavy service paths that were vulnerable to duplicate concurrent work during cache misses or repeated identical requests.

It reduces duplicate database, search, gRPC, and Docker image pull work by allowing one in-flight request per key to do the expensive work while concurrent callers wait for and reuse the same result.

That lowers backend pressure during bursty traffic, reduces cache stampede behavior, and keeps the existing fire-and-forget cache population model intact.