### PR TITLE
docs: refresh Chronoverse documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Chronoverse uses a message-driven microservice architecture:
 - **HTTP server** exposes the public REST API and mediates browser sessions, CSRF checks, and gRPC calls.
 - **gRPC services** own user, workflow, job, notification, and analytics domains.
 - **Kafka topics** carry workflow, job, log, and analytics events between workers.
-- **PostgreSQL** stores transactional state, leases, idempotency records, and outbox events.
-- **ClickHouse** stores analytics and retained job logs.
+- **PostgreSQL** stores transactional state, analytics, leases, idempotency records, and outbox events.
+- **ClickHouse** stores retained job logs.
 - **Redis** stores sessions, cached reads, and live log pub/sub state.
 - **Meilisearch** indexes retained job logs for search.
 - **Docker socket proxy** lets execution workers run containers without mounting the Docker socket directly.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Important API notes:
 - Retry-prone mutations require an `Idempotency-Key` header.
 - `CONTAINER` workflows can retain and search logs.
 - `HEARTBEAT` workflows do not generate execution logs.
-- Log APIs return HTTP `412 Precondition Failed` when retention is disabled for a workflow.
+- Retained log read/search APIs return HTTP `412 Precondition Failed` when retention is disabled for a workflow; live SSE streams report stream-open failures as `event: error`.
 - Production Nginx exposes the API below `/api/`; development exposes the server directly.
 
 ## Development Commands

--- a/README.md
+++ b/README.md
@@ -1,134 +1,176 @@
-# Chronoverse ⏳🌌
+# Chronoverse
 
 ![chronoverse](./.github/assets/chronoverse.png)
 
-**Distributed job scheduler & Orchestrator on your infrastructure**
+**Distributed job scheduler and orchestrator for your own infrastructure.**
 
-Chronoverse is a distributed job scheduling and orchestration system designed for reliability and scalability. It allows you to define, schedule, and execute various types of jobs across your infrastructure with powerful monitoring and management capabilities.
+Chronoverse runs scheduled and manual workflows across a Docker-backed execution
+fleet. It combines an HTTP dashboard/API, gRPC microservices, Kafka workers,
+transactional persistence, retained/searchable job logs, notifications, and
+analytics into one self-hosted stack.
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/hitesh22rana/chronoverse)](https://goreportcard.com/report/github.com/hitesh22rana/chronoverse) [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hitesh22rana/chronoverse)
+[![Go Report Card](https://goreportcard.com/badge/github.com/hitesh22rana/chronoverse)](https://goreportcard.com/report/github.com/hitesh22rana/chronoverse)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hitesh22rana/chronoverse)
 
 ## Features
 
-- **Workflow Management**: Create, update, and monitor scheduled workflows.
-- **Flexible Scheduling**: Configure workflows with precise time intervals in minutes.
-- **Multiple Workflow Types Support**:
-  - `HEARTBEAT`: Simple health check job (does not generate execution logs).
-  - `CONTAINER`: Execute custom containerized applications and scripts.
-- **Job Logs**: Comprehensive execution history with logs stored in ClickHouse when log retention is enabled.
-- **Live Log Streaming**: Real-time job log streaming using Server-Sent Events (SSE) for running jobs with automatic fallback to static logs for completed jobs.
-- **Log Retention Controls**: Configure per-workflow log retention; log read APIs return precondition failure when retention is disabled.
-- **Real-time Notifications**: Dashboard-based alerts for workflow and job state changes.
-- **Observability**: Built-in OpenTelemetry integration for traces, metrics and logs.
-- **Security**: JWT-based authentication and authorization.
+- **Workflow management**: create, update, terminate, delete, search, and monitor workflows.
+- **Scheduled and manual runs**: run workflows automatically by minute interval or trigger a job on demand.
+- **Workflow kinds**:
+  - `HEARTBEAT`: lightweight health-check workflow without execution logs.
+  - `CONTAINER`: runs containerized workloads and can retain stdout/stderr logs.
+- **Replay-safe execution**: idempotency keys, workflow generations, deterministic event keys, transactional outbox delivery, durable job leases, worker retries, and stale-event guards.
+- **Job execution lifecycle**: queued, running, completed, failed, and canceled jobs with automatic retry handling for system failures.
+- **Retained job logs**: ClickHouse-backed logs, Meilisearch-backed search, raw log download, stream filtering, and Server-Sent Events for live output.
+- **Retention controls**: per-workflow log retention with explicit behavior for non-log-producing or retention-disabled workflows.
+- **Notifications and analytics**: user notifications, workflow/job analytics, retained log counts, and execution duration summaries.
+- **Security by default in compose**: generated certificates, TLS/mTLS across infrastructure and gRPC services, CSRF-protected session cookies, and Ed25519 JWTs for service authorization.
+- **Observability**: OpenTelemetry traces, metrics, and logs exported to the bundled Grafana OTEL LGTM stack.
 
 ## Architecture
 
-Chronoverse implements a message-driven microservices architecture where components communicate through two primary channels:
+Chronoverse uses a message-driven microservice architecture:
 
-1. **Kafka**: For reliable, asynchronous processing and event-driven workflows.
-2. **gRPC**: For efficient, low-latency synchronous service-to-service communication.
+- **HTTP server** exposes the public REST API and mediates browser sessions, CSRF checks, and gRPC calls.
+- **gRPC services** own user, workflow, job, notification, and analytics domains.
+- **Kafka topics** carry workflow, job, log, and analytics events between workers.
+- **PostgreSQL** stores transactional state, leases, idempotency records, and outbox events.
+- **ClickHouse** stores analytics and retained job logs.
+- **Redis** stores sessions, cached reads, and live log pub/sub state.
+- **Meilisearch** indexes retained job logs for search.
+- **Docker socket proxy** lets execution workers run containers without mounting the Docker socket directly.
+- **LGTM** provides local OpenTelemetry collection and dashboards.
 
-This dual communication approach ensures both reliability for critical background processes and responsiveness for user-facing operations. Data persistence is handled by PostgreSQL for transactional data and ClickHouse for analytics and retained job logs.
+For the full event flow and replay-safety model, see [Architecture](./docs/architecture.md).
 
-### Core Services
+## Components
 
-- **Server**: HTTP API gateway exposing RESTful endpoints with middleware for authentication and authorization.
-- **Users Service**: Manages user accounts, authentication tokens, and notification preferences.
-- **Workflows Service**: Handles workflow definitions, configuration storage, and build status management.
-- **Jobs Service**: Manages job lifecycle from scheduling through execution and completion.
-- **Notifications Service**: Provides real-time alerts and status updates.
-- **Analytics Service**: Provides insights into job and workflow performance and trends.
+### Services
 
-### Worker Components
+- `server`: HTTP API gateway for the dashboard and external clients.
+- `users-service`: user accounts, login, token issuance, and preferences.
+- `workflows-service`: workflow definitions, build status, generation checks, and cleanup.
+- `jobs-service`: scheduling, job state, log reads/search, live log streams, leases, and retry state.
+- `notifications-service`: notification creation and read-state management.
+- `analytics-service`: user and workflow analytics reads.
 
-- **Scheduling Worker**: Identifies jobs due for execution based on their schedules and processes them through Kafka.
-- **Workflow Worker**: Builds Docker image configurations from workflow definitions and prepares execution templates.
-- **Execution Worker**: Executes scheduled jobs in isolated containers with proper resource management, manages execution lifecycle and captures outputs/logs.
-- **JobLogs Processor**: Performs efficient batch insertion of execution logs from Kafka to ClickHouse for persistent storage and optimized querying when retention is enabled.
-- **Analytics Processor**: Consumes job and workflow events from Kafka, processes them to generate analytics data, and stores the results for querying.
-- **Database Migration**: Manages database schema evolution and applies necessary migrations for PostgreSQL and ClickHouse during deployments or updates.
+### Workers and Jobs
 
-All workers communicate through Kafka topics, enabling horizontal scaling and fault tolerance. This message-driven architecture ensures that job processing can continue even if individual components experience temporary outages.
+- `scheduling-worker`: scans due workflows and creates replay-safe job dispatch events.
+- `workflow-worker`: processes workflow build events and prepares executable workflow configuration.
+- `execution-worker`: claims leased jobs, runs containers, renews leases, publishes logs, and recovers expired leases.
+- `joblogs-processor`: batches log events into ClickHouse and Meilisearch when retention is enabled.
+- `analytics-processor`: consumes workflow, job, and log events into analytics tables with dedupe.
+- `outbox-relay`: publishes transactional outbox events to Kafka with processing leases, retries, dead handling, and cleanup.
+- `database-migration`: applies PostgreSQL, ClickHouse, and Meilisearch schema/index migrations.
 
 ## Getting Started
 
 ### Prerequisites
 
-- **Docker**: [Install Docker](https://docs.docker.com/get-docker/)
-- **Docker Compose**: [Install Docker Compose](https://docs.docker.com/compose/install/)
+- Docker
+- Docker Compose
 
-No other dependencies are required as all services run in containers with automated setup.
+The compose stacks build or pull all runtime services. Local Go, Node.js, Buf,
+and lint tooling are only needed when developing the codebase directly.
 
-### Installation
+### Development Stack
 
-1. Clone the repository:
+```sh
+git clone https://github.com/hitesh22rana/chronoverse.git
+cd chronoverse
+docker compose -f compose.dev.yaml up -d
+```
 
-   ```
-   git clone https://github.com/hitesh22rana/chronoverse.git
-   cd chronoverse
-   ```
+Development defaults expose internal ports for debugging:
 
-2. Choose the appropriate deployment environment:
+- Dashboard: `http://localhost:3001`
+- HTTP API: `http://localhost:8080`
+- gRPC services: `50051` through `50055`
+- PostgreSQL: `5432`
+- ClickHouse TLS: `9440`
+- Redis TLS: `6379`
+- Meilisearch HTTPS: `7700`
+- Kafka SSL/controller: `9094` / `9093`
+- LGTM dashboard: `http://localhost:3000`
 
-   **For Development:**
+### Production Stack
 
-   ```
-   docker compose -f compose.dev.yaml up -d
-   ```
+```sh
+docker compose -f compose.prod.yaml up -d
+```
 
-   **For Production:**
+Production uses published images, internal service networking, resource limits,
+replicated workers, and a single Nginx entry point:
 
-   ```
-   docker compose -f compose.prod.yaml up -d
-   ```
+- Dashboard and proxied API: `http://localhost`
+- API routes through Nginx: `/api/...`
+- LGTM dashboard: `http://localhost:3000`
 
-### Deployment Environments
+Before running a real deployment, replace development secrets, default
+passwords, and generated local certificate assumptions with environment-specific
+values. See [Configuration](./docs/configuration.md) and [Operations](./docs/operations.md).
 
-#### 1. Development Environment (compose.dev.yaml)
+## API and Usage
 
-- All service ports are exposed for easy debugging and direct access.
-- Database ports (5432, 9000, 6379) accessible from the host.
-- gRPC service ports (50051-50055) available for direct testing.
-- Monitoring ports fully exposed.
-- Dashboard is accessible via port 3001.
-- Suitable for local development and testing.
+The dashboard talks to the HTTP API using cookie sessions and CSRF protection.
+External clients can use the same public routes documented in [API](./docs/api.md).
 
-#### 2. Production Environment (compose.prod.yaml)
+Important API notes:
 
-- Enhanced security with minimal port exposure.
-- Dashboard is accessible via port 80/443 through Nginx/reverse proxy.
-- Monitoring dashboard can be accessed via port 3000.
-- All internal services communicate via Docker's internal network.
-- No direct external access to databases or internal microservices.
-- Jobs service is wired to workflows service over internal TLS for retention-aware log access checks.
-- gRPC reflection disabled for additional security.
+- Retry-prone mutations require an `Idempotency-Key` header.
+- `CONTAINER` workflows can retain and search logs.
+- `HEARTBEAT` workflows do not generate execution logs.
+- Log APIs return HTTP `412 Precondition Failed` when retention is disabled for a workflow.
+- Production Nginx exposes the API below `/api/`; development exposes the server directly.
 
-### Configuration
+## Development Commands
 
-Configuration is managed through environment variables with sensible defaults in the [docker-compose.yaml](./docker-compose.yaml) file.
+```sh
+make tools
+make generate
+make test/short
+make test
+make lint
+make build/all
+```
 
-## License
+Dashboard commands live in `dashboard/`:
 
-This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details.
+```sh
+npm install
+npm run dev:port
+npm run build
+npm run lint
+```
+
+More operational commands and troubleshooting notes are in [Operations](./docs/operations.md).
+
+## Documentation
+
+- [Architecture](./docs/architecture.md)
+- [Configuration](./docs/configuration.md)
+- [API](./docs/api.md)
+- [Operations](./docs/operations.md)
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome.
 
 1. Fork the repository.
-2. Create your feature branch (`git checkout -b feature/amazing-feature`).
-3. Commit your changes (`git commit -m 'Add some amazing feature'`).
-4. Push to the branch (`git push origin feature/amazing-feature`).
-5. Open a Pull Request.
+2. Create a feature branch.
+3. Make the change with tests and documentation where relevant.
+4. Run the applicable checks.
+5. Open a pull request.
+
+## License
+
+Chronoverse is licensed under the MIT License. See [LICENSE](./LICENSE).
 
 ## Acknowledgments
 
-- [Franz-go](https://github.com/twmb/franz-go) - Kafka client
+- [Franz-go](https://github.com/twmb/franz-go)
 - [Docker SDK for Go](https://github.com/moby/moby)
 - [OpenTelemetry Go](https://github.com/open-telemetry/opentelemetry-go)
-- [Docker OTEL lgtm](https://github.com/grafana/docker-otel-lgtm)
-
----
-
-Built with ❤️ by [Hitesh Rana](https://github.com/hitesh22rana)
+- [Docker OTEL LGTM](https://github.com/grafana/docker-otel-lgtm)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,379 @@
+# HTTP API
+
+The HTTP API is served by `server`. Development exposes it directly on
+`http://localhost:8080`. Production exposes it through Nginx under `/api/...`;
+for example, development `GET /workflows` maps to production
+`GET /api/workflows`.
+
+All non-auth application routes require a valid session cookie. Mutating routes
+also require CSRF validation. Browser clients get the session and CSRF cookies
+from login or registration.
+
+## Common Behavior
+
+### Headers
+
+- `Content-Type: application/json` for JSON request bodies.
+- `Idempotency-Key: <unique-key>` is required for retry-prone mutations:
+  - `POST /workflows`
+  - `PUT /workflows/{workflow_id}`
+  - `POST /workflows/{workflow_id}/jobs/schedule`
+
+Use a stable idempotency key when retrying the same user action. Use a new key
+for a new action.
+
+### Status Mapping
+
+The server maps gRPC errors to HTTP status codes. Important cases:
+
+- `400 Bad Request`: invalid input, invalid filters, missing idempotency key.
+- `401 Unauthorized`: missing or invalid session.
+- `403 Forbidden`: permission denied.
+- `404 Not Found`: resource not found.
+- `409 Conflict`: already exists or aborted operation.
+- `412 Precondition Failed`: state precondition failed, including disabled log
+  retention on log reads/search/streams.
+- `429 Too Many Requests`: resource exhausted.
+- `503 Service Unavailable`: downstream service unavailable.
+
+## Authentication
+
+### Register
+
+`POST /auth/register`
+
+Body:
+
+```json
+{
+  "email": "user@example.com",
+  "password": "password"
+}
+```
+
+Creates the user, issues a session cookie, and returns `201 Created`.
+
+### Login
+
+`POST /auth/login`
+
+Body:
+
+```json
+{
+  "email": "user@example.com",
+  "password": "password"
+}
+```
+
+Issues a session cookie and returns `201 Created`.
+
+### Logout
+
+`POST /auth/logout`
+
+Deletes the session and CSRF cookies and returns `204 No Content`.
+
+### Validate Session
+
+`POST /auth/validate`
+
+Returns `200 OK` when the current session and CSRF token are valid.
+
+## Users
+
+### Get Current User
+
+`GET /users`
+
+Returns the current user's profile and preference data.
+
+### Update Current User
+
+`PUT /users`
+
+Body:
+
+```json
+{
+  "notification_preference": "ALL"
+}
+```
+
+Returns `204 No Content`. The current handler accepts a `password` field in the
+shape but only forwards notification preference updates.
+
+## Workflows
+
+Workflow kinds:
+
+- `HEARTBEAT`: no execution logs and `log_retention` must be disabled.
+- `CONTAINER`: executes a container workload and may retain logs.
+
+Build statuses:
+
+- `QUEUED`
+- `STARTED`
+- `COMPLETED`
+- `FAILED`
+- `CANCELED`
+
+### List Workflows
+
+`GET /workflows`
+
+Query parameters:
+
+- `cursor`: pagination cursor.
+- `query`: text query.
+- `kind`: `HEARTBEAT` or `CONTAINER`.
+- `build_status`: one of the build statuses above.
+- `terminated`: boolean string.
+- `interval_min`: minimum interval in minutes.
+- `interval_max`: maximum interval in minutes.
+
+Response includes `workflows` and `cursor`.
+
+### Create Workflow
+
+`POST /workflows`
+
+Requires `Idempotency-Key`.
+
+Body:
+
+```json
+{
+  "name": "nightly-report",
+  "payload": "{\"image\":\"alpine:latest\",\"cmd\":[\"echo\",\"hello\"]}",
+  "kind": "CONTAINER",
+  "interval": 60,
+  "max_consecutive_job_failures_allowed": 3,
+  "log_retention": true
+}
+```
+
+Fields:
+
+- `name`: display name.
+- `payload`: workflow-kind-specific JSON string.
+- `kind`: `HEARTBEAT` or `CONTAINER`.
+- `interval`: schedule interval in minutes.
+- `max_consecutive_job_failures_allowed`: failure threshold before workflow
+  behavior changes.
+- `log_retention`: optional. `CONTAINER` defaults to retained logs when unset;
+  `HEARTBEAT` persists with retention disabled.
+
+Returns `201 Created` with the workflow ID.
+
+### Get Workflow
+
+`GET /workflows/{workflow_id}`
+
+Returns workflow fields including:
+
+- `id`
+- `name`
+- `payload`
+- `kind`
+- `build_status`
+- `interval`
+- `consecutive_job_failures_count`
+- `max_consecutive_job_failures_allowed`
+- `created_at`
+- `updated_at`
+- `terminated_at`
+- `log_retention`
+- `generation`
+
+### Update Workflow
+
+`PUT /workflows/{workflow_id}`
+
+Requires `Idempotency-Key`.
+
+Body:
+
+```json
+{
+  "name": "nightly-report",
+  "payload": "{\"image\":\"alpine:latest\",\"cmd\":[\"echo\",\"updated\"]}",
+  "interval": 120,
+  "max_consecutive_job_failures_allowed": 3
+}
+```
+
+Returns `204 No Content`.
+
+### Terminate Workflow
+
+`PATCH /workflows/{workflow_id}`
+
+Terminates the workflow and returns `204 No Content`.
+
+### Delete Workflow
+
+`DELETE /workflows/{workflow_id}`
+
+Deletes a terminated workflow and returns `204 No Content`. Active workflows or
+workflows with active jobs can fail with `412 Precondition Failed`.
+
+## Jobs
+
+Job statuses:
+
+- `PENDING`
+- `QUEUED`
+- `RUNNING`
+- `COMPLETED`
+- `FAILED`
+- `CANCELED`
+
+Job triggers:
+
+- `AUTOMATIC`
+- `MANUAL`
+
+### List Jobs
+
+`GET /workflows/{workflow_id}/jobs`
+
+Query parameters:
+
+- `cursor`: pagination cursor.
+- `status`: job status filter.
+- `trigger`: `AUTOMATIC` or `MANUAL`.
+
+Response includes `jobs` and `cursor`. Job entries include `attempts` in list
+responses.
+
+### Manual Schedule
+
+`POST /workflows/{workflow_id}/jobs/schedule`
+
+Requires `Idempotency-Key`.
+
+Schedules an immediate manual job and returns `201 Created` with the job ID.
+
+### Get Job
+
+`GET /workflows/{workflow_id}/jobs/{job_id}`
+
+Returns:
+
+- `id`
+- `workflow_id`
+- `status`
+- `trigger`
+- `scheduled_at`
+- `started_at`
+- `completed_at`
+- `created_at`
+- `updated_at`
+
+Lease metadata such as lease tokens is internal to worker gRPC APIs and is not
+returned by the public HTTP job detail route.
+
+## Job Logs
+
+Log streams:
+
+- `stdout`
+- `stderr`
+- omit `stream` for all streams.
+
+Log APIs are available only when the workflow supports logs and log retention is
+enabled. `HEARTBEAT` workflows do not produce execution logs. If retention is
+disabled, log read/search/stream endpoints return `412 Precondition Failed`.
+
+### Get Logs
+
+`GET /workflows/{workflow_id}/jobs/{job_id}/logs`
+
+Query parameters:
+
+- `cursor`: pagination cursor.
+
+Returns retained logs from ClickHouse.
+
+### Search Logs
+
+`GET /workflows/{workflow_id}/jobs/{job_id}/logs/search`
+
+Query parameters:
+
+- `cursor`: pagination cursor.
+- `stream`: `stdout` or `stderr`.
+- `q`: message search text.
+
+If `q` is omitted, the route returns filtered retained logs by stream. If `q` is
+present, it searches retained logs through Meilisearch.
+
+### Download Raw Logs
+
+`GET /workflows/{workflow_id}/jobs/{job_id}/logs/raw`
+
+Streams retained logs as `text/plain` for terminal jobs. Non-terminal jobs return
+`400 Bad Request`.
+
+### Stream Live Logs
+
+`GET /workflows/{workflow_id}/jobs/{job_id}/events`
+
+Streams Server-Sent Events for a running job. Production Nginx has a dedicated
+no-buffering proxy location for this route:
+
+`/api/workflows/{workflow_id}/jobs/{job_id}/events`
+
+The endpoint returns `412 Precondition Failed` if the job is not running or log
+retention is disabled.
+
+## Notifications
+
+### List Notifications
+
+`GET /notifications`
+
+Query parameters:
+
+- `cursor`: pagination cursor.
+
+Returns notifications for the current user.
+
+### Mark Notifications Read
+
+`PUT /notifications`
+
+Body:
+
+```json
+{
+  "ids": ["notification-id"]
+}
+```
+
+Returns `204 No Content`.
+
+## Analytics
+
+### User Analytics
+
+`GET /analytics`
+
+Returns current-user aggregate totals:
+
+- `total_workflows`
+- `total_jobs`
+- `total_joblogs`
+- `total_job_execution_duration`
+
+### Workflow Analytics
+
+`GET /analytics/{workflow_id}`
+
+Returns workflow aggregate totals:
+
+- `workflow_id`
+- `total_job_execution_duration`
+- `total_jobs`
+- `total_joblogs`

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,7 +32,8 @@ The server maps gRPC errors to HTTP status codes. Important cases:
 - `404 Not Found`: resource not found.
 - `409 Conflict`: already exists or aborted operation.
 - `412 Precondition Failed`: state precondition failed, including disabled log
-  retention on log reads/search/streams.
+  retention on retained log read/search routes. SSE stream-open failures are
+  sent as `event: error` frames after stream headers are written.
 - `429 Too Many Requests`: resource exhausted.
 - `503 Service Unavailable`: downstream service unavailable.
 
@@ -284,7 +285,8 @@ Log streams:
 
 Log APIs are available only when the workflow supports logs and log retention is
 enabled. `HEARTBEAT` workflows do not produce execution logs. If retention is
-disabled, log read/search/stream endpoints return `412 Precondition Failed`.
+disabled, retained log read/search routes return `412 Precondition Failed`; live
+SSE streams report the failure as an `event: error` frame.
 
 ### Get Logs
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -325,8 +325,10 @@ no-buffering proxy location for this route:
 
 `/api/workflows/{workflow_id}/jobs/{job_id}/events`
 
-The endpoint returns `412 Precondition Failed` if the job is not running or log
-retention is disabled.
+After the SSE headers are sent, stream-open and stream-receive failures are sent
+as `event: error` frames on the `text/event-stream` response. For example, a
+non-running job or disabled log retention is reported as an SSE error event
+rather than an HTTP `412 Precondition Failed` response.
 
 ## Notifications
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,11 +52,11 @@ debugging.
 
 ## Data Stores and Infrastructure
 
-- **PostgreSQL** stores users, workflows, jobs, idempotency keys, outbox events,
-  leases, retry state, and transactional metadata.
+- **PostgreSQL** stores users, workflows, jobs, analytics, idempotency keys,
+  outbox events, leases, retry state, and transactional metadata.
 - **Kafka** carries asynchronous events on the `workflows`, `jobs`, `job_logs`,
   and `analytics` topics. Topic creation is explicit; auto-create is disabled.
-- **ClickHouse** stores retained job logs and analytics data.
+- **ClickHouse** stores retained job logs.
 - **Redis** stores HTTP sessions, cached service reads, and live log
   publish/subscribe state.
 - **Meilisearch** indexes retained job logs for search.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,157 @@
+# Architecture
+
+Chronoverse is a distributed scheduler built around synchronous gRPC services
+and asynchronous Kafka workers. The public HTTP server and dashboard handle
+user-facing workflows; background workers handle scheduling, builds, execution,
+log delivery, notifications, analytics, and replay-safe event publication.
+
+## Runtime Topology
+
+### Entry Points
+
+- `dashboard` is the Next.js UI. In development it is exposed on host port
+  `3001`; in production it sits behind Nginx on port `80`.
+- `server` is the public HTTP API. In development it is exposed on host port
+  `8080`; in production it is only reachable inside the compose network and is
+  proxied by Nginx under `/api/`.
+- `nginx` exists in production only. It proxies dashboard traffic to
+  `dashboard:3000`, rewrites `/api/...` to `server:8080`, and disables buffering
+  for job log SSE routes.
+
+### Domain Services
+
+- `users-service` owns users, authentication, authorization metadata, and
+  notification preferences.
+- `workflows-service` owns workflow definitions, workflow generations, build
+  status, termination/deletion rules, cleanup, and workflow list filters.
+- `jobs-service` owns scheduled jobs, manual job creation, job status, job
+  leases, log reads, log search, raw log download, and live log streams.
+- `notifications-service` owns notification listing and marking notifications as
+  read.
+- `analytics-service` reads user and workflow analytics.
+
+These services expose gRPC ports `50051` through `50055` inside the stack. The
+development compose file also exposes those ports on the host for direct
+debugging.
+
+### Workers
+
+- `scheduling-worker` scans PostgreSQL for workflows that are due and creates
+  job dispatch work.
+- `workflow-worker` consumes workflow events, builds Docker execution metadata,
+  and updates workflow build state.
+- `execution-worker` consumes job events, claims durable leases, runs containers,
+  streams/publishes logs, renews leases, and recovers expired leases.
+- `joblogs-processor` consumes log events and batches retained logs into
+  ClickHouse and Meilisearch.
+- `analytics-processor` consumes workflow, job, and log events and updates
+  analytics tables.
+- `outbox-relay` claims transactional outbox rows and publishes them to Kafka.
+- `database-migration` applies PostgreSQL migrations, ClickHouse migrations, and
+  Meilisearch index setup before application services start.
+
+## Data Stores and Infrastructure
+
+- **PostgreSQL** stores users, workflows, jobs, idempotency keys, outbox events,
+  leases, retry state, and transactional metadata.
+- **Kafka** carries asynchronous events on the `workflows`, `jobs`, `job_logs`,
+  and `analytics` topics. Topic creation is explicit; auto-create is disabled.
+- **ClickHouse** stores retained job logs and analytics data.
+- **Redis** stores HTTP sessions, cached service reads, and live log
+  publish/subscribe state.
+- **Meilisearch** indexes retained job logs for search.
+- **Docker socket proxy** exposes a narrow Docker API surface to execution
+  workers for container lifecycle and log access.
+- **LGTM** receives OpenTelemetry data and exposes local dashboards.
+
+## Event Flow
+
+### Workflow Create and Update
+
+1. A client sends `POST /workflows` or `PUT /workflows/{workflow_id}` with an
+   `Idempotency-Key` header.
+2. The HTTP server validates session and CSRF state, then calls
+   `workflows-service`.
+3. `workflows-service` writes workflow state in PostgreSQL, records the
+   idempotency key, updates the workflow generation/build hash as needed, and
+   creates outbox events in the same transaction.
+4. `outbox-relay` claims pending outbox rows and publishes workflow events to
+   Kafka.
+5. `workflow-worker` consumes the workflow event, builds workflow execution
+   metadata, and updates the workflow build status through `workflows-service`.
+6. Notification and analytics events are published through the same durable
+   event path.
+
+### Scheduling and Manual Runs
+
+- Automatic scheduling is driven by `scheduling-worker`. It scans due workflows,
+  uses workflow generation guards, and creates replay-safe job events.
+- Manual scheduling is driven by `POST /workflows/{workflow_id}/jobs/schedule`
+  and also requires `Idempotency-Key`.
+- Job dispatch events include trigger metadata (`AUTOMATIC` or `MANUAL`) and
+  dispatch-attempt data so repeated processing does not create duplicate work.
+
+### Job Execution
+
+1. `execution-worker` consumes job events and calls `jobs-service` to claim the
+   job.
+2. `jobs-service` grants a lease only when the job, workflow, dispatch attempt,
+   and current state are valid.
+3. The worker starts the container through the Docker proxy, attaches the
+   container ID, and renews the lease while the job runs.
+4. Logs are emitted both for live streaming and durable processing when retention
+   is enabled.
+5. Completion, user failures, system failures, retries, and cancellations are
+   recorded through lease-token-protected job APIs.
+6. Expired running leases are recovered by workers and either retried, failed, or
+   cleaned up according to the job state.
+
+### Logs, Search, and Analytics
+
+- `CONTAINER` workflows can retain stdout/stderr logs when `log_retention` is
+  enabled.
+- `HEARTBEAT` workflows do not generate execution logs.
+- Running jobs can stream live logs over Server-Sent Events.
+- Completed retained logs are read from ClickHouse and searched through
+  Meilisearch.
+- `joblogs-processor` writes deterministic log event IDs so replayed log events
+  do not double-count or duplicate retained logs.
+- `analytics-processor` deduplicates processed events and cleans old processed
+  event records.
+
+## Replay-Safety Model
+
+Chronoverse treats duplicate events, worker restarts, and partial failures as
+expected operating conditions.
+
+- **Idempotency keys** are required for workflow create/update and manual job
+  scheduling. Retrying the same mutation with the same key should not duplicate
+  the command.
+- **Transactional outbox events** are written alongside state changes and later
+  published by `outbox-relay`. This prevents state changes from being committed
+  without their matching Kafka event.
+- **Outbox processing leases** let multiple relay replicas work safely. Failed
+  publication attempts are retried with backoff and eventually marked dead.
+- **Workflow generations** guard stale build, scheduling, reschedule,
+  termination, and deletion events.
+- **Build hashes** avoid unnecessary rebuild work when workflow execution inputs
+  have not changed.
+- **Deterministic event keys** deduplicate workflow, job, notification,
+  analytics, and log side effects.
+- **Durable job leases** ensure only one execution worker owns a running job at a
+  time. Lease tokens are required for status, container, completion, failure, and
+  retry operations.
+- **Partition-aware Kafka workers** preserve per-partition ordering and commit
+  only after the selected retry/commit policy permits it.
+- **Cleanup loops** remove old outbox and processed-event records after their
+  retention windows.
+
+## Security and Observability
+
+- Compose generates a local CA, service certificates, client certificates, and
+  Ed25519 auth keys through `init-certs`.
+- PostgreSQL, ClickHouse, Redis, Meilisearch, Kafka, and gRPC services run with
+  TLS or mTLS in compose.
+- The HTTP server uses encrypted session cookies, CSRF cookies, and service JWT
+  metadata for downstream gRPC calls.
+- Services and workers export OpenTelemetry data to `lgtm:4317`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,278 @@
+# Configuration
+
+Chronoverse configuration is environment-variable driven. The compose files
+provide working local defaults, but production deployments should replace
+default credentials, keys, hostnames, retention settings, and resource sizing.
+
+## Compose Profiles
+
+### Development: `compose.dev.yaml`
+
+Development builds local images and exposes internal ports for debugging:
+
+| Component | Host port | Notes |
+| --- | ---: | --- |
+| Dashboard | `3001` | Next.js dashboard, built with `NEXT_PUBLIC_API_URL=http://localhost:8080` |
+| HTTP API | `8080` | Direct server access |
+| LGTM | `3000` | Observability UI |
+| OTLP gRPC | `4317` | OpenTelemetry collector endpoint |
+| PostgreSQL | `5432` | TLS-enabled database |
+| ClickHouse | `9440` | Secure native protocol |
+| Redis | `6379` | TLS-enabled Redis |
+| Meilisearch | `7700` | HTTPS |
+| Kafka | `9094` | SSL broker listener |
+| Kafka controller | `9093` | Controller listener |
+| gRPC services | `50051`-`50055` | Users, workflows, jobs, notifications, analytics |
+
+Development Kafka topic partition defaults are:
+
+- `KAFKA_WORKFLOWS_TOPIC_PARTITIONS=2`
+- `KAFKA_JOBS_TOPIC_PARTITIONS=2`
+- `KAFKA_JOB_LOGS_TOPIC_PARTITIONS=2`
+- `KAFKA_ANALYTICS_TOPIC_PARTITIONS=2`
+
+### Production: `compose.prod.yaml`
+
+Production uses published `ghcr.io/hitesh22rana/chronoverse/*:latest` images,
+internal service networking, resource limits, and replicated workers. Host
+exposure is intentionally small:
+
+| Component | Host port | Notes |
+| --- | ---: | --- |
+| Nginx | `80` | Dashboard and `/api/...` reverse proxy |
+| LGTM | `3000` | Observability UI |
+
+Production Kafka topic partition defaults are:
+
+- `KAFKA_WORKFLOWS_TOPIC_PARTITIONS=2`
+- `KAFKA_JOBS_TOPIC_PARTITIONS=4`
+- `KAFKA_JOB_LOGS_TOPIC_PARTITIONS=4`
+- `KAFKA_ANALYTICS_TOPIC_PARTITIONS=2`
+
+Workers are configured with compose resource reservations and two replicas for
+the low/high-resource worker groups.
+
+## Core Environment Groups
+
+### Server
+
+The public HTTP server reads:
+
+- `SERVER_HOST`, `SERVER_PORT`
+- `SERVER_REQUEST_TIMEOUT`, `SERVER_READ_TIMEOUT`,
+  `SERVER_READ_HEADER_TIMEOUT`, `SERVER_IDLE_TIMEOUT`
+- `SERVER_REQUEST_BODY_LIMIT`
+- `SERVER_SESSION_EXPIRY`, `SERVER_CSRF_EXPIRY`,
+  `SERVER_CSRF_HMAC_SECRET`
+- `SERVER_HOST_URL`
+- `SERVER_ALLOWED_ORIGINS`
+- `SERVER_SAME_SITE_MODE`
+- `CRYPTO_SECRET`
+
+In development the dashboard calls the server directly. In production, Nginx
+proxies `/api/` to the server and rewrites the path before forwarding.
+
+### gRPC Servers and Clients
+
+Each gRPC service uses:
+
+- `GRPC_HOST`, `GRPC_PORT`, `GRPC_REQUEST_TIMEOUT`
+- `GRPC_TLS_ENABLED`, `GRPC_TLS_CA_FILE`, `GRPC_TLS_CERT_FILE`,
+  `GRPC_TLS_KEY_FILE`
+
+Service clients use:
+
+- `USERS_SERVICE_HOST`, `USERS_SERVICE_PORT`, `USERS_SERVICE_TLS_ENABLED`,
+  `USERS_SERVICE_TLS_CA_FILE`
+- `WORKFLOWS_SERVICE_HOST`, `WORKFLOWS_SERVICE_PORT`,
+  `WORKFLOWS_SERVICE_TLS_ENABLED`, `WORKFLOWS_SERVICE_TLS_CA_FILE`
+- `JOBS_SERVICE_HOST`, `JOBS_SERVICE_PORT`, `JOBS_SERVICE_TLS_ENABLED`,
+  `JOBS_SERVICE_TLS_CA_FILE`
+- `NOTIFICATIONS_SERVICE_HOST`, `NOTIFICATIONS_SERVICE_PORT`,
+  `NOTIFICATIONS_SERVICE_TLS_ENABLED`, `NOTIFICATIONS_SERVICE_TLS_CA_FILE`
+- `ANALYTICS_SERVICE_HOST`, `ANALYTICS_SERVICE_PORT`,
+  `ANALYTICS_SERVICE_TLS_ENABLED`, `ANALYTICS_SERVICE_TLS_CA_FILE`
+- `CLIENT_TLS_CERT_FILE`, `CLIENT_TLS_KEY_FILE` for mTLS client identity.
+
+### PostgreSQL
+
+Common settings:
+
+- `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`,
+  `POSTGRES_DB`
+- `POSTGRES_MAX_CONNS`, `POSTGRES_MIN_CONNS`,
+  `POSTGRES_MAX_CONN_LIFE`, `POSTGRES_MAX_CONN_IDLE`,
+  `POSTGRES_DIAL_TIMEOUT`
+- `POSTGRES_TLS_ENABLED`, `POSTGRES_TLS_CA_FILE`,
+  `POSTGRES_TLS_CERT_FILE`, `POSTGRES_TLS_KEY_FILE`
+
+PostgreSQL holds transactional state, idempotency records, job leases, and
+outbox events. Keep its TLS and credential values environment-specific outside
+local development.
+
+### ClickHouse
+
+Common settings:
+
+- `CLICKHOUSE_HOSTS`, `CLICKHOUSE_DATABASE`, `CLICKHOUSE_USERNAME`,
+  `CLICKHOUSE_PASSWORD`
+- `CLICKHOUSE_MAX_OPEN_CONNS`, `CLICKHOUSE_MAX_IDLE_CONNS`,
+  `CLICKHOUSE_CONN_MAX_LIFETIME`, `CLICKHOUSE_DIAL_TIMEOUT`
+- `CLICKHOUSE_TLS_ENABLED`, `CLICKHOUSE_TLS_CA_FILE`,
+  `CLICKHOUSE_TLS_CERT_FILE`, `CLICKHOUSE_TLS_KEY_FILE`
+
+ClickHouse stores retained job logs and analytics tables. It is only useful for
+job logs when workflow log retention is enabled.
+
+### Redis
+
+Common settings:
+
+- `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB`
+- `REDIS_POOL_SIZE`, `REDIS_MIN_IDLE_CONNS`
+- `REDIS_READ_TIMEOUT`, `REDIS_WRITE_TIMEOUT`
+- `REDIS_MAX_MEMORY`, `REDIS_EVICTION_POLICY`,
+  `REDIS_EVICTION_POLICY_SAMPLE_SIZE`
+- `REDIS_TLS_ENABLED`, `REDIS_TLS_CA_FILE`, `REDIS_TLS_CERT_FILE`,
+  `REDIS_TLS_KEY_FILE`
+
+Redis is used for sessions, cached reads, and live log stream state.
+
+### Meilisearch
+
+Common settings:
+
+- `MEILISEARCH_URI`
+- `MEILISEARCH_MASTER_KEY`
+- `MEILISEARCH_TLS_ENABLED`, `MEILISEARCH_TLS_CA_FILE`,
+  `MEILISEARCH_TLS_CERT_FILE`, `MEILISEARCH_TLS_KEY_FILE`
+
+The compose defaults include a development master key. Replace it for any
+shared or production environment.
+
+### Kafka
+
+Application services and workers use:
+
+- `KAFKA_BROKERS`
+- `KAFKA_CONSUMER_GROUP`
+- `KAFKA_TLS_ENABLED`, `KAFKA_TLS_CA_FILE`, `KAFKA_TLS_CERT_FILE`,
+  `KAFKA_TLS_KEY_FILE`
+
+Topic initialization uses:
+
+- `KAFKA_TOPIC_REPLICATION_FACTOR`
+- `KAFKA_WORKFLOWS_TOPIC_PARTITIONS`
+- `KAFKA_JOBS_TOPIC_PARTITIONS`
+- `KAFKA_JOB_LOGS_TOPIC_PARTITIONS`
+- `KAFKA_ANALYTICS_TOPIC_PARTITIONS`
+
+Kafka auto topic creation is disabled in compose. `init-kafka-topics` creates or
+expands the expected topics: `workflows`, `jobs`, `job_logs`, and `analytics`.
+
+## Domain and Worker Settings
+
+### Workflows Service
+
+- `WORKFLOWS_SERVICE_CONFIG_FETCH_LIMIT`
+- `WORKFLOWS_CLEANUP_ENABLED`
+- `WORKFLOWS_CLEANUP_INTERVAL`
+- `WORKFLOWS_CLEANUP_BATCH_SIZE`
+
+Cleanup removes old workflow-related idempotency/outbox state according to the
+service implementation.
+
+### Jobs Service
+
+- `JOBS_SERVICE_CONFIG_FETCH_LIMIT`
+- `JOBS_SERVICE_CONFIG_LOGS_FETCH_LIMIT`
+
+The jobs service also needs workflows-service client settings so log endpoints
+can enforce workflow retention policy.
+
+### Scheduling Worker
+
+- `SCHEDULING_WORKER_POLL_INTERVAL`
+- `SCHEDULING_WORKER_CONTEXT_TIMEOUT`
+- `SCHEDULING_WORKER_BATCH_SIZE`
+
+The batch size controls how many due workflows are scanned per polling pass.
+
+### Execution Worker
+
+- `EXECUTION_WORKER_ID`
+- `EXECUTION_WORKER_CONCURRENCY`
+- `EXECUTION_WORKER_LEASE_DURATION`
+- `EXECUTION_WORKER_LEASE_RENEW_INTERVAL`
+- `EXECUTION_WORKER_SYSTEM_RETRY_LIMIT`
+- `EXECUTION_WORKER_SYSTEM_RETRY_BACKOFF`
+- `EXECUTION_WORKER_RECOVERY_INTERVAL`
+- `EXECUTION_WORKER_RECOVERY_BATCH_SIZE`
+- `EXECUTION_WORKER_JOB_LOG_BATCH_SIZE`
+- `EXECUTION_WORKER_JOB_LOG_BATCH_INTERVAL`
+- `EXECUTION_WORKER_JOB_LOG_PUBLISH_TIMEOUT`
+- `EXECUTION_WORKER_JOB_LOG_PUBLISH_RETRIES`
+- `EXECUTION_WORKER_JOB_LOG_PUBLISH_BACKOFF`
+- `EXECUTION_WORKER_JOB_LOG_LIVE_TIMEOUT`
+- `EXECUTION_WORKER_JOB_LOG_LIVE_BUFFER_SIZE`
+
+If `EXECUTION_WORKER_ID` is empty, the worker falls back to the container
+hostname. Keep lease duration longer than the renewal interval.
+
+### Job Logs Processor
+
+- `JOBLOGS_PROCESSOR_BATCH_JOB_LOGS_SIZE_LIMIT`
+- `JOBLOGS_PROCESSOR_BATCH_JOB_LOGS_TIME_INTERVAL`
+
+Tune these values together with ClickHouse and Meilisearch capacity.
+
+### Analytics Processor
+
+- `ANALYTICS_PROCESSOR_CLEANUP_ENABLED`
+- `ANALYTICS_PROCESSOR_CLEANUP_INTERVAL`
+- `ANALYTICS_PROCESSOR_CLEANUP_BATCH_SIZE`
+- `ANALYTICS_PROCESSED_EVENTS_RETENTION`
+
+Processed-event retention supports replay-safe analytics dedupe while limiting
+metadata growth.
+
+### Outbox Relay
+
+- `OUTBOX_RELAY_WORKFLOW_ENABLED`
+- `OUTBOX_RELAY_JOBS_ENABLED`
+- `OUTBOX_RELAY_ANALYTICS_ENABLED`
+- `OUTBOX_RELAY_BATCH_SIZE`
+- `OUTBOX_RELAY_POLL_INTERVAL`
+- `OUTBOX_RELAY_CONTEXT_TIMEOUT`
+- `OUTBOX_RELAY_MAX_ATTEMPTS`
+- `OUTBOX_RELAY_RETRY_BACKOFF`
+- `OUTBOX_RELAY_PROCESSING_LEASE`
+- `OUTBOX_RELAY_WORKER_ID`
+- `OUTBOX_RELAY_CLEANUP_ENABLED`
+- `OUTBOX_RELAY_CLEANUP_INTERVAL`
+- `OUTBOX_RELAY_CLEANUP_BATCH_SIZE`
+- `OUTBOX_RELAY_PUBLISHED_RETENTION`
+
+Compose sets `OUTBOX_RELAY_WORKER_ID` from the hostname when not provided. Keep
+the processing lease longer than normal Kafka publish latency.
+
+## Dashboard Settings
+
+`NEXT_PUBLIC_API_URL` is injected at build time for the dashboard image.
+
+- Development uses `http://localhost:8080`.
+- Production uses the Nginx `/api` proxy in the generated Nginx config. If you
+  build a custom dashboard image, set `NEXT_PUBLIC_API_URL` to the public API
+  origin/path that browser clients should call.
+
+## Secrets and Certificates
+
+`init-certs` generates local certificates and auth keys under the shared `certs`
+volume. This is convenient for compose-based development and demos, but
+production environments should manage:
+
+- PostgreSQL, ClickHouse, Redis, Meilisearch, Kafka, and gRPC certificates.
+- Ed25519 auth key material (`auth.ed` and `auth.ed.pub`).
+- `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET`.
+- Database passwords and `MEILISEARCH_MASTER_KEY`.
+- Public hostnames, allowed origins, and same-site cookie policy.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,8 +121,8 @@ Common settings:
 - `CLICKHOUSE_TLS_ENABLED`, `CLICKHOUSE_TLS_CA_FILE`,
   `CLICKHOUSE_TLS_CERT_FILE`, `CLICKHOUSE_TLS_KEY_FILE`
 
-ClickHouse stores retained job logs and analytics tables. It is only useful for
-job logs when workflow log retention is enabled.
+ClickHouse stores retained job logs. Analytics are stored in PostgreSQL, while
+ClickHouse is only used for job logs when workflow log retention is enabled.
 
 ### Redis
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -219,7 +219,9 @@ Expected no-log cases:
 - `HEARTBEAT` workflows do not produce logs.
 - Workflows with `log_retention=false` do not persist searchable/downloadable
   logs.
-- Log endpoints return `412 Precondition Failed` when retention is disabled.
+- Retained log read/search endpoints return `412 Precondition Failed` when
+  retention is disabled; live SSE streams report the same condition as
+  `event: error`.
 
 Unexpected no-log cases:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,263 @@
+# Operations
+
+This guide covers day-to-day commands, startup behavior, health checks, tuning,
+and common troubleshooting paths for the compose-based Chronoverse stack.
+
+## Running the Stack
+
+### Development
+
+```sh
+docker compose -f compose.dev.yaml up -d
+```
+
+Useful endpoints:
+
+- Dashboard: `http://localhost:3001`
+- API: `http://localhost:8080`
+- LGTM: `http://localhost:3000`
+- gRPC: `localhost:50051` through `localhost:50055`
+
+Development builds local service images and exposes internal infrastructure
+ports for debugging.
+
+### Production
+
+```sh
+docker compose -f compose.prod.yaml up -d
+```
+
+Useful endpoints:
+
+- Dashboard: `http://localhost`
+- API through Nginx: `http://localhost/api/...`
+- LGTM: `http://localhost:3000`
+
+Production uses published images, internal service ports, generated TLS
+configuration, resource limits, and replicated worker settings.
+
+### Stop and Inspect
+
+```sh
+docker compose -f compose.dev.yaml ps
+docker compose -f compose.dev.yaml logs -f server
+docker compose -f compose.dev.yaml down
+```
+
+Use `compose.prod.yaml` in the same commands for the production stack.
+
+## Startup Order
+
+1. `init-certs` generates the local CA, service certificates, client
+   certificates, Kafka keystore/truststore files, and auth keys.
+2. PostgreSQL, ClickHouse, Redis, Meilisearch, Kafka, LGTM, and Docker proxy
+   start with TLS-enabled configuration.
+3. `init-kafka-topics` creates or expands Kafka topics.
+4. `init-database-migration` applies PostgreSQL migrations, ClickHouse
+   migrations, and Meilisearch index setup.
+5. gRPC services start after migrations and their dependencies are healthy.
+6. Workers start after dependent services and topics are ready.
+7. The dashboard starts after backend services.
+8. Production Nginx starts after dashboard and server.
+
+## Health Checks
+
+Compose includes health checks for infrastructure and gRPC services:
+
+- PostgreSQL uses `psql` with TLS client certs.
+- ClickHouse uses `clickhouse-client --secure`.
+- Redis uses `redis-cli --tls`.
+- Meilisearch uses HTTPS with cert/key/CA paths.
+- gRPC services use `grpc-health-probe` with TLS and service auth headers.
+
+If a service is stuck in `starting`, inspect the logs for that service and the
+dependency immediately before it in the startup order.
+
+## Build, Test, and Lint
+
+Repository commands:
+
+```sh
+make tools
+make generate
+make test/short
+make test
+make lint
+make lint/fix
+make build/all
+```
+
+Important notes:
+
+- `make generate` requires `buf`.
+- `make tools` installs Go tooling into `./.bin`.
+- `make test` runs Go tests with the race detector.
+- `make build/all` builds all Go services and workers, including `outbox-relay`.
+
+Dashboard commands:
+
+```sh
+cd dashboard
+npm install
+npm run dev:port
+npm run build
+npm run lint
+npm run lint:fix
+```
+
+The dashboard `dev:port` script runs on port `3001`, matching the dev compose
+dashboard port.
+
+## Operational Tuning
+
+### Kafka Topic Partitions
+
+Tune before starting the stack or before topic initialization:
+
+- `KAFKA_WORKFLOWS_TOPIC_PARTITIONS`
+- `KAFKA_JOBS_TOPIC_PARTITIONS`
+- `KAFKA_JOB_LOGS_TOPIC_PARTITIONS`
+- `KAFKA_ANALYTICS_TOPIC_PARTITIONS`
+- `KAFKA_TOPIC_REPLICATION_FACTOR`
+
+Kafka auto topic creation is disabled. The init job can expand partition counts
+but should not be treated as a substitute for capacity planning.
+
+### Scheduler
+
+- `SCHEDULING_WORKER_POLL_INTERVAL` controls how often due workflows are scanned.
+- `SCHEDULING_WORKER_CONTEXT_TIMEOUT` bounds each scan.
+- `SCHEDULING_WORKER_BATCH_SIZE` controls how many workflows can be processed per
+  pass.
+
+Lower intervals increase scheduling responsiveness and database load.
+
+### Execution Workers
+
+- `EXECUTION_WORKER_CONCURRENCY` controls parallel job execution.
+- `EXECUTION_WORKER_LEASE_DURATION` and
+  `EXECUTION_WORKER_LEASE_RENEW_INTERVAL` control lease ownership.
+- `EXECUTION_WORKER_SYSTEM_RETRY_LIMIT` and
+  `EXECUTION_WORKER_SYSTEM_RETRY_BACKOFF` control infrastructure retry behavior.
+- `EXECUTION_WORKER_RECOVERY_INTERVAL` and
+  `EXECUTION_WORKER_RECOVERY_BATCH_SIZE` control expired lease recovery.
+- `EXECUTION_WORKER_JOB_LOG_*` settings tune log batching, publish retries, live
+  publish timeout, and live log buffer size.
+
+Keep the lease duration comfortably above the renewal interval. Increase
+concurrency only when Docker host capacity, Kafka partitions, and downstream
+services can support it.
+
+### Outbox Relay
+
+- `OUTBOX_RELAY_BATCH_SIZE` and `OUTBOX_RELAY_POLL_INTERVAL` control throughput
+  and database polling pressure.
+- `OUTBOX_RELAY_PROCESSING_LEASE` controls how long a relay owns claimed rows.
+- `OUTBOX_RELAY_MAX_ATTEMPTS` and `OUTBOX_RELAY_RETRY_BACKOFF` control retry and
+  dead-event behavior.
+- `OUTBOX_RELAY_CLEANUP_*` and `OUTBOX_RELAY_PUBLISHED_RETENTION` control cleanup
+  of published events.
+- `OUTBOX_RELAY_WORKFLOW_ENABLED`, `OUTBOX_RELAY_JOBS_ENABLED`, and
+  `OUTBOX_RELAY_ANALYTICS_ENABLED` can disable topic groups when needed.
+
+If relay throughput is low, inspect Kafka publish latency and PostgreSQL query
+latency before reducing the poll interval.
+
+### Logs and Search
+
+- `JOBLOGS_PROCESSOR_BATCH_JOB_LOGS_SIZE_LIMIT`
+- `JOBLOGS_PROCESSOR_BATCH_JOB_LOGS_TIME_INTERVAL`
+- ClickHouse connection pool settings.
+- Meilisearch capacity and master key configuration.
+
+Large log volumes should be matched with enough Kafka `job_logs` partitions and
+ClickHouse insertion capacity.
+
+### Analytics Cleanup
+
+- `ANALYTICS_PROCESSOR_CLEANUP_ENABLED`
+- `ANALYTICS_PROCESSOR_CLEANUP_INTERVAL`
+- `ANALYTICS_PROCESSOR_CLEANUP_BATCH_SIZE`
+- `ANALYTICS_PROCESSED_EVENTS_RETENTION`
+
+Processed-event retention supports replay dedupe. Avoid setting it too low for
+the longest replay window you expect to tolerate.
+
+## Troubleshooting
+
+### TLS or Certificate Failures
+
+- Confirm `init-certs` completed successfully.
+- Confirm the `certs` volume exists and is mounted by the failing service.
+- For gRPC services, verify `GRPC_TLS_*` paths and client `*_SERVICE_TLS_CA_FILE`
+  paths match the generated files.
+- For Kafka, inspect the generated keystore/truststore files in the Kafka certs
+  mount.
+
+For local development, recreating the stack and cert volume can clear stale
+certificate state:
+
+```sh
+docker compose -f compose.dev.yaml down -v
+docker compose -f compose.dev.yaml up -d
+```
+
+This deletes local data volumes.
+
+### Compose Readiness Problems
+
+- Run `docker compose -f compose.dev.yaml ps` and find the first unhealthy or
+  restarting dependency.
+- Inspect dependency logs before application logs.
+- Check that database migration completed before services started.
+- Check `init-kafka-topics` output if workers are not receiving events.
+
+### Missing Logs
+
+Expected no-log cases:
+
+- `HEARTBEAT` workflows do not produce logs.
+- Workflows with `log_retention=false` do not persist searchable/downloadable
+  logs.
+- Log endpoints return `412 Precondition Failed` when retention is disabled.
+
+Unexpected no-log cases:
+
+- Confirm the job is a `CONTAINER` workflow.
+- Confirm the workflow has `log_retention=true`.
+- Confirm `joblogs-processor` is running.
+- Check ClickHouse health and Meilisearch health.
+- Inspect `job_logs` Kafka topic activity.
+
+### SSE Live Logs Do Not Stream
+
+- Development clients should call
+  `/workflows/{workflow_id}/jobs/{job_id}/events` on the API origin.
+- Production clients should call
+  `/api/workflows/{workflow_id}/jobs/{job_id}/events` through Nginx.
+- Confirm the job is still `RUNNING`; the stream endpoint is intended for live
+  running jobs.
+- Confirm the proxy path disables buffering. The included production Nginx config
+  has a dedicated SSE location.
+
+### Duplicate or Stale Events
+
+Chronoverse is designed to tolerate replay. Check these areas before treating a
+duplicate Kafka event as data corruption:
+
+- Mutation clients should reuse the same `Idempotency-Key` only for retries of
+  the same action.
+- `outbox-relay` should be running so committed outbox rows are published.
+- Workflow generation mismatch errors usually mean a stale event was ignored.
+- Job lease precondition failures usually mean another worker owns the job or
+  the lease expired.
+- Analytics and log processors dedupe deterministic event IDs and processed
+  event records.
+
+### Dashboard Cannot Reach API
+
+- Development dashboard builds with `NEXT_PUBLIC_API_URL=http://localhost:8080`.
+- Production should use the Nginx `/api` proxy.
+- Check `SERVER_ALLOWED_ORIGINS` when browser CORS requests fail.
+- Confirm session and CSRF cookies are scoped to the expected host and same-site
+  mode.


### PR DESCRIPTION
## Summary
- Refresh the README as a concise entry point for the current Chronoverse architecture and workflows
- Add focused docs for architecture, configuration, HTTP API behavior, and operations
- Document v1.2.4-era replay safety, outbox relay, durable job leases, idempotency keys, log retention, manual runs, SSE logs, search, TLS/mTLS, observability, and compose topology
- Clarify PostgreSQL-backed analytics storage and SSE log stream error-event behavior