### PR TITLE
Fix job log pagination and enforce Meilisearch mTLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO_BIN?=$(shell pwd)/.bin
+PROTOC_GEN_GO_GRPC_VERSION?=v1.6.2
 export PATH := $(GO_BIN):$(PATH)
 PKG_PATH=github.com/hitesh22rana/chronoverse/internal/pkg/svc
 APP_VERSION?=v0.0.1 # Default version
@@ -32,7 +33,11 @@ test: dependencies
 tools:
 	@mkdir -p ${GO_BIN}
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GO_BIN} v2.4.0
-	@cat tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % sh -c 'GOBIN=${GO_BIN} go install %@latest'
+	@grep _ tools.go | awk -F'"' '{print $$2}' | while read tool; do \
+		version=latest; \
+		if [ "$$tool" = "google.golang.org/grpc/cmd/protoc-gen-go-grpc" ]; then version=${PROTOC_GEN_GO_GRPC_VERSION}; fi; \
+		GOBIN=${GO_BIN} go install "$$tool@$$version"; \
+	done
 
 .PHONY: mockgen
 mockgen: tools

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -100,7 +100,7 @@ services:
       - chronoverse
 
   meilisearch:
-    image: getmeili/meilisearch:v1.15.0
+    image: getmeili/meilisearch:v1.45.2
     container_name: meilisearch
     ports:
       - "7700:7700"
@@ -108,8 +108,10 @@ services:
     environment:
       MEILI_MASTER_KEY: 35b09c3c7b1001ed1fbed7db29a155d0201ab22d527b41bfba9003da7bb3b404
       MEILI_SSL_AUTH_PATH: /certs/ca/ca.crt
+      MEILI_SSL_REQUIRE_AUTH: true
       MEILI_SSL_CERT_PATH: /certs/meilisearch/meilisearch.crt
       MEILI_SSL_KEY_PATH: /certs/meilisearch/meilisearch.key
+      MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: true
     volumes:
       - meilisearch:/meili_data
       - ./certs:/certs:ro
@@ -120,7 +122,7 @@ services:
       test: |
         sh -c '
           if [ -n "$$MEILI_SSL_AUTH_PATH" ] && [ -n "$$MEILI_SSL_CERT_PATH" ] && [ -n "$$MEILI_SSL_KEY_PATH" ]; then
-            curl --cert "$$MEILI_SSL_CERT_PATH" --key "$$MEILI_SSL_KEY_PATH" --cacert "$$MEILI_SSL_AUTH_PATH" -f https://meilisearch:7700/health
+            curl --cert /certs/clients/client.crt --key /certs/clients/client.key --cacert "$$MEILI_SSL_AUTH_PATH" -f https://meilisearch:7700/health
           else
             curl -f http://meilisearch:7700/health
           fi

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -146,14 +146,16 @@ services:
       - chronoverse
 
   meilisearch:
-    image: getmeili/meilisearch:v1.15.0
+    image: getmeili/meilisearch:v1.45.2
     container_name: meilisearch
     restart: on-failure
     environment:
       MEILI_MASTER_KEY: 35b09c3c7b1001ed1fbed7db29a155d0201ab22d527b41bfba9003da7bb3b404
       MEILI_SSL_AUTH_PATH: /certs/ca/ca.crt
+      MEILI_SSL_REQUIRE_AUTH: true
       MEILI_SSL_CERT_PATH: /certs/meilisearch/meilisearch.crt
       MEILI_SSL_KEY_PATH: /certs/meilisearch/meilisearch.key
+      MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: true
       ENV: production
     volumes:
       - meilisearch:/meili_data
@@ -165,7 +167,7 @@ services:
       test: |
         sh -c '
           if [ -n "$$MEILI_SSL_AUTH_PATH" ] && [ -n "$$MEILI_SSL_CERT_PATH" ] && [ -n "$$MEILI_SSL_KEY_PATH" ]; then
-            curl --cert "$$MEILI_SSL_CERT_PATH" --key "$$MEILI_SSL_KEY_PATH" --cacert "$$MEILI_SSL_AUTH_PATH" -f https://meilisearch:7700/health
+            curl --cert /certs/clients/client.crt --key /certs/clients/client.key --cacert "$$MEILI_SSL_AUTH_PATH" -f https://meilisearch:7700/health
           else
             curl -f http://meilisearch:7700/health
           fi

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -8,6 +8,11 @@ import {
     useTransition,
 } from "react"
 import {
+    usePathname,
+    useRouter,
+    useSearchParams,
+} from "next/navigation"
+import {
     Download,
     Filter,
     Loader2,
@@ -54,6 +59,81 @@ const getLogStreamStyles = (stream: string) => {
     }
 }
 
+const getLogStreamStripStyles = (stream: string) => {
+    switch (stream) {
+        case "stderr":
+            return "bg-red-500 dark:bg-red-400"
+        case "stdout":
+        default:
+            return "bg-emerald-500 dark:bg-emerald-400"
+    }
+}
+
+const highlightClass = "rounded bg-orange-400/80 px-0.5 text-inherit dark:bg-orange-500/70"
+
+const escapeHtml = (value: string) => {
+    return value.replace(/[&<>"']/g, (char) => {
+        switch (char) {
+            case "&":
+                return "&amp;"
+            case "<":
+                return "&lt;"
+            case ">":
+                return "&gt;"
+            case "\"":
+                return "&quot;"
+            case "'":
+                return "&#39;"
+            default:
+                return char
+        }
+    })
+}
+
+const escapeRegExp = (value: string) => {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+const stripHighlightTags = (message: string) => {
+    return message.replace(/<\/?em>/g, "")
+}
+
+const extractHighlightedTerms = (message: string) => {
+    const terms: string[] = []
+    const highlightPattern = /<em>([\s\S]*?)<\/em>/g
+
+    for (const match of message.matchAll(highlightPattern)) {
+        const term = match[1]
+        if (term?.trim()) {
+            terms.push(term)
+        }
+    }
+
+    return Array.from(new Set(terms)).sort((a, b) => b.length - a.length)
+}
+
+const renderHighlightedText = (message: string, terms: string[]) => {
+    if (!terms.length) {
+        return escapeHtml(message)
+    }
+
+    const highlightPattern = new RegExp(terms.map(escapeRegExp).join("|"), "gi")
+    let lastIndex = 0
+    let rendered = ""
+
+    for (const match of message.matchAll(highlightPattern)) {
+        const matchText = match[0]
+        const matchIndex = match.index ?? 0
+
+        rendered += escapeHtml(message.slice(lastIndex, matchIndex))
+        rendered += `<mark class="${highlightClass}">${escapeHtml(matchText)}</mark>`
+        lastIndex = matchIndex + matchText.length
+    }
+
+    rendered += escapeHtml(message.slice(lastIndex))
+    return rendered
+}
+
 export function LogsViewer({
     workflowId,
     jobId,
@@ -61,10 +141,12 @@ export function LogsViewer({
     completedAt,
 }: LogViewerProps) {
     const [isSearchPending, startSearchTransition] = useTransition()
+    const router = useRouter()
+    const pathname = usePathname()
+    const searchParams = useSearchParams()
 
     const [popoverOpen, setPopoverOpen] = useState(false)
     const [isSearchFocused, setIsSearchFocused] = useState(false)
-    const [parseJson, setParseJson] = useState<boolean>(true)
     const searchInputRef = useRef<HTMLInputElement>(null)
 
     const {
@@ -89,6 +171,20 @@ export function LogsViewer({
     const [searchInput, setSearchInput] = useState(searchQuery)
     const [stream, setStream] = useState(streamFilter || "all")
     const disableLogInteractions = isRetentionDisabled || isLogsUnsupportedForKind
+    const parseJson = searchParams.get("json") === "true"
+
+    const updateJsonRendering = useCallback((enabled: boolean) => {
+        const params = new URLSearchParams(searchParams.toString())
+
+        if (enabled) {
+            params.set("json", "true")
+        } else {
+            params.delete("json")
+        }
+
+        const query = params.toString()
+        router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+    }, [pathname, router, searchParams])
 
     // Debounced search update
     useEffect(() => {
@@ -122,16 +218,22 @@ export function LogsViewer({
         return () => window.removeEventListener("keydown", handleKeyDown)
     }, [isSearchFocused])
 
-    // Parse log message (with JSON pretty print)
+    // Parse log message and render Meili <em> highlights safely.
     const parseLog = useCallback(
         (message: string) => {
-            if (!parseJson) return message
+            const shouldRenderSearchHighlights = Boolean(searchQuery)
+            const highlightedTerms = shouldRenderSearchHighlights ? extractHighlightedTerms(message) : []
+            const rawMessage = shouldRenderSearchHighlights ? stripHighlightTags(message) : message
+
+            if (!parseJson) {
+                return renderHighlightedText(rawMessage, highlightedTerms)
+            }
 
             try {
-                const parsed = JSON.parse(message)
-                return JSON.stringify(parsed, null, 2)
+                const parsed = JSON.parse(rawMessage)
+                return renderHighlightedText(JSON.stringify(parsed, null, 2), highlightedTerms)
             } catch {
-                return message.replace(jsonRegex, (match) => {
+                const formattedMessage = rawMessage.replace(jsonRegex, (match) => {
                     try {
                         const parsed = JSON.parse(match)
                         return JSON.stringify(parsed, null, 2)
@@ -139,9 +241,11 @@ export function LogsViewer({
                         return match
                     }
                 })
+
+                return renderHighlightedText(formattedMessage, highlightedTerms)
             }
         },
-        [parseJson]
+        [parseJson, searchQuery]
     )
 
     // Row renderer for Virtuoso
@@ -152,15 +256,17 @@ export function LogsViewer({
         return (
             <div
                 className={cn(
-                    "flex hover:bg-muted/50 px-2 py-1 group",
+                    "flex min-h-6 hover:bg-muted/50 group",
                     getLogStreamStyles(log.stream)
                 )}
             >
-                <span className="text-muted-foreground mr-4 select-none min-w-[5ch] text-right hover:text-primary">
-                    {index + 1}
-                </span>
                 <span
-                    className="flex-1 whitespace-pre-wrap break-all"
+                    className={cn("my-1 w-1 flex-none rounded-sm", getLogStreamStripStyles(log.stream))}
+                    title={log.stream}
+                    aria-hidden="true"
+                />
+                <span
+                    className="flex-1 whitespace-pre-wrap break-all px-3 py-1"
                     dangerouslySetInnerHTML={{
                         __html: formattedMessage,
                     }}
@@ -256,7 +362,7 @@ export function LogsViewer({
                             </span>
                             <Switch
                                 checked={parseJson}
-                                onCheckedChange={setParseJson}
+                                onCheckedChange={updateJsonRendering}
                                 disabled={(jobStatus === "CANCELED" && logs.length === 0) || (logs.length === 0 && !!completedAt)}
                             />
                         </div>
@@ -299,7 +405,6 @@ export function LogsViewer({
                         endReached={handleEndReached}
                         overscan={200}
                         className="flex flex-1 w-full h-full"
-                        followOutput={jobStatus === "RUNNING" && "smooth"}
                     />
                 ) : isLogsUnsupportedForKind ? (
                     <div className="flex flex-col items-center justify-center h-full text-muted-foreground m-auto">
@@ -337,7 +442,7 @@ export function LogsViewer({
                 {isFetchingNextPage && (
                     <div className="flex items-center justify-center py-4">
                         <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                        <span className="text-sm text-muted-foreground">Loading more logs...</span>
+                        <span className="text-sm text-muted-foreground">Loading older logs...</span>
                     </div>
                 )}
             </CardContent>

--- a/dashboard/src/components/dashboard/notifications-drawer.tsx
+++ b/dashboard/src/components/dashboard/notifications-drawer.tsx
@@ -127,7 +127,7 @@ export function NotificationsDrawer({ open, onClose }: NotificationsDrawerProps)
     const toggleSelect = (id: string) => {
         setSelected((prev) => {
             const next = new Set(prev)
-             
+
             next.has(id) ? next.delete(id) : next.add(id)
             return next
         })
@@ -150,6 +150,21 @@ export function NotificationsDrawer({ open, onClose }: NotificationsDrawerProps)
     }
 
     useEffect(() => {
+        if (!open) {
+            clearSelection()
+        }
+    }, [open])
+
+    useEffect(() => {
+        const notificationIds = new Set(notifications.map((n) => n.id))
+
+        setSelected((prev) => {
+            const next = new Set([...prev].filter((id) => notificationIds.has(id)))
+            return next.size === prev.size ? prev : next
+        })
+    }, [notifications])
+
+    useEffect(() => {
         if (notifications.length === 0) {
             setSelectAll(false)
             return
@@ -163,6 +178,21 @@ export function NotificationsDrawer({ open, onClose }: NotificationsDrawerProps)
         if (selected.size === 0) return
         markAsRead(Array.from(selected))
         clearSelection()
+    }
+
+    const handleNotificationClick = (notification: Notification) => {
+        if (!notification.read_at) {
+            markAsRead([notification.id])
+        }
+
+        setSelected((prev) => {
+            if (!prev.has(notification.id)) return prev
+
+            const next = new Set(prev)
+            next.delete(notification.id)
+            return next
+        })
+        onClose()
     }
 
     // Item renderer
@@ -190,9 +220,6 @@ export function NotificationsDrawer({ open, onClose }: NotificationsDrawerProps)
                     meta.color,
                     !n.read_at && "ring-1 ring-white/5"
                 )}
-                onClick={() => {
-                    if (!n.read_at) markAsRead([n.id])
-                }}
             >
                 <div
                     onClick={(e) => {
@@ -203,7 +230,12 @@ export function NotificationsDrawer({ open, onClose }: NotificationsDrawerProps)
                     <Checkbox checked={selected.has(n.id)} />
                 </div>
 
-                <Link href={payload.action_url} prefetch={false} className="flex-1 min-w-0 flex flex-col gap-2">
+                <Link
+                    href={payload.action_url}
+                    prefetch={false}
+                    className="flex-1 min-w-0 flex flex-col gap-2"
+                    onClick={() => handleNotificationClick(n)}
+                >
                     <div className="flex items-center justify-between gap-2">
                         <p className="font-medium text-sm truncate">{payload.title}</p>
                         <span className="text-xs text-muted-foreground shrink-0">
@@ -239,7 +271,7 @@ export function NotificationsDrawer({ open, onClose }: NotificationsDrawerProps)
         <Sheet open={open} onOpenChange={onClose}>
             <SheetContent className="w-full sm:max-w-md p-0 gap-0 h-full flex flex-col">
                 {/* header */}
-                <SheetHeader className="px-6 py-4 border-b flex-shrink-0">
+                <SheetHeader className="px-6 py-4 border-b shrink-0">
                     <div className="flex items-center gap-2">
                         <Bell className="h-5 w-5" />
                         <SheetTitle>Notifications</SheetTitle>

--- a/dashboard/src/hooks/use-job-logs.ts
+++ b/dashboard/src/hooks/use-job-logs.ts
@@ -14,8 +14,6 @@ import {
 import {
     useInfiniteQuery,
     useMutation,
-    useQuery,
-    useQueryClient
 } from "@tanstack/react-query"
 import { EventSourcePolyfill } from "event-source-polyfill"
 import { toast } from "sonner"
@@ -27,10 +25,21 @@ import { fetchWithAuth } from "@/lib/api-client"
 const API_URL = process.env.NEXT_PUBLIC_API_URL
 
 export type JobLog = {
+    event_id?: string
     timestamp: string
     message: string
     sequence_num: number
     stream: "stdout" | "stderr"
+}
+
+type JobLogWire = {
+    event_id?: string
+    eventId?: string
+    timestamp?: string
+    message?: string
+    sequence_num?: number | string
+    sequenceNum?: number | string
+    stream?: string
 }
 
 export type JobLogsResponseData = {
@@ -43,10 +52,82 @@ export type JobLogsResponseData = {
 const kindsWithLogs = ['CONTAINER']
 const terminalJobStatus = ['COMPLETED', 'FAILED', 'CANCELED']
 
+const logKey = (log: JobLog): string => {
+    if (log.event_id) {
+        return log.event_id
+    }
+
+    return `${log.sequence_num}:${log.stream}:${log.timestamp}:${log.message}`
+}
+
+const sequenceNumFromEventID = (eventID?: string): number | undefined => {
+    if (!eventID) {
+        return undefined
+    }
+
+    const sequenceNum = Number(eventID.split(":").at(-1))
+    return Number.isFinite(sequenceNum) ? sequenceNum : undefined
+}
+
+const normalizeJobLog = (log: JobLogWire): JobLog => {
+    const eventID = log.event_id || log.eventId
+    const sequenceNum = Number(log.sequence_num ?? log.sequenceNum ?? sequenceNumFromEventID(eventID) ?? 0)
+
+    return {
+        event_id: eventID,
+        timestamp: log.timestamp || "",
+        message: log.message || "",
+        sequence_num: Number.isFinite(sequenceNum) ? sequenceNum : 0,
+        stream: log.stream === "stderr" ? "stderr" : "stdout",
+    }
+}
+
+const mergeLiveLogs = (existingLogs: JobLog[], newLogs: JobLog[]): JobLog[] => {
+    return sortLogsDesc(uniqueLogsByKey([...existingLogs, ...newLogs]))
+}
+
+const compareLogsDesc = (a: JobLog, b: JobLog): number => {
+    const sequenceOrder = b.sequence_num - a.sequence_num
+    if (sequenceOrder !== 0) return sequenceOrder
+
+    const streamOrder = a.stream.localeCompare(b.stream)
+    if (streamOrder !== 0) return streamOrder
+
+    const eventOrder = (a.event_id || logKey(a)).localeCompare(b.event_id || logKey(b))
+    if (eventOrder !== 0) return eventOrder
+
+    return b.timestamp.localeCompare(a.timestamp)
+}
+
+const sortLogsDesc = (logs: JobLog[]): JobLog[] => {
+    return [...logs].sort(compareLogsDesc)
+}
+
+const uniqueLogsByKey = (logs: JobLog[]): JobLog[] => {
+    const uniqueLogsMap = new Map<string, JobLog>()
+
+    logs.forEach((log) => {
+        const key = logKey(log)
+        const existingLog = uniqueLogsMap.get(key)
+        if (!existingLog || compareLogsDesc(log, existingLog) < 0) {
+            uniqueLogsMap.set(key, log)
+        }
+    })
+
+    return Array.from(uniqueLogsMap.values())
+}
+
+const logsFromPages = (pages?: JobLogsResponseData[]): JobLog[] => {
+    if (!pages?.length) {
+        return []
+    }
+
+    return sortLogsDesc(uniqueLogsByKey(pages.flatMap((page) => page?.logs || [])))
+}
+
 export function useJobLogs(workflowId: string, jobId: string, jobStatus: string) {
     const { workflow, isLoading: isWorkflowLoading } = useWorkflowDetails(workflowId)
     const router = useRouter()
-    const queryClient = useQueryClient()
     const searchParams = useSearchParams()
 
     const searchQuery = searchParams.get("q") || ""
@@ -54,6 +135,7 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
 
     const [isConnected, setIsConnected] = useState(false)
     const [isSSEEnabled, setIsSSEEnabled] = useState(false)
+    const [liveLogs, setLiveLogs] = useState<JobLog[]>([])
     const eventSourceRef = useRef<EventSourcePolyfill | null>(null)
 
     const logsURL = `${API_URL}/workflows/${workflowId}/jobs/${jobId}/logs`
@@ -143,31 +225,20 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         }
     })
 
-    // Helper function to merge logs and remove duplicates
-    const mergeLogs = (existingLogs: JobLog[], newLogs: JobLog[]): JobLog[] => {
-        const combined = [...existingLogs, ...newLogs]
-
-        // Create a map to track unique logs by sequence_num
-        const uniqueLogsMap = new Map<number, JobLog>()
-
-        // Add all logs to the map, later entries will overwrite earlier ones with same sequence_num
-        combined.forEach(log => {
-            uniqueLogsMap.set(log.sequence_num, log)
-        })
-
-        // Convert back to array and sort by sequence_num
-        return Array.from(uniqueLogsMap.values()).sort((a, b) => a.sequence_num - b.sequence_num)
-    }
-
-    // For completed jobs, use infinite query with pagination
+    // Retained logs are newest-first; fetching the next page loads older logs.
+    const jobLogsInfiniteQueryKey = useMemo(
+        () => ["job-logs", workflowId, jobId, jobStatus],
+        [workflowId, jobId, jobStatus]
+    )
     const jobLogsInfiniteQuery = useInfiniteQuery<JobLogsResponseData, Error>({
-        queryKey: ["job-logs", workflowId, jobId, jobStatus],
+        queryKey: jobLogsInfiniteQueryKey,
         queryFn: async ({ pageParam }) => {
+            const isFirstPage = !pageParam
             const url = pageParam
                 ? `${logsURL}?cursor=${pageParam}`
                 : logsURL
 
-            const response = await fetchWithAuth(url)
+            const response = await fetchWithAuth(url, isFirstPage ? { cache: "no-store" } : undefined)
 
             if (!response.ok) {
                 throw new Error("failed to fetch job logs")
@@ -178,12 +249,13 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
             return {
                 id: res.id,
                 workflow_id: res.workflow_id,
-                logs: res.logs || [],
+                logs: (res.logs || []).map(normalizeJobLog),
                 cursor: res.cursor || undefined,
             }
         },
         initialPageParam: null,
         getNextPageParam: (lastPage) => lastPage?.cursor || null,
+        refetchOnMount: "always",
         enabled: shouldFetch && !getSearchQueryParams && Boolean(workflowId) && Boolean(jobId),
     })
 
@@ -191,11 +263,12 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
     const jobLogsSearchInfiniteQuery = useInfiniteQuery<JobLogsResponseData, Error>({
         queryKey: ["job-logs/search", workflowId, jobId, searchQuery, streamFilter],
         queryFn: async ({ pageParam }) => {
+            const isFirstPage = !pageParam
             const url = pageParam
                 ? `${searchURL}?${getSearchQueryParams}&cursor=${pageParam}`
                 : `${searchURL}?${getSearchQueryParams}`
 
-            const response = await fetchWithAuth(url);
+            const response = await fetchWithAuth(url, isFirstPage ? { cache: "no-store" } : undefined);
 
             if (!response.ok) {
                 throw new Error("failed to fetch job logs");
@@ -206,71 +279,28 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
             return {
                 id: jobId,
                 workflow_id: workflowId,
-                logs: res.logs || [],
+                logs: (res.logs || []).map(normalizeJobLog),
                 cursor: res.cursor || undefined,
             }
         },
         initialPageParam: null,
         getNextPageParam: (lastPage) => lastPage?.cursor || null,
+        refetchOnMount: "always",
         enabled: shouldFetch && Boolean(getSearchQueryParams) && Boolean(workflowId) && Boolean(jobId),
     });
 
-    // For running jobs, use regular query + SSE
-    const jobLogsSSEQueryKey = useMemo(() => [`job-logs/events`, workflowId, jobId], [workflowId, jobId])
-    const jobLogsSSEQuery = useQuery({
-        queryKey: jobLogsSSEQueryKey,
-        queryFn: async (): Promise<JobLog[]> => {
-            const allLogs: JobLog[] = []
-            let cursor: string | undefined = undefined
-
-            // Fetch all pages of logs
-            while (true) {
-                const url = cursor
-                    ? `${logsURL}?cursor=${cursor}`
-                    : logsURL
-
-                const response = await fetchWithAuth(url)
-
-                if (!response.ok) {
-                    throw new Error("Failed to fetch job logs")
-                }
-
-                const res = await response.json() as JobLogsResponseData
-
-                if (res.logs && res.logs.length > 0) {
-                    allLogs.push(...res.logs)
-                }
-
-                // If there's no cursor, we've fetched all pages
-                if (!res.cursor) {
-                    break
-                }
-
-                cursor = res.cursor
-            }
-
-            return allLogs
-        },
-        enabled: shouldFetch && !getSearchQueryParams && isRunning && Boolean(workflowId) && Boolean(jobId),
-        staleTime: Infinity,
-        gcTime: Infinity,
-    })
+    useEffect(() => {
+        setLiveLogs([])
+    }, [workflowId, jobId])
 
     // Handle SSE connection for running jobs
     useEffect(() => {
-        // Only connect to SSE if:
-        // 1. Job is running
-        // 2. Initial logs have been fetched successfully
-        // 3. We have workflowId and jobId
-        if (!shouldFetch || !isRunning || !jobLogsSSEQuery.isSuccess || !workflowId || !jobId) {
+        if (!shouldFetch || !isRunning || Boolean(getSearchQueryParams) || !workflowId || !jobId) {
             setIsConnected(false)
             setIsSSEEnabled(false)
             return
         }
 
-        let firstPass: boolean = true;
-
-        // Enable SSE after initial fetch is complete
         setIsSSEEnabled(true)
 
         const eventSource = new EventSourcePolyfill(sseURL, {
@@ -287,16 +317,9 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         eventSource.addEventListener('log', (event) => {
             try {
                 const messageEvent = event as MessageEvent
-                const logData: JobLog = JSON.parse(messageEvent.data)
+                const logData = normalizeJobLog(JSON.parse(messageEvent.data) as JobLogWire)
 
-                queryClient.setQueryData(jobLogsSSEQueryKey, (oldData: JobLog[] | undefined) => {
-                    const existingLogs = oldData || []
-                    if (!firstPass) {
-                        return [...existingLogs, logData]
-                    }
-                    firstPass = false;
-                    return mergeLogs(existingLogs, [logData])
-                })
+                setLiveLogs((existingLogs) => mergeLiveLogs(existingLogs, [logData]))
             } catch { /* ignore parsing errors */ }
         })
 
@@ -321,8 +344,9 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
             eventSource.close()
             eventSourceRef.current = null
             setIsConnected(false)
+            setIsSSEEnabled(false)
         }
-    }, [queryClient, jobLogsSSEQueryKey, sseURL, isRunning, shouldFetch, jobLogsSSEQuery.isSuccess, workflowId, jobId])
+    }, [sseURL, isRunning, shouldFetch, getSearchQueryParams, workflowId, jobId])
 
     useEffect(() => {
         if (jobLogsSearchInfiniteQuery.error instanceof Error) {
@@ -331,17 +355,24 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         if (jobLogsInfiniteQuery.error instanceof Error) {
             toast.error(jobLogsInfiniteQuery.error.message)
         }
-        if (jobLogsSSEQuery.error instanceof Error) {
-            toast.error(jobLogsSSEQuery.error.message)
-        }
-    }, [jobLogsSearchInfiniteQuery.error, jobLogsInfiniteQuery.error, jobLogsSSEQuery.error])
+    }, [jobLogsSearchInfiniteQuery.error, jobLogsInfiniteQuery.error])
+
+    const retainedLogs = useMemo(
+        () => logsFromPages(jobLogsInfiniteQuery.data?.pages),
+        [jobLogsInfiniteQuery.data?.pages]
+    )
+    const runningLogs = useMemo(
+        () => mergeLiveLogs(retainedLogs, liveLogs),
+        [retainedLogs, liveLogs]
+    )
+    const searchLogs = useMemo(
+        () => logsFromPages(jobLogsSearchInfiniteQuery.data?.pages),
+        [jobLogsSearchInfiniteQuery.data?.pages]
+    )
 
     if (shouldFetch && Boolean(getSearchQueryParams)) {
-        const allPages = jobLogsSearchInfiniteQuery.data?.pages || [];
-        const logs = allPages.length > 0 ? allPages.flatMap((page) => page?.logs || []) : [];
-
         return {
-            logs,
+            logs: searchLogs,
             isLoading: jobLogsSearchInfiniteQuery.isLoading,
             error: jobLogsSearchInfiniteQuery.error,
             fetchNextPage: jobLogsSearchInfiniteQuery.fetchNextPage,
@@ -363,11 +394,8 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
     }
 
     if (isCompleted) {
-        const allPages = jobLogsInfiniteQuery.data?.pages || []
-        const logs = allPages.length > 0 ? allPages.flatMap((page) => page?.logs || []) : []
-
         return {
-            logs,
+            logs: retainedLogs,
             isLoading: jobLogsInfiniteQuery.isLoading,
             error: jobLogsInfiniteQuery.error,
             fetchNextPage: jobLogsInfiniteQuery.fetchNextPage,
@@ -394,13 +422,13 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
 
     if (isRunning) {
         return {
-            logs: jobLogsSSEQuery.data || [],
-            isLoading: jobLogsSSEQuery.isLoading,
-            error: jobLogsSSEQuery.error,
-            fetchNextPage: () => Promise.resolve(),
-            isFetchingNextPage: false,
-            hasNextPage: false,
-            refetch: jobLogsSSEQuery.refetch,
+            logs: runningLogs,
+            isLoading: jobLogsInfiniteQuery.isLoading,
+            error: jobLogsInfiniteQuery.error,
+            fetchNextPage: jobLogsInfiniteQuery.fetchNextPage,
+            isFetchingNextPage: jobLogsInfiniteQuery.isFetchingNextPage,
+            hasNextPage: jobLogsInfiniteQuery.hasNextPage,
+            refetch: jobLogsInfiniteQuery.refetch,
             searchQuery: searchQuery,
             updateSearchQuery: updateSearchQuery,
             streamFilter: streamFilter,

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,31 +1,31 @@
 # HTTP API
-
+ 
 The HTTP API is served by `server`. Development exposes it directly on
 `http://localhost:8080`. Production exposes it through Nginx under `/api/...`;
 for example, development `GET /workflows` maps to production
 `GET /api/workflows`.
-
+ 
 All non-auth application routes require a valid session cookie. Mutating routes
 also require CSRF validation. Browser clients get the session and CSRF cookies
 from login or registration.
-
+ 
 ## Common Behavior
-
+ 
 ### Headers
-
+ 
 - `Content-Type: application/json` for JSON request bodies.
 - `Idempotency-Key: <unique-key>` is required for retry-prone mutations:
   - `POST /workflows`
   - `PUT /workflows/{workflow_id}`
   - `POST /workflows/{workflow_id}/jobs/schedule`
-
+ 
 Use a stable idempotency key when retrying the same user action. Use a new key
 for a new action.
-
+ 
 ### Status Mapping
-
+ 
 The server maps gRPC errors to HTTP status codes. Important cases:
-
+ 
 - `400 Bad Request`: invalid input, invalid filters, missing idempotency key.
 - `401 Unauthorized`: missing or invalid session.
 - `403 Forbidden`: permission denied.
@@ -36,95 +36,95 @@ The server maps gRPC errors to HTTP status codes. Important cases:
   sent as `event: error` frames after stream headers are written.
 - `429 Too Many Requests`: resource exhausted.
 - `503 Service Unavailable`: downstream service unavailable.
-
+ 
 ## Authentication
-
+ 
 ### Register
-
+ 
 `POST /auth/register`
-
+ 
 Body:
-
+ 
 ```json
 {
   "email": "user@example.com",
   "password": "password"
 }
 ```
-
+ 
 Creates the user, issues a session cookie, and returns `201 Created`.
-
+ 
 ### Login
-
+ 
 `POST /auth/login`
-
+ 
 Body:
-
+ 
 ```json
 {
   "email": "user@example.com",
   "password": "password"
 }
 ```
-
+ 
 Issues a session cookie and returns `201 Created`.
-
+ 
 ### Logout
-
+ 
 `POST /auth/logout`
-
+ 
 Deletes the session and CSRF cookies and returns `204 No Content`.
-
+ 
 ### Validate Session
-
+ 
 `POST /auth/validate`
-
+ 
 Returns `200 OK` when the current session and CSRF token are valid.
-
+ 
 ## Users
-
+ 
 ### Get Current User
-
+ 
 `GET /users`
-
+ 
 Returns the current user's profile and preference data.
-
+ 
 ### Update Current User
-
+ 
 `PUT /users`
-
+ 
 Body:
-
+ 
 ```json
 {
   "notification_preference": "ALL"
 }
 ```
-
+ 
 Returns `204 No Content`. The current handler accepts a `password` field in the
 shape but only forwards notification preference updates.
-
+ 
 ## Workflows
-
+ 
 Workflow kinds:
-
+ 
 - `HEARTBEAT`: no execution logs and `log_retention` must be disabled.
 - `CONTAINER`: executes a container workload and may retain logs.
-
+ 
 Build statuses:
-
+ 
 - `QUEUED`
 - `STARTED`
 - `COMPLETED`
 - `FAILED`
 - `CANCELED`
-
+ 
 ### List Workflows
-
+ 
 `GET /workflows`
-
+ 
 Query parameters:
-
+ 
 - `cursor`: pagination cursor.
 - `query`: text query.
 - `kind`: `HEARTBEAT` or `CONTAINER`.
@@ -132,17 +132,17 @@ Query parameters:
 - `terminated`: boolean string.
 - `interval_min`: minimum interval in minutes.
 - `interval_max`: maximum interval in minutes.
-
+ 
 Response includes `workflows` and `cursor`.
-
+ 
 ### Create Workflow
-
+ 
 `POST /workflows`
-
+ 
 Requires `Idempotency-Key`.
-
+ 
 Body:
-
+ 
 ```json
 {
   "name": "nightly-report",
@@ -153,9 +153,9 @@ Body:
   "log_retention": true
 }
 ```
-
+ 
 Fields:
-
+ 
 - `name`: display name.
 - `payload`: workflow-kind-specific JSON string.
 - `kind`: `HEARTBEAT` or `CONTAINER`.
@@ -164,15 +164,15 @@ Fields:
   behavior changes.
 - `log_retention`: optional. `CONTAINER` defaults to retained logs when unset;
   `HEARTBEAT` persists with retention disabled.
-
+ 
 Returns `201 Created` with the workflow ID.
-
+ 
 ### Get Workflow
-
+ 
 `GET /workflows/{workflow_id}`
-
+ 
 Returns workflow fields including:
-
+ 
 - `id`
 - `name`
 - `payload`
@@ -186,15 +186,15 @@ Returns workflow fields including:
 - `terminated_at`
 - `log_retention`
 - `generation`
-
+ 
 ### Update Workflow
-
+ 
 `PUT /workflows/{workflow_id}`
-
+ 
 Requires `Idempotency-Key`.
-
+ 
 Body:
-
+ 
 ```json
 {
   "name": "nightly-report",
@@ -203,65 +203,65 @@ Body:
   "max_consecutive_job_failures_allowed": 3
 }
 ```
-
+ 
 Returns `204 No Content`.
-
+ 
 ### Terminate Workflow
-
+ 
 `PATCH /workflows/{workflow_id}`
-
+ 
 Terminates the workflow and returns `204 No Content`.
-
+ 
 ### Delete Workflow
-
+ 
 `DELETE /workflows/{workflow_id}`
-
+ 
 Deletes a terminated workflow and returns `204 No Content`. Active workflows or
 workflows with active jobs can fail with `412 Precondition Failed`.
-
+ 
 ## Jobs
-
+ 
 Job statuses:
-
+ 
 - `PENDING`
 - `QUEUED`
 - `RUNNING`
 - `COMPLETED`
 - `FAILED`
 - `CANCELED`
-
+ 
 Job triggers:
-
+ 
 - `AUTOMATIC`
 - `MANUAL`
-
+ 
 ### List Jobs
-
+ 
 `GET /workflows/{workflow_id}/jobs`
-
+ 
 Query parameters:
-
+ 
 - `cursor`: pagination cursor.
 - `status`: job status filter.
 - `trigger`: `AUTOMATIC` or `MANUAL`.
-
+ 
 Response includes `jobs` and `cursor`. Job entries include `attempts` in list
 responses.
-
+ 
 ### Manual Schedule
-
+ 
 `POST /workflows/{workflow_id}/jobs/schedule`
-
+ 
 Requires `Idempotency-Key`.
-
+ 
 Schedules an immediate manual job and returns `201 Created` with the job ID.
-
+ 
 ### Get Job
-
+ 
 `GET /workflows/{workflow_id}/jobs/{job_id}`
-
+ 
 Returns:
-
+ 
 - `id`
 - `workflow_id`
 - `status`
@@ -271,112 +271,115 @@ Returns:
 - `completed_at`
 - `created_at`
 - `updated_at`
-
+ 
 Lease metadata such as lease tokens is internal to worker gRPC APIs and is not
 returned by the public HTTP job detail route.
-
+ 
 ## Job Logs
-
+ 
 Log streams:
-
+ 
 - `stdout`
 - `stderr`
 - omit `stream` for all streams.
-
+ 
 Log APIs are available only when the workflow supports logs and log retention is
 enabled. `HEARTBEAT` workflows do not produce execution logs. If retention is
 disabled, retained log read/search routes return `412 Precondition Failed`; live
 SSE streams report the failure as an `event: error` frame.
-
+ 
 ### Get Logs
-
+ 
 `GET /workflows/{workflow_id}/jobs/{job_id}/logs`
-
+ 
 Query parameters:
-
+ 
 - `cursor`: pagination cursor.
-
-Returns retained logs from ClickHouse.
-
+ 
+Returns retained logs from ClickHouse in descending sequence order: latest logs
+first, older logs on later cursor pages.
+ 
 ### Search Logs
-
+ 
 `GET /workflows/{workflow_id}/jobs/{job_id}/logs/search`
-
+ 
 Query parameters:
-
+ 
 - `cursor`: pagination cursor.
 - `stream`: `stdout` or `stderr`.
 - `q`: message search text.
-
+ 
 If `q` is omitted, the route returns filtered retained logs by stream. If `q` is
-present, it searches retained logs through Meilisearch.
-
+present, it searches retained logs through Meilisearch. Results are returned in
+descending sequence order: latest logs first, older logs on later cursor pages.
+ 
 ### Download Raw Logs
-
+ 
 `GET /workflows/{workflow_id}/jobs/{job_id}/logs/raw`
-
+ 
 Streams retained logs as `text/plain` for terminal jobs. Non-terminal jobs return
-`400 Bad Request`.
-
+`400 Bad Request`. Raw downloads are streamed in ascending sequence order so the
+file reads oldest to newest.
+ 
 ### Stream Live Logs
-
+ 
 `GET /workflows/{workflow_id}/jobs/{job_id}/events`
-
+ 
 Streams Server-Sent Events for a running job. Production Nginx has a dedicated
 no-buffering proxy location for this route:
-
+ 
 `/api/workflows/{workflow_id}/jobs/{job_id}/events`
-
+ 
 After the SSE headers are sent, stream-open and stream-receive failures are sent
 as `event: error` frames on the `text/event-stream` response. For example, a
 non-running job or disabled log retention is reported as an SSE error event
 rather than an HTTP `412 Precondition Failed` response.
-
+ 
 ## Notifications
-
+ 
 ### List Notifications
-
+ 
 `GET /notifications`
-
+ 
 Query parameters:
-
+ 
 - `cursor`: pagination cursor.
-
+ 
 Returns notifications for the current user.
-
+ 
 ### Mark Notifications Read
-
+ 
 `PUT /notifications`
-
+ 
 Body:
-
+ 
 ```json
 {
   "ids": ["notification-id"]
 }
 ```
-
+ 
 Returns `204 No Content`.
-
+ 
 ## Analytics
-
+ 
 ### User Analytics
-
+ 
 `GET /analytics`
-
+ 
 Returns current-user aggregate totals:
-
+ 
 - `total_workflows`
 - `total_jobs`
 - `total_joblogs`
 - `total_job_execution_duration`
-
+ 
 ### Workflow Analytics
-
+ 
 `GET /analytics/{workflow_id}`
-
+ 
 Returns workflow aggregate totals:
-
+ 
 - `workflow_id`
 - `total_job_execution_duration`
 - `total_jobs`

--- a/internal/model/jobs/jobs.go
+++ b/internal/model/jobs/jobs.go
@@ -207,6 +207,7 @@ func (j *ExpiredJobLease) ToProto() *jobspb.ExpiredJobLease {
 
 // JobLog represents the log of the job.
 type JobLog struct {
+	EventID     string    `db:"event_id"`
 	Timestamp   time.Time `db:"timestamp"`
 	Message     string    `db:"message"`
 	SequenceNum uint32    `db:"sequence_num"`
@@ -220,8 +221,19 @@ func (l *JobLog) ToProto() *jobspb.Log {
 		Message:     l.Message,
 		SequenceNum: l.SequenceNum,
 		Stream:      l.Stream,
+		EventId:     l.EventID,
 	}
 }
+
+// JobLogsSortOrder represents retained job log ordering.
+type JobLogsSortOrder int
+
+// Job log sort orders.
+const (
+	JobLogsSortOrderUnspecified JobLogsSortOrder = 0
+	JobLogsSortOrderDesc        JobLogsSortOrder = 1
+	JobLogsSortOrderAsc         JobLogsSortOrder = 2
+)
 
 // GetJobLogsFilters represents the filters for filtering job logs.
 type GetJobLogsFilters struct {

--- a/internal/pkg/meilisearch/index.go
+++ b/internal/pkg/meilisearch/index.go
@@ -27,12 +27,13 @@ var Indexes map[string]*Index = map[string]*Index{
 		PrimaryKey: "id",
 		Searchable: []string{"message"},
 		Filterable: []any{
+			"id",
 			"job_id",
 			"workflow_id",
 			"user_id",
 			"sequence_num",
 			"stream",
 		},
-		Sortable: []string{"sequence_num"},
+		Sortable: []string{"sequence_num", "id"},
 	},
 }

--- a/internal/repository/joblogs/process_logs_batch.go
+++ b/internal/repository/joblogs/process_logs_batch.go
@@ -80,6 +80,7 @@ func (r *Repository) processLogsBatch(ctx context.Context, batch []*queueData) (
 	for _, log := range logs {
 		documents = append(documents, &map[string]any{
 			"id":           meiliLogDocumentID(log.EventKey),
+			"event_id":     log.EventKey,
 			"job_id":       log.JobID,
 			"workflow_id":  log.WorkflowID,
 			"user_id":      log.UserID,

--- a/internal/repository/jobs/jobs.go
+++ b/internal/repository/jobs/jobs.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -40,6 +39,12 @@ const (
 	delimiter             = '$'
 	jobStatusUpdateBuffer = time.Minute // 1 minute
 )
+
+type jobLogsCursor struct {
+	SequenceNum uint32 `json:"sequence_num"`
+	Stream      string `json:"stream,omitempty"`
+	EventID     string `json:"event_id,omitempty"`
+}
 
 // Services represents the services used by the executor.
 type Services struct {
@@ -402,6 +407,7 @@ func (r *Repository) GetJobLogs(
 	workflowID,
 	userID,
 	cursor string,
+	sortOrder jobsmodel.JobLogsSortOrder,
 	getJobLogsFilters *jobsmodel.GetJobLogsFilters,
 ) (res *jobsmodel.GetJobLogsResponse, jobStatus string, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.GetJobLogs")
@@ -434,17 +440,12 @@ func (r *Repository) GetJobLogs(
 		return nil, "", err
 	}
 
+	ascending := sortOrder == jobsmodel.JobLogsSortOrderAsc
 	logQueryArgs := []any{jobID, workflowID, userID}
 	logsQuery := fmt.Sprintf(`
-    SELECT latest_timestamp AS timestamp, message, sequence_num, stream
-    FROM (
-        SELECT
-            max(timestamp) AS latest_timestamp,
-            argMax(message, timestamp) AS message,
-            sequence_num,
-            stream
-        FROM %s
-        WHERE job_id = $1 AND workflow_id = $2 AND user_id = $3
+    SELECT timestamp, message, sequence_num, stream, event_id
+    FROM %s
+    WHERE job_id = $1 AND workflow_id = $2 AND user_id = $3
     `, clickhouse.TableJobLogs)
 
 	switch getJobLogsFilters.Stream {
@@ -455,22 +456,34 @@ func (r *Repository) GetJobLogs(
 	}
 
 	if cursor != "" {
-		sequenceNum, _err := extractDataFromGetJobLogsCursor(cursor)
+		logsCursor, _err := extractDataFromGetJobLogsCursor(cursor)
 		if _err != nil {
 			err = _err
 			return nil, "", err
 		}
 
-		logsQuery += ` AND sequence_num >= $4`
-		logQueryArgs = append(logQueryArgs, sequenceNum)
+		sequenceOperator := "<"
+		if ascending {
+			sequenceOperator = ">"
+		}
+		logsQuery += ` AND (
+                sequence_num ` + sequenceOperator + ` $4
+                OR (sequence_num = $4 AND stream > $5)
+                OR (sequence_num = $4 AND stream = $5 AND event_id >= $6)
+            )`
+		logQueryArgs = append(logQueryArgs, logsCursor.SequenceNum, logsCursor.Stream, logsCursor.EventID)
 	}
 
+	sequenceDirection := "DESC"
+	if ascending {
+		sequenceDirection = "ASC"
+	}
+	// Keep the newest unmerged ReplacingMergeTree duplicate before LIMIT BY collapses event IDs.
 	logsQuery += fmt.Sprintf(`
-        GROUP BY event_id, sequence_num, stream
-    )
-    ORDER BY sequence_num ASC, stream ASC
+    ORDER BY sequence_num %s, stream ASC, event_id ASC, timestamp DESC
+    LIMIT 1 BY event_id
     LIMIT %d;
-    `, r.cfg.LogsFetchLimit+1)
+    `, sequenceDirection, r.cfg.LogsFetchLimit+1)
 
 	statusQueryArgs := []any{jobID, workflowID, userID}
 	statusQuery := fmt.Sprintf(`
@@ -482,7 +495,7 @@ func (r *Repository) GetJobLogs(
 	eg, egCtx := errgroup.WithContext(ctx)
 	var (
 		logs          []*jobsmodel.JobLog
-		nextCursorSeq uint32
+		nextCursor    jobLogsCursor
 		fetchedStatus string
 		completedAt   sql.NullTime
 	)
@@ -500,21 +513,29 @@ func (r *Repository) GetJobLogs(
 		defer rows.Close()
 
 		tmp := make([]*jobsmodel.JobLog, 0, r.cfg.LogsFetchLimit+1)
+		tmpCursors := make([]jobLogsCursor, 0, r.cfg.LogsFetchLimit+1)
 		for rows.Next() {
 			var (
-				ts   time.Time
-				msg  string
-				seq  uint32
-				strm string
+				ts      time.Time
+				msg     string
+				seq     uint32
+				strm    string
+				eventID string
 			)
-			if scanErr := rows.Scan(&ts, &msg, &seq, &strm); scanErr != nil {
+			if scanErr := rows.Scan(&ts, &msg, &seq, &strm, &eventID); scanErr != nil {
 				return status.Errorf(codes.Internal, "failed to scan logs: %v", scanErr)
 			}
 			tmp = append(tmp, &jobsmodel.JobLog{
+				EventID:     eventID,
 				Timestamp:   ts,
 				Message:     msg,
 				SequenceNum: seq,
 				Stream:      strm,
+			})
+			tmpCursors = append(tmpCursors, jobLogsCursor{
+				SequenceNum: seq,
+				Stream:      strm,
+				EventID:     eventID,
 			})
 		}
 		if rowsErr := rows.Err(); rowsErr != nil {
@@ -523,7 +544,7 @@ func (r *Repository) GetJobLogs(
 
 		// Check if there are more logs
 		if len(tmp) > r.cfg.LogsFetchLimit {
-			nextCursorSeq = tmp[r.cfg.LogsFetchLimit].SequenceNum
+			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
 			tmp = tmp[:r.cfg.LogsFetchLimit]
 		}
 		logs = tmp
@@ -567,7 +588,7 @@ func (r *Repository) GetJobLogs(
 		ID:         jobID,
 		WorkflowID: workflowID,
 		JobLogs:    logs,
-		Cursor:     encodeJobLogsCursor(nextCursorSeq),
+		Cursor:     encodeJobLogsCursor(nextCursor),
 	}, fetchedStatus, nil
 }
 
@@ -698,13 +719,18 @@ func (r *Repository) SearchJobLogs(
 	}
 
 	if cursor != "" {
-		sequenceNum, _err := extractDataFromGetJobLogsCursor(cursor)
+		logsCursor, _err := extractDataFromGetJobLogsCursor(cursor)
 		if _err != nil {
 			err = _err
 			return nil, "", err
 		}
 
-		filter += fmt.Sprintf(` AND sequence_num >= %d`, sequenceNum)
+		filter += fmt.Sprintf(
+			` AND (sequence_num < %d OR (sequence_num = %d AND id >= %q))`,
+			logsCursor.SequenceNum,
+			logsCursor.SequenceNum,
+			logsCursor.EventID,
+		)
 	}
 
 	statusQueryArgs := []any{jobID, workflowID, userID}
@@ -717,7 +743,7 @@ func (r *Repository) SearchJobLogs(
 	eg, egCtx := errgroup.WithContext(ctx)
 	var (
 		logs          []*jobsmodel.JobLog
-		nextCursorSeq uint32
+		nextCursor    jobLogsCursor
 		fetchedStatus string
 		completedAt   sql.NullTime
 	)
@@ -728,10 +754,10 @@ func (r *Repository) SearchJobLogs(
 			searchJobLogsFilters.Message,
 			&meilisearch.SearchRequest{
 				Filter:                filter,
-				AttributesToRetrieve:  []string{"message", "sequence_num", "stream", "timestamp"},
+				AttributesToRetrieve:  []string{"id", "event_id", "message", "sequence_num", "stream", "timestamp"},
 				AttributesToHighlight: []string{"message"},
 				AttributesToSearchOn:  []string{"message"},
-				Sort:                  []string{"sequence_num:asc"},
+				Sort:                  []string{"sequence_num:desc", "id:asc"},
 				Limit:                 int64(r.cfg.LogsFetchLimit + 1),
 			},
 		)
@@ -740,23 +766,11 @@ func (r *Repository) SearchJobLogs(
 		}
 
 		tmp := make([]*jobsmodel.JobLog, 0, len(searchRes.Hits))
+		tmpCursors := make([]jobLogsCursor, 0, len(searchRes.Hits))
 		for _, hit := range searchRes.Hits {
-			var source map[string]any
-
-			// Prefer _formatted if present
-			if formattedRaw, ok := hit["_formatted"]; ok {
-				if scanErr := json.Unmarshal(formattedRaw, &source); scanErr != nil {
-					return status.Errorf(codes.Internal, "failed to unmarshal data: %v", scanErr)
-				}
-			} else {
-				source = make(map[string]any)
-				for k, v := range hit {
-					var val any
-					if scanErr := json.Unmarshal(v, &val); scanErr != nil {
-						return status.Errorf(codes.Internal, "failed to unmarshal data: %v", scanErr)
-					}
-					source[k] = val
-				}
+			source, scanErr := searchHitSource(hit)
+			if scanErr != nil {
+				return scanErr
 			}
 
 			log := &jobsmodel.JobLog{}
@@ -766,6 +780,11 @@ func (r *Repository) SearchJobLogs(
 					return status.Errorf(codes.Internal, "invalid timestamp format: %v", scanErr)
 				}
 				log.Timestamp = parsed
+			}
+
+			log.EventID = searchHitString(source, "event_id")
+			if log.EventID == "" {
+				log.EventID = searchHitString(source, "id")
 			}
 
 			if msg, ok := source["message"].(string); ok {
@@ -788,11 +807,16 @@ func (r *Repository) SearchJobLogs(
 			}
 
 			tmp = append(tmp, log)
+			tmpCursors = append(tmpCursors, jobLogsCursor{
+				SequenceNum: log.SequenceNum,
+				Stream:      log.Stream,
+				EventID:     searchHitString(source, "id"),
+			})
 		}
 
 		// Check if there are more logs
 		if len(tmp) > r.cfg.LogsFetchLimit {
-			nextCursorSeq = tmp[r.cfg.LogsFetchLimit].SequenceNum
+			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
 			tmp = tmp[:r.cfg.LogsFetchLimit]
 		}
 		logs = tmp
@@ -836,7 +860,7 @@ func (r *Repository) SearchJobLogs(
 		ID:         jobID,
 		WorkflowID: workflowID,
 		JobLogs:    logs,
-		Cursor:     encodeJobLogsCursor(nextCursorSeq),
+		Cursor:     encodeJobLogsCursor(nextCursor),
 	}, fetchedStatus, nil
 }
 
@@ -937,15 +961,18 @@ func parseTime(t string) (time.Time, error) {
 	return time.Parse(time.RFC3339Nano, t)
 }
 
-// encodeJobLogsCursor encodes the cursor.
-func encodeJobLogsCursor(sequenceNum uint32) string {
-	if sequenceNum == 0 {
+// encodeJobLogsCursor encodes the cursor for descending log pagination.
+func encodeJobLogsCursor(cursor jobLogsCursor) string {
+	if cursor.SequenceNum == 0 && cursor.Stream == "" && cursor.EventID == "" {
 		return ""
 	}
 
-	buf := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf, sequenceNum)
-	return base64.StdEncoding.EncodeToString(buf)
+	payload, err := json.Marshal(cursor)
+	if err != nil {
+		return ""
+	}
+
+	return base64.StdEncoding.EncodeToString(payload)
 }
 
 // encodeListJobsCursor encodes the cursor.
@@ -958,18 +985,64 @@ func encodeListJobsCursor(cursor string) string {
 }
 
 // extractDataFromGetJobLogsCursor extracts the data from the cursor.
-func extractDataFromGetJobLogsCursor(cursor string) (uint32, error) {
+func extractDataFromGetJobLogsCursor(cursor string) (jobLogsCursor, error) {
 	decodedBytes, err := base64.StdEncoding.DecodeString(cursor)
 	if err != nil {
-		return 0, status.Errorf(codes.InvalidArgument, "invalid cursor: %v", err)
+		return jobLogsCursor{}, status.Errorf(codes.InvalidArgument, "invalid cursor: %v", err)
 	}
 
-	// Must be exactly 4 bytes for a uint32
-	if len(decodedBytes) != 4 {
-		return 0, status.Errorf(codes.InvalidArgument, "invalid cursor format")
+	var logsCursor jobLogsCursor
+	if err = json.Unmarshal(decodedBytes, &logsCursor); err != nil {
+		return jobLogsCursor{}, status.Errorf(codes.InvalidArgument, "invalid cursor format: %v", err)
 	}
 
-	return binary.BigEndian.Uint32(decodedBytes), nil
+	if logsCursor.Stream == "" || logsCursor.EventID == "" {
+		return jobLogsCursor{}, status.Errorf(codes.InvalidArgument, "invalid cursor format")
+	}
+
+	return logsCursor, nil
+}
+
+func searchHitString(source map[string]any, field string) string {
+	if source == nil {
+		return ""
+	}
+	value, ok := source[field].(string)
+	if !ok {
+		return ""
+	}
+
+	return value
+}
+
+func searchHitSource(hit map[string]json.RawMessage) (map[string]any, error) {
+	source := make(map[string]any)
+	for k, v := range hit {
+		if k == "_formatted" {
+			continue
+		}
+
+		var val any
+		if err := json.Unmarshal(v, &val); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to unmarshal data: %v", err)
+		}
+		source[k] = val
+	}
+
+	formattedRaw, ok := hit["_formatted"]
+	if !ok {
+		return source, nil
+	}
+
+	var formatted map[string]any
+	if err := json.Unmarshal(formattedRaw, &formatted); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to unmarshal data: %v", err)
+	}
+	if msg, ok := formatted["message"].(string); ok {
+		source["message"] = msg
+	}
+
+	return source, nil
 }
 
 // extractDataFromListJobsCursor extracts the data from the cursor.

--- a/internal/repository/jobs/jobs_test.go
+++ b/internal/repository/jobs/jobs_test.go
@@ -1,0 +1,33 @@
+//nolint:testpackage // Tests unexported cursor helpers directly.
+package jobs
+
+import (
+	"testing"
+)
+
+func TestJobLogsCursorRoundTrip(t *testing.T) {
+	want := jobLogsCursor{
+		SequenceNum: 42,
+		Stream:      "stdout",
+		EventID:     "log:job:stdout:42",
+	}
+
+	encoded := encodeJobLogsCursor(want)
+	if encoded == "" {
+		t.Fatal("expected encoded cursor")
+	}
+
+	got, err := extractDataFromGetJobLogsCursor(encoded)
+	if err != nil {
+		t.Fatalf("expected cursor to decode: %v", err)
+	}
+	if got != want {
+		t.Fatalf("unexpected cursor: got %+v want %+v", got, want)
+	}
+}
+
+func TestEncodeJobLogsCursorEmpty(t *testing.T) {
+	if got := encodeJobLogsCursor(jobLogsCursor{}); got != "" {
+		t.Fatalf("expected empty cursor, got %q", got)
+	}
+}

--- a/internal/server/jobs_handlers.go
+++ b/internal/server/jobs_handlers.go
@@ -228,9 +228,7 @@ func (s *Server) handleGetJobLogs(w http.ResponseWriter, r *http.Request) {
 
 	// Write the response
 	w.Header().Set("Content-Type", "application/json")
-	if res.GetCursor() != "" {
-		w.Header().Set("Cache-Control", "public, max-age=7200") // Cache for 2 hrs
-	}
+	setJobLogsCacheControl(w, cursor, res.GetCursor())
 
 	w.WriteHeader(http.StatusOK)
 	//nolint:errcheck // The error is always nil
@@ -313,13 +311,20 @@ func (s *Server) handleSearchJobLogs(w http.ResponseWriter, r *http.Request) {
 
 	// Write the response
 	w.Header().Set("Content-Type", "application/json")
-	if res.GetCursor() != "" {
-		w.Header().Set("Cache-Control", "public, max-age=7200") // Cache for 2 hrs
-	}
+	setJobLogsCacheControl(w, cursor, res.GetCursor())
 
 	w.WriteHeader(http.StatusOK)
 	//nolint:errcheck // The error is always nil
 	json.NewEncoder(w).Encode(res)
+}
+
+func setJobLogsCacheControl(w http.ResponseWriter, requestCursor, responseCursor string) {
+	if requestCursor != "" && responseCursor != "" {
+		w.Header().Set("Cache-Control", "public, max-age=7200") // Cache for 2 hrs
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
 }
 
 // handleDownloadJobLogs streams job logs to the client for download.
@@ -379,6 +384,10 @@ func (s *Server) handleDownloadJobLogs(w http.ResponseWriter, r *http.Request) {
 			WorkflowId: workflowID,
 			UserId:     userID,
 			Cursor:     cursor,
+			SortOrder:  jobspb.LogSortOrder_LOG_SORT_ORDER_ASC,
+			Filters: &jobspb.GetJobLogsFilters{
+				Stream: jobspb.LogStream_LOG_STREAM_ALL,
+			},
 		})
 		if err != nil {
 			// Handle fetch error

--- a/internal/server/jobs_handlers_test.go
+++ b/internal/server/jobs_handlers_test.go
@@ -1,0 +1,151 @@
+//nolint:testpackage // Tests unexported handlers directly.
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	jobspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
+)
+
+type fakeJobsServiceClient struct {
+	jobspb.JobsServiceClient
+
+	getJobLogsResponse    *jobspb.GetJobLogsResponse
+	getJobLogsRequest     *jobspb.GetJobLogsRequest
+	searchJobLogsResponse *jobspb.GetJobLogsResponse
+	searchJobLogsRequest  *jobspb.SearchJobLogsRequest
+}
+
+func (f *fakeJobsServiceClient) GetJobLogs(_ context.Context, req *jobspb.GetJobLogsRequest, _ ...grpc.CallOption) (*jobspb.GetJobLogsResponse, error) {
+	f.getJobLogsRequest = req
+	if f.getJobLogsResponse != nil {
+		return f.getJobLogsResponse, nil
+	}
+
+	return &jobspb.GetJobLogsResponse{}, nil
+}
+
+func (f *fakeJobsServiceClient) SearchJobLogs(_ context.Context, req *jobspb.SearchJobLogsRequest, _ ...grpc.CallOption) (*jobspb.GetJobLogsResponse, error) {
+	f.searchJobLogsRequest = req
+	if f.searchJobLogsResponse != nil {
+		return f.searchJobLogsResponse, nil
+	}
+
+	return &jobspb.GetJobLogsResponse{}, nil
+}
+
+func TestHandleGetJobLogsCacheControl(t *testing.T) {
+	tests := []struct {
+		name           string
+		target         string
+		responseCursor string
+		want           string
+	}{
+		{
+			name:           "first page is not cached",
+			target:         "/workflows/workflow_id/jobs/job_id/logs",
+			responseCursor: "next-cursor",
+			want:           "no-store",
+		},
+		{
+			name:           "cursor page with another page is cached",
+			target:         "/workflows/workflow_id/jobs/job_id/logs?cursor=current-cursor",
+			responseCursor: "next-cursor",
+			want:           "public, max-age=7200",
+		},
+		{
+			name:           "cursor tail page is not cached",
+			target:         "/workflows/workflow_id/jobs/job_id/logs?cursor=tail-cursor",
+			responseCursor: "",
+			want:           "no-store",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeJobsServiceClient{
+				getJobLogsResponse: &jobspb.GetJobLogsResponse{
+					Cursor: tt.responseCursor,
+				},
+			}
+			s := &Server{jobsClient: client}
+
+			req := newJobLogsHandlerRequest(tt.target)
+			res := httptest.NewRecorder()
+			s.handleGetJobLogs(res, req)
+
+			if res.Code != http.StatusOK {
+				t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
+			}
+			if got := res.Header().Get("Cache-Control"); got != tt.want {
+				t.Fatalf("expected Cache-Control %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestHandleSearchJobLogsCacheControl(t *testing.T) {
+	tests := []struct {
+		name           string
+		target         string
+		responseCursor string
+		want           string
+	}{
+		{
+			name:           "first search page is not cached",
+			target:         "/workflows/workflow_id/jobs/job_id/logs/search?q=message",
+			responseCursor: "next-cursor",
+			want:           "no-store",
+		},
+		{
+			name:           "search cursor page with another page is cached",
+			target:         "/workflows/workflow_id/jobs/job_id/logs/search?q=message&cursor=current-cursor",
+			responseCursor: "next-cursor",
+			want:           "public, max-age=7200",
+		},
+		{
+			name:           "search cursor tail page is not cached",
+			target:         "/workflows/workflow_id/jobs/job_id/logs/search?q=message&cursor=tail-cursor",
+			responseCursor: "",
+			want:           "no-store",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeJobsServiceClient{
+				searchJobLogsResponse: &jobspb.GetJobLogsResponse{
+					Cursor: tt.responseCursor,
+				},
+			}
+			s := &Server{jobsClient: client}
+
+			req := newJobLogsHandlerRequest(tt.target)
+			res := httptest.NewRecorder()
+			s.handleSearchJobLogs(res, req)
+
+			if res.Code != http.StatusOK {
+				t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
+			}
+			if got := res.Header().Get("Cache-Control"); got != tt.want {
+				t.Fatalf("expected Cache-Control %q, got %q", tt.want, got)
+			}
+			if client.searchJobLogsRequest == nil {
+				t.Fatal("expected SearchJobLogs to be called")
+			}
+		})
+	}
+}
+
+func newJobLogsHandlerRequest(target string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	req.SetPathValue("workflow_id", "workflow_id")
+	req.SetPathValue("job_id", "job_id")
+
+	return req.WithContext(context.WithValue(req.Context(), userIDKey{}, "user_id"))
+}

--- a/internal/service/jobs/jobs.go
+++ b/internal/service/jobs/jobs.go
@@ -48,7 +48,7 @@ type Repository interface {
 	RecoverExpiredJobLeases(ctx context.Context, batchSize int32, workerID string, leaseDuration time.Duration) ([]*jobsmodel.ExpiredJobLease, error)
 	GetJob(ctx context.Context, jobID, workflowID, userID string) (*jobsmodel.GetJobResponse, error)
 	GetJobByID(ctx context.Context, jobID string) (*jobsmodel.GetJobByIDResponse, error)
-	GetJobLogs(ctx context.Context, jobID, workflowID, userID, cursor string, filters *jobsmodel.GetJobLogsFilters) (*jobsmodel.GetJobLogsResponse, string, error)
+	GetJobLogs(ctx context.Context, jobID, workflowID, userID, cursor string, sortOrder jobsmodel.JobLogsSortOrder, filters *jobsmodel.GetJobLogsFilters) (*jobsmodel.GetJobLogsResponse, string, error)
 	StreamJobLogs(ctx context.Context, jobID, workflowID, userID string) (*goredis.PubSub, error)
 	SearchJobLogs(ctx context.Context, jobID, workflowID, userID, cursor string, filters *jobsmodel.SearchJobLogsFilters) (*jobsmodel.GetJobLogsResponse, string, error)
 	ListJobs(ctx context.Context, workflowID, userID, cursor string, filters *jobsmodel.ListJobsFilters) (*jobsmodel.ListJobsResponse, error)
@@ -537,6 +537,7 @@ type GetJobLogsRequest struct {
 	WorkflowID string                       `validate:"required"`
 	UserID     string                       `validate:"required"`
 	Cursor     string                       `validate:"omitempty"`
+	SortOrder  int                          `validate:"omitempty,min=0,max=2"`
 	Filters    *jobsmodel.GetJobLogsFilters `validate:"required"`
 }
 
@@ -569,6 +570,7 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		WorkflowID: req.GetWorkflowId(),
 		UserID:     req.GetUserId(),
 		Cursor:     req.GetCursor(),
+		SortOrder:  int(req.GetSortOrder()),
 		Filters:    filters,
 	})
 	if err != nil {
@@ -576,27 +578,32 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	sortOrder := normalizeJobLogsSortOrder(jobsmodel.JobLogsSortOrder(req.GetSortOrder()))
+
 	// Check if the job logs are cached
 	cacheKey := fmt.Sprintf(
-		"job_logs:%s:%s:%s:%s",
+		"job_logs:%s:%s:%s:%s:%d",
 		req.GetUserId(),
 		req.GetId(),
 		req.GetCursor(),
 		req.GetFilters().GetStream(),
+		sortOrder,
 	)
-	cacheRes, cacheErr := s.cache.Get(ctx, cacheKey, &jobsmodel.GetJobLogsResponse{})
-	if cacheErr != nil {
-		if errors.Is(cacheErr, context.DeadlineExceeded) || errors.Is(cacheErr, context.Canceled) {
-			err = status.Error(codes.DeadlineExceeded, cacheErr.Error())
-			return nil, err
+	isCursorPage := req.GetCursor() != ""
+	if isCursorPage {
+		cacheRes, cacheErr := s.cache.Get(ctx, cacheKey, &jobsmodel.GetJobLogsResponse{})
+		if cacheErr != nil {
+			if errors.Is(cacheErr, context.DeadlineExceeded) || errors.Is(cacheErr, context.Canceled) {
+				err = status.Error(codes.DeadlineExceeded, cacheErr.Error())
+				return nil, err
+			}
+		} else {
+			// Cache hit, return cached response
+			//nolint:errcheck,forcetypeassert // Ignore error as we are just reading from cache
+			return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 		}
-	} else {
-		// Cache hit, return cached response
-		//nolint:errcheck,forcetypeassert // Ignore error as we are just reading from cache
-		return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 	}
 
-	//nolint:dupl // The logic for fetching job logs and searching job logs is similar, we can ignore the duplication here
 	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
 		_res, jobStatus, _err := s.repo.GetJobLogs(
 			ctx,
@@ -604,14 +611,16 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 			req.GetWorkflowId(),
 			req.GetUserId(),
 			req.GetCursor(),
+			sortOrder,
 			filters,
 		)
 		if _err != nil {
 			return nil, _err
 		}
 
-		// Cache stable pages once for the shared result.
-		if isTerminalJobStatus(jobStatus) || _res.Cursor != "" {
+		// Cache only stable cursor pages. A cursor page with no response cursor is the current tail,
+		// which can still receive late retained logs while the repo reports the job as running.
+		if isCursorPage && (_res.Cursor != "" || isTerminalJobStatus(jobStatus)) {
 			go func() {
 				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 				defer cancel()
@@ -709,6 +718,7 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 
 				select {
 				case ch <- &jobsmodel.JobLog{
+					EventID:     log.EventKey,
 					Timestamp:   log.TimeStamp,
 					Message:     log.Message,
 					SequenceNum: log.SequenceNum,
@@ -779,19 +789,21 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 		req.GetFilters().GetMessage(),
 		req.GetFilters().GetStream(),
 	)
-	cacheRes, cacheErr := s.cache.Get(ctx, cacheKey, &jobsmodel.GetJobLogsResponse{})
-	if cacheErr != nil {
-		if errors.Is(cacheErr, context.DeadlineExceeded) || errors.Is(cacheErr, context.Canceled) {
-			err = status.Error(codes.DeadlineExceeded, cacheErr.Error())
-			return nil, err
+	isCursorPage := req.GetCursor() != ""
+	if isCursorPage {
+		cacheRes, cacheErr := s.cache.Get(ctx, cacheKey, &jobsmodel.GetJobLogsResponse{})
+		if cacheErr != nil {
+			if errors.Is(cacheErr, context.DeadlineExceeded) || errors.Is(cacheErr, context.Canceled) {
+				err = status.Error(codes.DeadlineExceeded, cacheErr.Error())
+				return nil, err
+			}
+		} else {
+			// Cache hit, return cached response
+			//nolint:errcheck,forcetypeassert // Ignore error as we are just reading from cache
+			return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 		}
-	} else {
-		// Cache hit, return cached response
-		//nolint:errcheck,forcetypeassert // Ignore error as we are just reading from cache
-		return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 	}
 
-	//nolint:dupl // The logic for fetching job logs and searching job logs is similar, we can ignore the duplication here
 	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
 		_res, jobStatus, _err := s.repo.SearchJobLogs(
 			ctx,
@@ -805,7 +817,7 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 			return nil, _err
 		}
 
-		if isTerminalJobStatus(jobStatus) || _res.Cursor != "" {
+		if isCursorPage && (_res.Cursor != "" || isTerminalJobStatus(jobStatus)) {
 			go func() {
 				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 				defer cancel()
@@ -956,6 +968,14 @@ func validateFailureKind(kind string) error {
 	default:
 		return status.Errorf(codes.InvalidArgument, "invalid failure kind: %s", kind)
 	}
+}
+
+func normalizeJobLogsSortOrder(sortOrder jobsmodel.JobLogsSortOrder) jobsmodel.JobLogsSortOrder {
+	if sortOrder == jobsmodel.JobLogsSortOrderAsc {
+		return jobsmodel.JobLogsSortOrderAsc
+	}
+
+	return jobsmodel.JobLogsSortOrderDesc
 }
 
 func isTerminalJobStatus(jobStatus string) bool {

--- a/internal/service/jobs/jobs_test.go
+++ b/internal/service/jobs/jobs_test.go
@@ -706,11 +706,12 @@ func TestGetJobLogs(t *testing.T) {
 					},
 				}
 				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s",
+					"job_logs:%s:%s:%s:%s:%d",
 					req.GetUserId(),
 					req.GetId(),
 					req.GetCursor(),
 					req.GetFilters().GetStream(),
+					jobsmodel.JobLogsSortOrderDesc,
 				)
 				var filters *jobsmodel.GetJobLogsFilters
 				if req.GetFilters() != nil {
@@ -724,13 +725,14 @@ func TestGetJobLogs(t *testing.T) {
 					gomock.Any(),
 					cacheKey,
 					gomock.Any(),
-				).Return(nil, status.Error(codes.NotFound, "cache miss"))
+				).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
 				repo.EXPECT().GetJobLogs(
 					gomock.Any(),
 					req.GetId(),
 					req.GetWorkflowId(),
 					req.GetUserId(),
 					req.GetCursor(),
+					jobsmodel.JobLogsSortOrderDesc,
 					filters,
 				).Return(data, "COMPLETED", nil)
 				cache.EXPECT().Set(
@@ -768,7 +770,7 @@ func TestGetJobLogs(t *testing.T) {
 				Id:         "job_id",
 				WorkflowId: "workflow_id",
 				UserId:     "user_id",
-				Cursor:     "",
+				Cursor:     "cursor",
 				Filters: &jobspb.GetJobLogsFilters{
 					Stream: jobspb.LogStream_LOG_STREAM_ALL,
 				},
@@ -777,11 +779,12 @@ func TestGetJobLogs(t *testing.T) {
 				cache.EXPECT().Get(
 					gomock.Any(),
 					fmt.Sprintf(
-						"job_logs:%s:%s:%s:%s",
+						"job_logs:%s:%s:%s:%s:%d",
 						req.GetUserId(),
 						req.GetId(),
 						req.GetCursor(),
 						req.GetFilters().GetStream(),
+						jobsmodel.JobLogsSortOrderDesc,
 					),
 					gomock.Any(),
 				).Return(&jobsmodel.GetJobLogsResponse{
@@ -833,7 +836,7 @@ func TestGetJobLogs(t *testing.T) {
 				Id:         "job_id",
 				WorkflowId: "workflow_id",
 				UserId:     "user_id",
-				Cursor:     "",
+				Cursor:     "cursor",
 				Filters: &jobspb.GetJobLogsFilters{
 					Stream: jobspb.LogStream_LOG_STREAM_ALL,
 				},
@@ -859,11 +862,12 @@ func TestGetJobLogs(t *testing.T) {
 					Cursor: "cursor",
 				}
 				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s",
+					"job_logs:%s:%s:%s:%s:%d",
 					req.GetUserId(),
 					req.GetId(),
 					req.GetCursor(),
 					req.GetFilters().GetStream(),
+					jobsmodel.JobLogsSortOrderDesc,
 				)
 				var filters *jobsmodel.GetJobLogsFilters
 				if req.GetFilters() != nil {
@@ -877,13 +881,14 @@ func TestGetJobLogs(t *testing.T) {
 					gomock.Any(),
 					cacheKey,
 					gomock.Any(),
-				).Return(nil, status.Error(codes.NotFound, "cache miss"))
+				).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
 				repo.EXPECT().GetJobLogs(
 					gomock.Any(),
 					req.GetId(),
 					req.GetWorkflowId(),
 					req.GetUserId(),
 					req.GetCursor(),
+					jobsmodel.JobLogsSortOrderDesc,
 					filters,
 				).Return(data, "COMPLETED", nil)
 				cache.EXPECT().Set(
@@ -917,6 +922,68 @@ func TestGetJobLogs(t *testing.T) {
 			isErr: false,
 		},
 		{
+			name: "success: running cursor tail skips cache write",
+			req: &jobspb.GetJobLogsRequest{
+				Id:         "job_id_tail",
+				WorkflowId: "workflow_id",
+				UserId:     "user_id_tail",
+				Cursor:     "tail-cursor",
+				Filters: &jobspb.GetJobLogsFilters{
+					Stream: jobspb.LogStream_LOG_STREAM_ALL,
+				},
+			},
+			mock: func(req *jobspb.GetJobLogsRequest) {
+				data := &jobsmodel.GetJobLogsResponse{
+					ID:         req.GetId(),
+					WorkflowID: req.GetWorkflowId(),
+					JobLogs: []*jobsmodel.JobLog{
+						{
+							Timestamp:   timestamp,
+							Message:     "log tail",
+							SequenceNum: 1,
+							Stream:      "stdout",
+						},
+					},
+				}
+				cacheKey := fmt.Sprintf(
+					"job_logs:%s:%s:%s:%s:%d",
+					req.GetUserId(),
+					req.GetId(),
+					req.GetCursor(),
+					req.GetFilters().GetStream(),
+					jobsmodel.JobLogsSortOrderDesc,
+				)
+				filters := &jobsmodel.GetJobLogsFilters{Stream: int(req.GetFilters().GetStream())}
+				cache.EXPECT().
+					Get(gomock.Any(), cacheKey, gomock.Any()).
+					Return(nil, status.Error(codes.NotFound, "cache miss"))
+				repo.EXPECT().GetJobLogs(
+					gomock.Any(),
+					req.GetId(),
+					req.GetWorkflowId(),
+					req.GetUserId(),
+					req.GetCursor(),
+					jobsmodel.JobLogsSortOrderDesc,
+					filters,
+				).Return(data, jobsmodel.JobStatusRunning.ToString(), nil)
+			},
+			want: want{
+				&jobsmodel.GetJobLogsResponse{
+					ID:         "job_id_tail",
+					WorkflowID: "workflow_id",
+					JobLogs: []*jobsmodel.JobLog{
+						{
+							Timestamp:   timestamp,
+							Message:     "log tail",
+							SequenceNum: 1,
+							Stream:      "stdout",
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		{
 			name: "success: singleflight deduplicates cache miss",
 			req: &jobspb.GetJobLogsRequest{
 				Id:         "job_id",
@@ -928,18 +995,19 @@ func TestGetJobLogs(t *testing.T) {
 			},
 			mock: func(req *jobspb.GetJobLogsRequest) {
 				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s",
+					"job_logs:%s:%s:%s:%s:%d",
 					req.GetUserId(),
 					req.GetId(),
 					req.GetCursor(),
 					req.GetFilters().GetStream(),
+					jobsmodel.JobLogsSortOrderDesc,
 				)
 				filters := &jobsmodel.GetJobLogsFilters{Stream: int(req.GetFilters().GetStream())}
 
 				cache.EXPECT().
 					Get(gomock.Any(), cacheKey, gomock.Any()).
 					Return(nil, status.Error(codes.NotFound, "cache miss")).
-					Times(2)
+					AnyTimes()
 				cache.EXPECT().
 					Set(gomock.Any(), cacheKey, gomock.Any(), gomock.Any()).
 					Return(nil).
@@ -948,8 +1016,8 @@ func TestGetJobLogs(t *testing.T) {
 				singleflightRepoCalls = 0
 				singleflightReleaseChan = make(chan struct{})
 				repo.EXPECT().
-					GetJobLogs(gomock.Any(), req.GetId(), req.GetWorkflowId(), req.GetUserId(), req.GetCursor(), filters).
-					DoAndReturn(func(_ any, _, _, _, _ string, _ *jobsmodel.GetJobLogsFilters) (*jobsmodel.GetJobLogsResponse, string, error) {
+					GetJobLogs(gomock.Any(), req.GetId(), req.GetWorkflowId(), req.GetUserId(), req.GetCursor(), jobsmodel.JobLogsSortOrderDesc, filters).
+					DoAndReturn(func(_ any, _, _, _, _ string, _ jobsmodel.JobLogsSortOrder, _ *jobsmodel.GetJobLogsFilters) (*jobsmodel.GetJobLogsResponse, string, error) {
 						atomic.AddInt32(&singleflightRepoCalls, 1)
 						<-singleflightReleaseChan
 						return &jobsmodel.GetJobLogsResponse{
@@ -1036,11 +1104,12 @@ func TestGetJobLogs(t *testing.T) {
 			},
 			mock: func(req *jobspb.GetJobLogsRequest) {
 				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s",
+					"job_logs:%s:%s:%s:%s:%d",
 					req.GetUserId(),
 					req.GetId(),
 					req.GetCursor(),
 					req.GetFilters().GetStream(),
+					jobsmodel.JobLogsSortOrderDesc,
 				)
 				var filters *jobsmodel.GetJobLogsFilters
 				if req.GetFilters() != nil {
@@ -1054,13 +1123,14 @@ func TestGetJobLogs(t *testing.T) {
 					gomock.Any(),
 					cacheKey,
 					gomock.Any(),
-				).Return(nil, status.Error(codes.NotFound, "cache miss"))
+				).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
 				repo.EXPECT().GetJobLogs(
 					gomock.Any(),
 					req.GetId(),
 					req.GetWorkflowId(),
 					req.GetUserId(),
 					req.GetCursor(),
+					jobsmodel.JobLogsSortOrderDesc,
 					filters,
 				).Return(nil, "", status.Error(codes.NotFound, "job not found"))
 			},
@@ -1080,11 +1150,12 @@ func TestGetJobLogs(t *testing.T) {
 			},
 			mock: func(req *jobspb.GetJobLogsRequest) {
 				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s",
+					"job_logs:%s:%s:%s:%s:%d",
 					req.GetUserId(),
 					req.GetId(),
 					req.GetCursor(),
 					req.GetFilters().GetStream(),
+					jobsmodel.JobLogsSortOrderDesc,
 				)
 				var filters *jobsmodel.GetJobLogsFilters
 				if req.GetFilters() != nil {
@@ -1098,13 +1169,14 @@ func TestGetJobLogs(t *testing.T) {
 					gomock.Any(),
 					cacheKey,
 					gomock.Any(),
-				).Return(nil, status.Error(codes.NotFound, "cache miss"))
+				).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
 				repo.EXPECT().GetJobLogs(
 					gomock.Any(),
 					req.GetId(),
 					req.GetWorkflowId(),
 					req.GetUserId(),
 					req.GetCursor(),
+					jobsmodel.JobLogsSortOrderDesc,
 					filters,
 				).Return(nil, "", status.Error(codes.Internal, "internal server error"))
 			},
@@ -1138,6 +1210,47 @@ func TestGetJobLogs(t *testing.T) {
 
 			assert.Equal(t, jobLogs, tt.want.GetJobLogsResponse)
 		})
+	}
+}
+
+func TestGetJobLogsAscendingSortOrder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repo := jobsmock.NewMockRepository(ctrl)
+	cache := jobsmock.NewMockCache(ctrl)
+	s := jobs.New(validator.New(), repo, cache)
+
+	req := &jobspb.GetJobLogsRequest{
+		Id:         "job_id",
+		WorkflowId: "workflow_id",
+		UserId:     "user_id",
+		SortOrder:  jobspb.LogSortOrder_LOG_SORT_ORDER_ASC,
+		Filters: &jobspb.GetJobLogsFilters{
+			Stream: jobspb.LogStream_LOG_STREAM_ALL,
+		},
+	}
+	filters := &jobsmodel.GetJobLogsFilters{Stream: int(req.GetFilters().GetStream())}
+	cacheKey := fmt.Sprintf(
+		"job_logs:%s:%s:%s:%s:%d",
+		req.GetUserId(),
+		req.GetId(),
+		req.GetCursor(),
+		req.GetFilters().GetStream(),
+		jobsmodel.JobLogsSortOrderAsc,
+	)
+
+	cache.EXPECT().Get(gomock.Any(), cacheKey, gomock.Any()).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
+	repo.EXPECT().
+		GetJobLogs(gomock.Any(), req.GetId(), req.GetWorkflowId(), req.GetUserId(), req.GetCursor(), jobsmodel.JobLogsSortOrderAsc, filters).
+		Return(&jobsmodel.GetJobLogsResponse{ID: req.GetId(), WorkflowID: req.GetWorkflowId()}, jobsmodel.JobStatusRunning.ToString(), nil)
+
+	res, err := s.GetJobLogs(t.Context(), req)
+	if err != nil {
+		t.Fatalf("GetJobLogs() error = %v", err)
+	}
+	if res.ID != req.GetId() {
+		t.Fatalf("unexpected response ID: got %q want %q", res.ID, req.GetId())
 	}
 }
 
@@ -1375,7 +1488,7 @@ func TestSearchJobLogs(t *testing.T) {
 					gomock.Any(),
 					cacheKey,
 					gomock.Any(),
-				).Return(nil, status.Error(codes.NotFound, "cache miss"))
+				).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
 				repo.EXPECT().SearchJobLogs(
 					gomock.Any(),
 					req.GetId(),
@@ -1419,7 +1532,7 @@ func TestSearchJobLogs(t *testing.T) {
 				Id:         "job_id",
 				WorkflowId: "workflow_id",
 				UserId:     "user_id",
-				Cursor:     "",
+				Cursor:     "cursor",
 				Filters: &jobspb.SearchJobLogsFilters{
 					Stream:  jobspb.LogStream_LOG_STREAM_ALL,
 					Message: "message",
@@ -1483,7 +1596,7 @@ func TestSearchJobLogs(t *testing.T) {
 				Id:         "job_id",
 				WorkflowId: "workflow_id",
 				UserId:     "user_id",
-				Cursor:     "",
+				Cursor:     "cursor",
 				Filters: &jobspb.SearchJobLogsFilters{
 					Stream:  jobspb.LogStream_LOG_STREAM_ALL,
 					Message: "message",
@@ -1530,7 +1643,7 @@ func TestSearchJobLogs(t *testing.T) {
 					gomock.Any(),
 					cacheKey,
 					gomock.Any(),
-				).Return(nil, status.Error(codes.NotFound, "cache miss"))
+				).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
 				repo.EXPECT().SearchJobLogs(
 					gomock.Any(),
 					req.GetId(),
@@ -1565,6 +1678,71 @@ func TestSearchJobLogs(t *testing.T) {
 						},
 					},
 					Cursor: "cursor",
+				},
+			},
+			isErr: false,
+		},
+		{
+			name: "success: running cursor tail skips cache write",
+			req: &jobspb.SearchJobLogsRequest{
+				Id:         "job_id_search_tail",
+				WorkflowId: "workflow_id",
+				UserId:     "user_id_search_tail",
+				Cursor:     "tail-cursor",
+				Filters: &jobspb.SearchJobLogsFilters{
+					Stream:  jobspb.LogStream_LOG_STREAM_ALL,
+					Message: "message",
+				},
+			},
+			mock: func(req *jobspb.SearchJobLogsRequest) {
+				data := &jobsmodel.GetJobLogsResponse{
+					ID:         req.GetId(),
+					WorkflowID: req.GetWorkflowId(),
+					JobLogs: []*jobsmodel.JobLog{
+						{
+							Timestamp:   timestamp,
+							Message:     "message tail",
+							SequenceNum: 1,
+							Stream:      "stdout",
+						},
+					},
+				}
+				cacheKey := fmt.Sprintf(
+					"job_logs:%s:%s:%s:%s:%s",
+					req.GetUserId(),
+					req.GetId(),
+					req.GetCursor(),
+					req.GetFilters().GetMessage(),
+					req.GetFilters().GetStream(),
+				)
+				filters := &jobsmodel.SearchJobLogsFilters{
+					Stream:  int(req.GetFilters().GetStream()),
+					Message: req.GetFilters().GetMessage(),
+				}
+				cache.EXPECT().
+					Get(gomock.Any(), cacheKey, gomock.Any()).
+					Return(nil, status.Error(codes.NotFound, "cache miss"))
+				repo.EXPECT().SearchJobLogs(
+					gomock.Any(),
+					req.GetId(),
+					req.GetWorkflowId(),
+					req.GetUserId(),
+					req.GetCursor(),
+					filters,
+				).Return(data, jobsmodel.JobStatusRunning.ToString(), nil)
+			},
+			want: want{
+				&jobsmodel.GetJobLogsResponse{
+					ID:         "job_id_search_tail",
+					WorkflowID: "workflow_id",
+					JobLogs: []*jobsmodel.JobLog{
+						{
+							Timestamp:   timestamp,
+							Message:     "message tail",
+							SequenceNum: 1,
+							Stream:      "stdout",
+						},
+					},
 				},
 			},
 			isErr: false,
@@ -1615,7 +1793,7 @@ func TestSearchJobLogs(t *testing.T) {
 					gomock.Any(),
 					cacheKey,
 					gomock.Any(),
-				).Return(nil, status.Error(codes.NotFound, "cache miss"))
+				).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
 				repo.EXPECT().SearchJobLogs(
 					gomock.Any(),
 					req.GetId(),
@@ -1662,7 +1840,7 @@ func TestSearchJobLogs(t *testing.T) {
 					gomock.Any(),
 					cacheKey,
 					gomock.Any(),
-				).Return(nil, status.Error(codes.NotFound, "cache miss"))
+				).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
 				repo.EXPECT().SearchJobLogs(
 					gomock.Any(),
 					req.GetId(),

--- a/internal/service/jobs/mock/jobs.go
+++ b/internal/service/jobs/mock/jobs.go
@@ -147,9 +147,9 @@ func (mr *MockRepositoryMockRecorder) GetJobByID(ctx, jobID any) *gomock.Call {
 }
 
 // GetJobLogs mocks base method.
-func (m *MockRepository) GetJobLogs(ctx context.Context, jobID, workflowID, userID, cursor string, filters *jobs.GetJobLogsFilters) (*jobs.GetJobLogsResponse, string, error) {
+func (m *MockRepository) GetJobLogs(ctx context.Context, jobID, workflowID, userID, cursor string, sortOrder jobs.JobLogsSortOrder, filters *jobs.GetJobLogsFilters) (*jobs.GetJobLogsResponse, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetJobLogs", ctx, jobID, workflowID, userID, cursor, filters)
+	ret := m.ctrl.Call(m, "GetJobLogs", ctx, jobID, workflowID, userID, cursor, sortOrder, filters)
 	ret0, _ := ret[0].(*jobs.GetJobLogsResponse)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -157,9 +157,9 @@ func (m *MockRepository) GetJobLogs(ctx context.Context, jobID, workflowID, user
 }
 
 // GetJobLogs indicates an expected call of GetJobLogs.
-func (mr *MockRepositoryMockRecorder) GetJobLogs(ctx, jobID, workflowID, userID, cursor, filters any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) GetJobLogs(ctx, jobID, workflowID, userID, cursor, sortOrder, filters any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobLogs", reflect.TypeOf((*MockRepository)(nil).GetJobLogs), ctx, jobID, workflowID, userID, cursor, filters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobLogs", reflect.TypeOf((*MockRepository)(nil).GetJobLogs), ctx, jobID, workflowID, userID, cursor, sortOrder, filters)
 }
 
 // ListJobs mocks base method.

--- a/pkg/proto/go/jobs/jobs.pb.go
+++ b/pkg/proto/go/jobs/jobs.pb.go
@@ -74,6 +74,56 @@ func (LogStream) EnumDescriptor() ([]byte, []int) {
 	return file_jobs_jobs_proto_rawDescGZIP(), []int{0}
 }
 
+// LogSortOrder represents the order used for retained log pagination.
+type LogSortOrder int32
+
+const (
+	LogSortOrder_LOG_SORT_ORDER_UNSPECIFIED LogSortOrder = 0
+	LogSortOrder_LOG_SORT_ORDER_DESC        LogSortOrder = 1
+	LogSortOrder_LOG_SORT_ORDER_ASC         LogSortOrder = 2
+)
+
+// Enum value maps for LogSortOrder.
+var (
+	LogSortOrder_name = map[int32]string{
+		0: "LOG_SORT_ORDER_UNSPECIFIED",
+		1: "LOG_SORT_ORDER_DESC",
+		2: "LOG_SORT_ORDER_ASC",
+	}
+	LogSortOrder_value = map[string]int32{
+		"LOG_SORT_ORDER_UNSPECIFIED": 0,
+		"LOG_SORT_ORDER_DESC":        1,
+		"LOG_SORT_ORDER_ASC":         2,
+	}
+)
+
+func (x LogSortOrder) Enum() *LogSortOrder {
+	p := new(LogSortOrder)
+	*p = x
+	return p
+}
+
+func (x LogSortOrder) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (LogSortOrder) Descriptor() protoreflect.EnumDescriptor {
+	return file_jobs_jobs_proto_enumTypes[1].Descriptor()
+}
+
+func (LogSortOrder) Type() protoreflect.EnumType {
+	return &file_jobs_jobs_proto_enumTypes[1]
+}
+
+func (x LogSortOrder) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use LogSortOrder.Descriptor instead.
+func (LogSortOrder) EnumDescriptor() ([]byte, []int) {
+	return file_jobs_jobs_proto_rawDescGZIP(), []int{1}
+}
+
 // ScheduleJobRequest contains the details needed to create a new job.
 type ScheduleJobRequest struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
@@ -1711,11 +1761,12 @@ func (x *GetJobLogsFilters) GetStream() LogStream {
 // GetJobLogsRequest contains the details needed to get the logs of a job.
 type GetJobLogsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                   // ID of the job
-	WorkflowId    string                 `protobuf:"bytes,2,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"` // ID of the workflow
-	UserId        string                 `protobuf:"bytes,3,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`             // ID of the user
-	Cursor        string                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`                           // Cursor for pagination
-	Filters       *GetJobLogsFilters     `protobuf:"bytes,5,opt,name=filters,proto3" json:"filters,omitempty"`                         // Filters applied to the search
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                                        // ID of the job
+	WorkflowId    string                 `protobuf:"bytes,2,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`                      // ID of the workflow
+	UserId        string                 `protobuf:"bytes,3,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`                                  // ID of the user
+	Cursor        string                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`                                                // Cursor for pagination
+	Filters       *GetJobLogsFilters     `protobuf:"bytes,5,opt,name=filters,proto3" json:"filters,omitempty"`                                              // Filters applied to the search
+	SortOrder     LogSortOrder           `protobuf:"varint,6,opt,name=sort_order,json=sortOrder,proto3,enum=jobs.LogSortOrder" json:"sort_order,omitempty"` // Sort order for retained log pagination
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1785,6 +1836,13 @@ func (x *GetJobLogsRequest) GetFilters() *GetJobLogsFilters {
 	return nil
 }
 
+func (x *GetJobLogsRequest) GetSortOrder() LogSortOrder {
+	if x != nil {
+		return x.SortOrder
+	}
+	return LogSortOrder_LOG_SORT_ORDER_UNSPECIFIED
+}
+
 // Log contains the details of a log.
 type Log struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1792,6 +1850,7 @@ type Log struct {
 	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`                             // Log message
 	SequenceNum   uint32                 `protobuf:"varint,3,opt,name=sequence_num,json=sequenceNum,proto3" json:"sequence_num,omitempty"` // Sequence number of the log
 	Stream        string                 `protobuf:"bytes,4,opt,name=stream,proto3" json:"stream,omitempty"`                               // Stream type (stdout or stderr)
+	EventId       string                 `protobuf:"bytes,5,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`              // Unique retained/live log event ID
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1850,6 +1909,13 @@ func (x *Log) GetSequenceNum() uint32 {
 func (x *Log) GetStream() string {
 	if x != nil {
 		return x.Stream
+	}
+	return ""
+}
+
+func (x *Log) GetEventId() string {
+	if x != nil {
+		return x.EventId
 	}
 	return ""
 }
@@ -2554,19 +2620,22 @@ const file_jobs_jobs_proto_rawDesc = "" +
 	"\n" +
 	"updated_at\x18\v \x01(\tR\tupdatedAt\"<\n" +
 	"\x11GetJobLogsFilters\x12'\n" +
-	"\x06stream\x18\x01 \x01(\x0e2\x0f.jobs.LogStreamR\x06stream\"\xa8\x01\n" +
+	"\x06stream\x18\x01 \x01(\x0e2\x0f.jobs.LogStreamR\x06stream\"\xdb\x01\n" +
 	"\x11GetJobLogsRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vworkflow_id\x18\x02 \x01(\tR\n" +
 	"workflowId\x12\x17\n" +
 	"\auser_id\x18\x03 \x01(\tR\x06userId\x12\x16\n" +
 	"\x06cursor\x18\x04 \x01(\tR\x06cursor\x121\n" +
-	"\afilters\x18\x05 \x01(\v2\x17.jobs.GetJobLogsFiltersR\afilters\"x\n" +
+	"\afilters\x18\x05 \x01(\v2\x17.jobs.GetJobLogsFiltersR\afilters\x121\n" +
+	"\n" +
+	"sort_order\x18\x06 \x01(\x0e2\x12.jobs.LogSortOrderR\tsortOrder\"\x93\x01\n" +
 	"\x03Log\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\tR\ttimestamp\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12!\n" +
 	"\fsequence_num\x18\x03 \x01(\rR\vsequenceNum\x12\x16\n" +
-	"\x06stream\x18\x04 \x01(\tR\x06stream\"|\n" +
+	"\x06stream\x18\x04 \x01(\tR\x06stream\x12\x19\n" +
+	"\bevent_id\x18\x05 \x01(\tR\aeventId\"|\n" +
 	"\x12GetJobLogsResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vworkflow_id\x18\x02 \x01(\tR\n" +
@@ -2623,7 +2692,11 @@ const file_jobs_jobs_proto_rawDesc = "" +
 	"\x16LOG_STREAM_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11LOG_STREAM_STDOUT\x10\x01\x12\x15\n" +
 	"\x11LOG_STREAM_STDERR\x10\x02\x12\x12\n" +
-	"\x0eLOG_STREAM_ALL\x10\x032\xa2\t\n" +
+	"\x0eLOG_STREAM_ALL\x10\x03*_\n" +
+	"\fLogSortOrder\x12\x1e\n" +
+	"\x1aLOG_SORT_ORDER_UNSPECIFIED\x10\x00\x12\x17\n" +
+	"\x13LOG_SORT_ORDER_DESC\x10\x01\x12\x16\n" +
+	"\x12LOG_SORT_ORDER_ASC\x10\x022\xa2\t\n" +
 	"\vJobsService\x12D\n" +
 	"\vScheduleJob\x12\x18.jobs.ScheduleJobRequest\x1a\x19.jobs.ScheduleJobResponse\"\x00\x12P\n" +
 	"\x0fUpdateJobStatus\x12\x1c.jobs.UpdateJobStatusRequest\x1a\x1d.jobs.UpdateJobStatusResponse\"\x00\x12;\n" +
@@ -2656,93 +2729,95 @@ func file_jobs_jobs_proto_rawDescGZIP() []byte {
 	return file_jobs_jobs_proto_rawDescData
 }
 
-var file_jobs_jobs_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_jobs_jobs_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_jobs_jobs_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_jobs_jobs_proto_goTypes = []any{
 	(LogStream)(0),                          // 0: jobs.LogStream
-	(*ScheduleJobRequest)(nil),              // 1: jobs.ScheduleJobRequest
-	(*ScheduleJobResponse)(nil),             // 2: jobs.ScheduleJobResponse
-	(*UpdateJobStatusRequest)(nil),          // 3: jobs.UpdateJobStatusRequest
-	(*UpdateJobStatusResponse)(nil),         // 4: jobs.UpdateJobStatusResponse
-	(*ClaimJobRequest)(nil),                 // 5: jobs.ClaimJobRequest
-	(*ClaimJobResponse)(nil),                // 6: jobs.ClaimJobResponse
-	(*RenewJobLeaseRequest)(nil),            // 7: jobs.RenewJobLeaseRequest
-	(*RenewJobLeaseResponse)(nil),           // 8: jobs.RenewJobLeaseResponse
-	(*AttachJobContainerRequest)(nil),       // 9: jobs.AttachJobContainerRequest
-	(*AttachJobContainerResponse)(nil),      // 10: jobs.AttachJobContainerResponse
-	(*CompleteJobRequest)(nil),              // 11: jobs.CompleteJobRequest
-	(*CompleteJobResponse)(nil),             // 12: jobs.CompleteJobResponse
-	(*FailJobRequest)(nil),                  // 13: jobs.FailJobRequest
-	(*FailJobResponse)(nil),                 // 14: jobs.FailJobResponse
-	(*CancelClaimedJobRequest)(nil),         // 15: jobs.CancelClaimedJobRequest
-	(*CancelClaimedJobResponse)(nil),        // 16: jobs.CancelClaimedJobResponse
-	(*ReleaseJobForRetryRequest)(nil),       // 17: jobs.ReleaseJobForRetryRequest
-	(*ReleaseJobForRetryResponse)(nil),      // 18: jobs.ReleaseJobForRetryResponse
-	(*ExpiredJobLease)(nil),                 // 19: jobs.ExpiredJobLease
-	(*RecoverExpiredJobLeasesRequest)(nil),  // 20: jobs.RecoverExpiredJobLeasesRequest
-	(*RecoverExpiredJobLeasesResponse)(nil), // 21: jobs.RecoverExpiredJobLeasesResponse
-	(*GetJobRequest)(nil),                   // 22: jobs.GetJobRequest
-	(*GetJobResponse)(nil),                  // 23: jobs.GetJobResponse
-	(*GetJobByIDRequest)(nil),               // 24: jobs.GetJobByIDRequest
-	(*GetJobByIDResponse)(nil),              // 25: jobs.GetJobByIDResponse
-	(*GetJobLogsFilters)(nil),               // 26: jobs.GetJobLogsFilters
-	(*GetJobLogsRequest)(nil),               // 27: jobs.GetJobLogsRequest
-	(*Log)(nil),                             // 28: jobs.Log
-	(*GetJobLogsResponse)(nil),              // 29: jobs.GetJobLogsResponse
-	(*StreamJobLogsRequest)(nil),            // 30: jobs.StreamJobLogsRequest
-	(*SearchJobLogsFilters)(nil),            // 31: jobs.SearchJobLogsFilters
-	(*SearchJobLogsRequest)(nil),            // 32: jobs.SearchJobLogsRequest
-	(*ListJobsFilters)(nil),                 // 33: jobs.ListJobsFilters
-	(*ListJobsRequest)(nil),                 // 34: jobs.ListJobsRequest
-	(*JobsResponse)(nil),                    // 35: jobs.JobsResponse
-	(*ListJobsResponse)(nil),                // 36: jobs.ListJobsResponse
+	(LogSortOrder)(0),                       // 1: jobs.LogSortOrder
+	(*ScheduleJobRequest)(nil),              // 2: jobs.ScheduleJobRequest
+	(*ScheduleJobResponse)(nil),             // 3: jobs.ScheduleJobResponse
+	(*UpdateJobStatusRequest)(nil),          // 4: jobs.UpdateJobStatusRequest
+	(*UpdateJobStatusResponse)(nil),         // 5: jobs.UpdateJobStatusResponse
+	(*ClaimJobRequest)(nil),                 // 6: jobs.ClaimJobRequest
+	(*ClaimJobResponse)(nil),                // 7: jobs.ClaimJobResponse
+	(*RenewJobLeaseRequest)(nil),            // 8: jobs.RenewJobLeaseRequest
+	(*RenewJobLeaseResponse)(nil),           // 9: jobs.RenewJobLeaseResponse
+	(*AttachJobContainerRequest)(nil),       // 10: jobs.AttachJobContainerRequest
+	(*AttachJobContainerResponse)(nil),      // 11: jobs.AttachJobContainerResponse
+	(*CompleteJobRequest)(nil),              // 12: jobs.CompleteJobRequest
+	(*CompleteJobResponse)(nil),             // 13: jobs.CompleteJobResponse
+	(*FailJobRequest)(nil),                  // 14: jobs.FailJobRequest
+	(*FailJobResponse)(nil),                 // 15: jobs.FailJobResponse
+	(*CancelClaimedJobRequest)(nil),         // 16: jobs.CancelClaimedJobRequest
+	(*CancelClaimedJobResponse)(nil),        // 17: jobs.CancelClaimedJobResponse
+	(*ReleaseJobForRetryRequest)(nil),       // 18: jobs.ReleaseJobForRetryRequest
+	(*ReleaseJobForRetryResponse)(nil),      // 19: jobs.ReleaseJobForRetryResponse
+	(*ExpiredJobLease)(nil),                 // 20: jobs.ExpiredJobLease
+	(*RecoverExpiredJobLeasesRequest)(nil),  // 21: jobs.RecoverExpiredJobLeasesRequest
+	(*RecoverExpiredJobLeasesResponse)(nil), // 22: jobs.RecoverExpiredJobLeasesResponse
+	(*GetJobRequest)(nil),                   // 23: jobs.GetJobRequest
+	(*GetJobResponse)(nil),                  // 24: jobs.GetJobResponse
+	(*GetJobByIDRequest)(nil),               // 25: jobs.GetJobByIDRequest
+	(*GetJobByIDResponse)(nil),              // 26: jobs.GetJobByIDResponse
+	(*GetJobLogsFilters)(nil),               // 27: jobs.GetJobLogsFilters
+	(*GetJobLogsRequest)(nil),               // 28: jobs.GetJobLogsRequest
+	(*Log)(nil),                             // 29: jobs.Log
+	(*GetJobLogsResponse)(nil),              // 30: jobs.GetJobLogsResponse
+	(*StreamJobLogsRequest)(nil),            // 31: jobs.StreamJobLogsRequest
+	(*SearchJobLogsFilters)(nil),            // 32: jobs.SearchJobLogsFilters
+	(*SearchJobLogsRequest)(nil),            // 33: jobs.SearchJobLogsRequest
+	(*ListJobsFilters)(nil),                 // 34: jobs.ListJobsFilters
+	(*ListJobsRequest)(nil),                 // 35: jobs.ListJobsRequest
+	(*JobsResponse)(nil),                    // 36: jobs.JobsResponse
+	(*ListJobsResponse)(nil),                // 37: jobs.ListJobsResponse
 }
 var file_jobs_jobs_proto_depIdxs = []int32{
-	19, // 0: jobs.RecoverExpiredJobLeasesResponse.jobs:type_name -> jobs.ExpiredJobLease
+	20, // 0: jobs.RecoverExpiredJobLeasesResponse.jobs:type_name -> jobs.ExpiredJobLease
 	0,  // 1: jobs.GetJobLogsFilters.stream:type_name -> jobs.LogStream
-	26, // 2: jobs.GetJobLogsRequest.filters:type_name -> jobs.GetJobLogsFilters
-	28, // 3: jobs.GetJobLogsResponse.logs:type_name -> jobs.Log
-	0,  // 4: jobs.SearchJobLogsFilters.stream:type_name -> jobs.LogStream
-	31, // 5: jobs.SearchJobLogsRequest.filters:type_name -> jobs.SearchJobLogsFilters
-	33, // 6: jobs.ListJobsRequest.filters:type_name -> jobs.ListJobsFilters
-	35, // 7: jobs.ListJobsResponse.jobs:type_name -> jobs.JobsResponse
-	1,  // 8: jobs.JobsService.ScheduleJob:input_type -> jobs.ScheduleJobRequest
-	3,  // 9: jobs.JobsService.UpdateJobStatus:input_type -> jobs.UpdateJobStatusRequest
-	5,  // 10: jobs.JobsService.ClaimJob:input_type -> jobs.ClaimJobRequest
-	7,  // 11: jobs.JobsService.RenewJobLease:input_type -> jobs.RenewJobLeaseRequest
-	9,  // 12: jobs.JobsService.AttachJobContainer:input_type -> jobs.AttachJobContainerRequest
-	11, // 13: jobs.JobsService.CompleteJob:input_type -> jobs.CompleteJobRequest
-	13, // 14: jobs.JobsService.FailJob:input_type -> jobs.FailJobRequest
-	15, // 15: jobs.JobsService.CancelClaimedJob:input_type -> jobs.CancelClaimedJobRequest
-	17, // 16: jobs.JobsService.ReleaseJobForRetry:input_type -> jobs.ReleaseJobForRetryRequest
-	20, // 17: jobs.JobsService.RecoverExpiredJobLeases:input_type -> jobs.RecoverExpiredJobLeasesRequest
-	22, // 18: jobs.JobsService.GetJob:input_type -> jobs.GetJobRequest
-	24, // 19: jobs.JobsService.GetJobByID:input_type -> jobs.GetJobByIDRequest
-	27, // 20: jobs.JobsService.GetJobLogs:input_type -> jobs.GetJobLogsRequest
-	30, // 21: jobs.JobsService.StreamJobLogs:input_type -> jobs.StreamJobLogsRequest
-	32, // 22: jobs.JobsService.SearchJobLogs:input_type -> jobs.SearchJobLogsRequest
-	34, // 23: jobs.JobsService.ListJobs:input_type -> jobs.ListJobsRequest
-	2,  // 24: jobs.JobsService.ScheduleJob:output_type -> jobs.ScheduleJobResponse
-	4,  // 25: jobs.JobsService.UpdateJobStatus:output_type -> jobs.UpdateJobStatusResponse
-	6,  // 26: jobs.JobsService.ClaimJob:output_type -> jobs.ClaimJobResponse
-	8,  // 27: jobs.JobsService.RenewJobLease:output_type -> jobs.RenewJobLeaseResponse
-	10, // 28: jobs.JobsService.AttachJobContainer:output_type -> jobs.AttachJobContainerResponse
-	12, // 29: jobs.JobsService.CompleteJob:output_type -> jobs.CompleteJobResponse
-	14, // 30: jobs.JobsService.FailJob:output_type -> jobs.FailJobResponse
-	16, // 31: jobs.JobsService.CancelClaimedJob:output_type -> jobs.CancelClaimedJobResponse
-	18, // 32: jobs.JobsService.ReleaseJobForRetry:output_type -> jobs.ReleaseJobForRetryResponse
-	21, // 33: jobs.JobsService.RecoverExpiredJobLeases:output_type -> jobs.RecoverExpiredJobLeasesResponse
-	23, // 34: jobs.JobsService.GetJob:output_type -> jobs.GetJobResponse
-	25, // 35: jobs.JobsService.GetJobByID:output_type -> jobs.GetJobByIDResponse
-	29, // 36: jobs.JobsService.GetJobLogs:output_type -> jobs.GetJobLogsResponse
-	28, // 37: jobs.JobsService.StreamJobLogs:output_type -> jobs.Log
-	29, // 38: jobs.JobsService.SearchJobLogs:output_type -> jobs.GetJobLogsResponse
-	36, // 39: jobs.JobsService.ListJobs:output_type -> jobs.ListJobsResponse
-	24, // [24:40] is the sub-list for method output_type
-	8,  // [8:24] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	27, // 2: jobs.GetJobLogsRequest.filters:type_name -> jobs.GetJobLogsFilters
+	1,  // 3: jobs.GetJobLogsRequest.sort_order:type_name -> jobs.LogSortOrder
+	29, // 4: jobs.GetJobLogsResponse.logs:type_name -> jobs.Log
+	0,  // 5: jobs.SearchJobLogsFilters.stream:type_name -> jobs.LogStream
+	32, // 6: jobs.SearchJobLogsRequest.filters:type_name -> jobs.SearchJobLogsFilters
+	34, // 7: jobs.ListJobsRequest.filters:type_name -> jobs.ListJobsFilters
+	36, // 8: jobs.ListJobsResponse.jobs:type_name -> jobs.JobsResponse
+	2,  // 9: jobs.JobsService.ScheduleJob:input_type -> jobs.ScheduleJobRequest
+	4,  // 10: jobs.JobsService.UpdateJobStatus:input_type -> jobs.UpdateJobStatusRequest
+	6,  // 11: jobs.JobsService.ClaimJob:input_type -> jobs.ClaimJobRequest
+	8,  // 12: jobs.JobsService.RenewJobLease:input_type -> jobs.RenewJobLeaseRequest
+	10, // 13: jobs.JobsService.AttachJobContainer:input_type -> jobs.AttachJobContainerRequest
+	12, // 14: jobs.JobsService.CompleteJob:input_type -> jobs.CompleteJobRequest
+	14, // 15: jobs.JobsService.FailJob:input_type -> jobs.FailJobRequest
+	16, // 16: jobs.JobsService.CancelClaimedJob:input_type -> jobs.CancelClaimedJobRequest
+	18, // 17: jobs.JobsService.ReleaseJobForRetry:input_type -> jobs.ReleaseJobForRetryRequest
+	21, // 18: jobs.JobsService.RecoverExpiredJobLeases:input_type -> jobs.RecoverExpiredJobLeasesRequest
+	23, // 19: jobs.JobsService.GetJob:input_type -> jobs.GetJobRequest
+	25, // 20: jobs.JobsService.GetJobByID:input_type -> jobs.GetJobByIDRequest
+	28, // 21: jobs.JobsService.GetJobLogs:input_type -> jobs.GetJobLogsRequest
+	31, // 22: jobs.JobsService.StreamJobLogs:input_type -> jobs.StreamJobLogsRequest
+	33, // 23: jobs.JobsService.SearchJobLogs:input_type -> jobs.SearchJobLogsRequest
+	35, // 24: jobs.JobsService.ListJobs:input_type -> jobs.ListJobsRequest
+	3,  // 25: jobs.JobsService.ScheduleJob:output_type -> jobs.ScheduleJobResponse
+	5,  // 26: jobs.JobsService.UpdateJobStatus:output_type -> jobs.UpdateJobStatusResponse
+	7,  // 27: jobs.JobsService.ClaimJob:output_type -> jobs.ClaimJobResponse
+	9,  // 28: jobs.JobsService.RenewJobLease:output_type -> jobs.RenewJobLeaseResponse
+	11, // 29: jobs.JobsService.AttachJobContainer:output_type -> jobs.AttachJobContainerResponse
+	13, // 30: jobs.JobsService.CompleteJob:output_type -> jobs.CompleteJobResponse
+	15, // 31: jobs.JobsService.FailJob:output_type -> jobs.FailJobResponse
+	17, // 32: jobs.JobsService.CancelClaimedJob:output_type -> jobs.CancelClaimedJobResponse
+	19, // 33: jobs.JobsService.ReleaseJobForRetry:output_type -> jobs.ReleaseJobForRetryResponse
+	22, // 34: jobs.JobsService.RecoverExpiredJobLeases:output_type -> jobs.RecoverExpiredJobLeasesResponse
+	24, // 35: jobs.JobsService.GetJob:output_type -> jobs.GetJobResponse
+	26, // 36: jobs.JobsService.GetJobByID:output_type -> jobs.GetJobByIDResponse
+	30, // 37: jobs.JobsService.GetJobLogs:output_type -> jobs.GetJobLogsResponse
+	29, // 38: jobs.JobsService.StreamJobLogs:output_type -> jobs.Log
+	30, // 39: jobs.JobsService.SearchJobLogs:output_type -> jobs.GetJobLogsResponse
+	37, // 40: jobs.JobsService.ListJobs:output_type -> jobs.ListJobsResponse
+	25, // [25:41] is the sub-list for method output_type
+	9,  // [9:25] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_jobs_jobs_proto_init() }
@@ -2756,7 +2831,7 @@ func file_jobs_jobs_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_jobs_jobs_proto_rawDesc), len(file_jobs_jobs_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/proto/jobs/jobs.proto
+++ b/proto/jobs/jobs.proto
@@ -188,6 +188,13 @@ enum LogStream {
   LOG_STREAM_ALL         = 3;
 }
 
+// LogSortOrder represents the order used for retained log pagination.
+enum LogSortOrder {
+  LOG_SORT_ORDER_UNSPECIFIED = 0;
+  LOG_SORT_ORDER_DESC        = 1;
+  LOG_SORT_ORDER_ASC         = 2;
+}
+
 // SearchJobLogsFilters are the filters that are to be applied on the get job logs request.
 message GetJobLogsFilters {
   LogStream stream = 1;
@@ -200,6 +207,7 @@ message GetJobLogsRequest {
   string            user_id     = 3; // ID of the user
   string            cursor      = 4; // Cursor for pagination
   GetJobLogsFilters filters     = 5; // Filters applied to the search
+  LogSortOrder      sort_order  = 6; // Sort order for retained log pagination
 }
 
 // Log contains the details of a log.
@@ -208,6 +216,7 @@ message Log {
   string message      = 2; // Log message
   uint32 sequence_num = 3; // Sequence number of the log
   string stream       = 4; // Stream type (stdout or stderr)
+  string event_id     = 5; // Unique retained/live log event ID
 }
 
 // GetJobLogsResponse contains the result of a job log retrieval attempt.


### PR DESCRIPTION
## Summary
- change job log viewing/search to latest-first pagination with lazy older-page fetching.
- merge live SSE logs with retained logs safety and preserve stable ordering/deduplication.
- update Meilisearch  to v1.45.2 with dumpless upgrade enabled and strict mTLS healthcheck.