### PR TITLE
Add safe job log highlights and filtered downloads

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-
+ 
 @custom-variant dark (&:is(.dark *));
-
+ 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -40,7 +40,7 @@
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
 }
-
+ 
 :root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);
@@ -75,7 +75,7 @@
   --sidebar-border: oklch(0.923 0.003 48.717);
   --sidebar-ring: oklch(0.709 0.01 56.259);
 }
-
+ 
 .dark {
   --background: oklch(0.147 0.004 49.25);
   --foreground: oklch(0.985 0.001 106.423);
@@ -109,7 +109,7 @@
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.553 0.013 58.071);
 }
-
+ 
 @layer base {
   * {
     @apply scroll-smooth;
@@ -122,7 +122,7 @@
     @apply antialiased;
     @apply h-full;
   }
-
+ 
   :root {
     --chart-1: oklch(0.646 0.222 41.116);
     --chart-2: oklch(0.6 0.118 184.704);
@@ -130,7 +130,7 @@
     --chart-4: oklch(0.828 0.189 84.429);
     --chart-5: oklch(0.769 0.188 70.08);
   }
-
+ 
   .dark {
     --chart-1: oklch(0.488 0.243 264.376);
     --chart-2: oklch(0.696 0.17 162.48);
@@ -138,12 +138,4 @@
     --chart-4: oklch(0.627 0.265 303.9);
     --chart-5: oklch(0.645 0.246 16.439);
   }
-}
-
-em {
-  background-color: var(--color-orange-400);
-  color: var(--color-white);
-  font-style: normal;
-  padding-block: calc(var(--spacing) * 0.5);
-  border-radius: var(--radius-xs)
 }

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 @import "tw-animate-css";
- 
+
 @custom-variant dark (&:is(.dark *));
- 
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -40,7 +40,7 @@
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
 }
- 
+
 :root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);
@@ -75,7 +75,7 @@
   --sidebar-border: oklch(0.923 0.003 48.717);
   --sidebar-ring: oklch(0.709 0.01 56.259);
 }
- 
+
 .dark {
   --background: oklch(0.147 0.004 49.25);
   --foreground: oklch(0.985 0.001 106.423);
@@ -109,7 +109,7 @@
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.553 0.013 58.071);
 }
- 
+
 @layer base {
   * {
     @apply scroll-smooth;
@@ -122,7 +122,7 @@
     @apply antialiased;
     @apply h-full;
   }
- 
+
   :root {
     --chart-1: oklch(0.646 0.222 41.116);
     --chart-2: oklch(0.6 0.118 184.704);
@@ -130,7 +130,7 @@
     --chart-4: oklch(0.828 0.189 84.429);
     --chart-5: oklch(0.769 0.188 70.08);
   }
- 
+
   .dark {
     --chart-1: oklch(0.488 0.243 264.376);
     --chart-2: oklch(0.696 0.17 162.48);

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -39,6 +39,7 @@ import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 
 import { useJobLogs } from "@/hooks/use-job-logs"
+import type { DownloadLogsFormat } from "@/hooks/use-job-logs"
 
 import { cn, jsonRegex } from "@/lib/utils"
 
@@ -70,6 +71,10 @@ const getLogStreamStripStyles = (stream: string) => {
 }
 
 const highlightClass = "rounded bg-orange-400/80 px-0.5 text-inherit dark:bg-orange-500/70"
+const highlightTokenPattern = /^[a-f0-9]{32}$/
+const highlightStartPrefix = "__CV_HL_START_"
+const highlightEndPrefix = "__CV_HL_END_"
+const highlightSuffix = "__"
 
 const escapeHtml = (value: string) => {
     return value.replace(/[&<>"']/g, (char) => {
@@ -90,47 +95,104 @@ const escapeHtml = (value: string) => {
     })
 }
 
-const escapeRegExp = (value: string) => {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-}
-
-const stripHighlightTags = (message: string) => {
-    return message.replace(/<\/?em>/g, "")
-}
-
-const extractHighlightedTerms = (message: string) => {
-    const terms: string[] = []
-    const highlightPattern = /<em>([\s\S]*?)<\/em>/g
-
-    for (const match of message.matchAll(highlightPattern)) {
-        const term = match[1]
-        if (term?.trim()) {
-            terms.push(term)
-        }
-    }
-
-    return Array.from(new Set(terms)).sort((a, b) => b.length - a.length)
-}
-
-const renderHighlightedText = (message: string, terms: string[]) => {
-    if (!terms.length) {
+const renderHighlightedText = (message: string, highlightToken?: string) => {
+    if (!highlightToken || !highlightTokenPattern.test(highlightToken)) {
         return escapeHtml(message)
     }
 
-    const highlightPattern = new RegExp(terms.map(escapeRegExp).join("|"), "gi")
-    let lastIndex = 0
+    const startTag = `${highlightStartPrefix}${highlightToken}${highlightSuffix}`
+    const endTag = `${highlightEndPrefix}${highlightToken}${highlightSuffix}`
+    let currentIndex = 0
     let rendered = ""
 
-    for (const match of message.matchAll(highlightPattern)) {
-        const matchText = match[0]
-        const matchIndex = match.index ?? 0
+    while (currentIndex < message.length) {
+        const startIndex = message.indexOf(startTag, currentIndex)
+        if (startIndex === -1) {
+            break
+        }
 
-        rendered += escapeHtml(message.slice(lastIndex, matchIndex))
-        rendered += `<mark class="${highlightClass}">${escapeHtml(matchText)}</mark>`
-        lastIndex = matchIndex + matchText.length
+        const matchStartIndex = startIndex + startTag.length
+        const endIndex = message.indexOf(endTag, matchStartIndex)
+        if (endIndex === -1) {
+            break
+        }
+
+        rendered += escapeHtml(message.slice(currentIndex, startIndex))
+        rendered += `<mark class="${highlightClass}">${escapeHtml(message.slice(matchStartIndex, endIndex))}</mark>`
+        currentIndex = endIndex + endTag.length
     }
 
-    rendered += escapeHtml(message.slice(lastIndex))
+    rendered += escapeHtml(message.slice(currentIndex))
+    return rendered
+}
+
+const getHighlightTags = (highlightToken?: string) => {
+    if (!highlightToken || !highlightTokenPattern.test(highlightToken)) {
+        return null
+    }
+
+    return {
+        startTag: `${highlightStartPrefix}${highlightToken}${highlightSuffix}`,
+        endTag: `${highlightEndPrefix}${highlightToken}${highlightSuffix}`,
+    }
+}
+
+const parseHighlightedMessage = (message: string, highlightToken?: string) => {
+    const tags = getHighlightTags(highlightToken)
+    if (!tags) {
+        return { rawMessage: message, highlightedSegments: [] }
+    }
+
+    const highlightedSegments: string[] = []
+    let currentIndex = 0
+    let rawMessage = ""
+
+    while (currentIndex < message.length) {
+        const startIndex = message.indexOf(tags.startTag, currentIndex)
+        if (startIndex === -1) {
+            break
+        }
+
+        const matchStartIndex = startIndex + tags.startTag.length
+        const endIndex = message.indexOf(tags.endTag, matchStartIndex)
+        if (endIndex === -1) {
+            break
+        }
+
+        rawMessage += message.slice(currentIndex, startIndex)
+        rawMessage += message.slice(matchStartIndex, endIndex)
+        highlightedSegments.push(message.slice(matchStartIndex, endIndex))
+        currentIndex = endIndex + tags.endTag.length
+    }
+
+    rawMessage += message.slice(currentIndex)
+    return { rawMessage, highlightedSegments }
+}
+
+const renderHighlightedSegments = (message: string, segments: string[]) => {
+    if (!segments.length) {
+        return escapeHtml(message)
+    }
+
+    let currentIndex = 0
+    let rendered = ""
+
+    for (const segment of segments) {
+        if (!segment) {
+            continue
+        }
+
+        const segmentIndex = message.indexOf(segment, currentIndex)
+        if (segmentIndex === -1) {
+            continue
+        }
+
+        rendered += escapeHtml(message.slice(currentIndex, segmentIndex))
+        rendered += `<mark class="${highlightClass}">${escapeHtml(segment)}</mark>`
+        currentIndex = segmentIndex + segment.length
+    }
+
+    rendered += escapeHtml(message.slice(currentIndex))
     return rendered
 }
 
@@ -146,6 +208,7 @@ export function LogsViewer({
     const searchParams = useSearchParams()
 
     const [popoverOpen, setPopoverOpen] = useState(false)
+    const [downloadPopoverOpen, setDownloadPopoverOpen] = useState(false)
     const [isSearchFocused, setIsSearchFocused] = useState(false)
     const searchInputRef = useRef<HTMLInputElement>(null)
 
@@ -170,6 +233,8 @@ export function LogsViewer({
 
     const [searchInput, setSearchInput] = useState(searchQuery)
     const [stream, setStream] = useState(streamFilter || "all")
+    const [downloadFilename, setDownloadFilename] = useState(`${jobId}-logs`)
+    const [downloadFormat, setDownloadFormat] = useState<DownloadLogsFormat>("txt")
     const disableLogInteractions = isRetentionDisabled || isLogsUnsupportedForKind
     const parseJson = searchParams.get("json") === "true"
 
@@ -185,6 +250,10 @@ export function LogsViewer({
         const query = params.toString()
         router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
     }, [pathname, router, searchParams])
+
+    useEffect(() => {
+        setDownloadFilename(`${jobId}-logs`)
+    }, [jobId])
 
     // Debounced search update
     useEffect(() => {
@@ -218,20 +287,18 @@ export function LogsViewer({
         return () => window.removeEventListener("keydown", handleKeyDown)
     }, [isSearchFocused])
 
-    // Parse log message and render Meili <em> highlights safely.
+    // Parse log message and render token-scoped Meili highlights safely.
     const parseLog = useCallback(
-        (message: string) => {
-            const shouldRenderSearchHighlights = Boolean(searchQuery)
-            const highlightedTerms = shouldRenderSearchHighlights ? extractHighlightedTerms(message) : []
-            const rawMessage = shouldRenderSearchHighlights ? stripHighlightTags(message) : message
-
+        (message: string, highlightToken?: string) => {
             if (!parseJson) {
-                return renderHighlightedText(rawMessage, highlightedTerms)
+                return renderHighlightedText(message, highlightToken)
             }
+
+            const { rawMessage, highlightedSegments } = parseHighlightedMessage(message, highlightToken)
 
             try {
                 const parsed = JSON.parse(rawMessage)
-                return renderHighlightedText(JSON.stringify(parsed, null, 2), highlightedTerms)
+                return renderHighlightedSegments(JSON.stringify(parsed, null, 2), highlightedSegments)
             } catch {
                 const formattedMessage = rawMessage.replace(jsonRegex, (match) => {
                     try {
@@ -242,17 +309,17 @@ export function LogsViewer({
                     }
                 })
 
-                return renderHighlightedText(formattedMessage, highlightedTerms)
+                return renderHighlightedSegments(formattedMessage, highlightedSegments)
             }
         },
-        [parseJson, searchQuery]
+        [parseJson]
     )
 
     // Row renderer for Virtuoso
     const LogRow = (index: number) => {
         const log = logs[index]
         if (!log) return null
-        const formattedMessage = parseLog(log.message)
+        const formattedMessage = parseLog(log.message, log.highlightToken)
         return (
             <div
                 className={cn(
@@ -366,19 +433,79 @@ export function LogsViewer({
                                 disabled={(jobStatus === "CANCELED" && logs.length === 0) || (logs.length === 0 && !!completedAt)}
                             />
                         </div>
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => downloadLogsMutation.mutate()}
-                            disabled={disableLogInteractions || isDownloadLogsMutationLoading || logs.length === 0 || jobStatus === "RUNNING"}
-                        >
-                            {isDownloadLogsMutationLoading ? (
-                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            ) : (
-                                <Download className="h-4 w-4 mr-2" />
-                            )}
-                            Download
-                        </Button>
+                        <Popover open={downloadPopoverOpen} onOpenChange={setDownloadPopoverOpen}>
+                            <PopoverTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={disableLogInteractions || isDownloadLogsMutationLoading || logs.length === 0 || jobStatus === "RUNNING"}
+                                >
+                                    {isDownloadLogsMutationLoading ? (
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    ) : (
+                                        <Download className="h-4 w-4 mr-2" />
+                                    )}
+                                    Download
+                                </Button>
+                            </PopoverTrigger>
+                            <PopoverContent className="w-64 m-2 flex flex-col gap-4" align="end">
+                                <div className="flex flex-col gap-2">
+                                    <Label htmlFor="download-filename" className="text-md">File name</Label>
+                                    <Input
+                                        id="download-filename"
+                                        value={downloadFilename}
+                                        onChange={(e) => setDownloadFilename(e.target.value)}
+                                        disabled={isDownloadLogsMutationLoading}
+                                    />
+                                </div>
+                                <div className="flex flex-col gap-2">
+                                    <Label className="text-md">File type</Label>
+                                    <Separator />
+                                    <RadioGroup
+                                        value={downloadFormat}
+                                        onValueChange={(value) => setDownloadFormat(value as DownloadLogsFormat)}
+                                        className="flex flex-col gap-2"
+                                        disabled={isDownloadLogsMutationLoading}
+                                    >
+                                        <div className="flex items-center gap-2">
+                                            <RadioGroupItem value="txt" id="download-format-txt" />
+                                            <Label htmlFor="download-format-txt" className="text-sm font-medium">
+                                                txt
+                                            </Label>
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            <RadioGroupItem value="json" id="download-format-json" />
+                                            <Label htmlFor="download-format-json" className="text-sm font-medium">
+                                                json
+                                            </Label>
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            <RadioGroupItem value="jsonl" id="download-format-jsonl" />
+                                            <Label htmlFor="download-format-jsonl" className="text-sm font-medium">
+                                                jsonl
+                                            </Label>
+                                        </div>
+                                    </RadioGroup>
+                                </div>
+                                <Button
+                                    onClick={() => {
+                                        downloadLogsMutation.mutate(
+                                            { filename: downloadFilename, format: downloadFormat },
+                                            { onSuccess: () => setDownloadPopoverOpen(false) }
+                                        )
+                                    }}
+                                    disabled={isDownloadLogsMutationLoading}
+                                    className="w-full"
+                                >
+                                    {isDownloadLogsMutationLoading ? (
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    ) : (
+                                        <Download className="h-4 w-4 mr-2" />
+                                    )}
+                                    Download
+                                </Button>
+                            </PopoverContent>
+                        </Popover>
                     </div>
                 </div>
             </CardHeader>

--- a/dashboard/src/hooks/use-job-logs.ts
+++ b/dashboard/src/hooks/use-job-logs.ts
@@ -26,6 +26,7 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL
 
 export type JobLog = {
     event_id?: string
+    highlightToken?: string
     timestamp: string
     message: string
     sequence_num: number
@@ -47,6 +48,14 @@ export type JobLogsResponseData = {
     workflow_id: string
     logs: JobLog[]
     cursor?: string
+    highlight_token?: string
+}
+
+export type DownloadLogsFormat = "txt" | "json" | "jsonl"
+
+type DownloadLogsOptions = {
+    filename: string
+    format: DownloadLogsFormat
 }
 
 const kindsWithLogs = ['CONTAINER']
@@ -69,12 +78,13 @@ const sequenceNumFromEventID = (eventID?: string): number | undefined => {
     return Number.isFinite(sequenceNum) ? sequenceNum : undefined
 }
 
-const normalizeJobLog = (log: JobLogWire): JobLog => {
+const normalizeJobLog = (log: JobLogWire, highlightToken?: string): JobLog => {
     const eventID = log.event_id || log.eventId
     const sequenceNum = Number(log.sequence_num ?? log.sequenceNum ?? sequenceNumFromEventID(eventID) ?? 0)
 
     return {
         event_id: eventID,
+        highlightToken,
         timestamp: log.timestamp || "",
         message: log.message || "",
         sequence_num: Number.isFinite(sequenceNum) ? sequenceNum : 0,
@@ -123,6 +133,11 @@ const logsFromPages = (pages?: JobLogsResponseData[]): JobLog[] => {
     }
 
     return sortLogsDesc(uniqueLogsByKey(pages.flatMap((page) => page?.logs || [])))
+}
+
+const downloadFilename = (filename: string, format: DownloadLogsFormat) => {
+    const base = (filename.trim() || "logs").replace(/\.(txt|json|jsonl)$/i, "")
+    return `${base}.${format}`
 }
 
 export function useJobLogs(workflowId: string, jobId: string, jobStatus: string) {
@@ -200,8 +215,11 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
 
     // Download raw logs from backend and trigger browser file download
     const downloadLogsMutation = useMutation({
-        mutationFn: async () => {
-            const response = await fetchWithAuth(logsDownloadURL)
+        mutationFn: async ({ filename, format }: DownloadLogsOptions) => {
+            const params = new URLSearchParams(getSearchQueryParams)
+            params.set("format", format)
+
+            const response = await fetchWithAuth(`${logsDownloadURL}?${params.toString()}`)
             if (!response.ok) {
                 throw new Error("failed to download logs")
             }
@@ -210,7 +228,7 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
             const objectUrl = URL.createObjectURL(blob)
             const a = document.createElement("a")
             a.href = objectUrl
-            a.download = `${jobId}-logs.txt`
+            a.download = downloadFilename(filename, format)
             document.body.appendChild(a)
             a.click()
             a.remove()
@@ -249,7 +267,7 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
             return {
                 id: res.id,
                 workflow_id: res.workflow_id,
-                logs: (res.logs || []).map(normalizeJobLog),
+                logs: (res.logs || []).map((log) => normalizeJobLog(log)),
                 cursor: res.cursor || undefined,
             }
         },
@@ -279,8 +297,9 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
             return {
                 id: jobId,
                 workflow_id: workflowId,
-                logs: (res.logs || []).map(normalizeJobLog),
+                logs: (res.logs || []).map((log) => normalizeJobLog(log, res.highlight_token)),
                 cursor: res.cursor || undefined,
+                highlight_token: res.highlight_token,
             }
         },
         initialPageParam: null,

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,31 +1,31 @@
 # HTTP API
- 
+
 The HTTP API is served by `server`. Development exposes it directly on
 `http://localhost:8080`. Production exposes it through Nginx under `/api/...`;
 for example, development `GET /workflows` maps to production
 `GET /api/workflows`.
- 
+
 All non-auth application routes require a valid session cookie. Mutating routes
 also require CSRF validation. Browser clients get the session and CSRF cookies
 from login or registration.
- 
+
 ## Common Behavior
- 
+
 ### Headers
- 
+
 - `Content-Type: application/json` for JSON request bodies.
 - `Idempotency-Key: <unique-key>` is required for retry-prone mutations:
   - `POST /workflows`
   - `PUT /workflows/{workflow_id}`
   - `POST /workflows/{workflow_id}/jobs/schedule`
- 
+
 Use a stable idempotency key when retrying the same user action. Use a new key
 for a new action.
- 
+
 ### Status Mapping
- 
+
 The server maps gRPC errors to HTTP status codes. Important cases:
- 
+
 - `400 Bad Request`: invalid input, invalid filters, missing idempotency key.
 - `401 Unauthorized`: missing or invalid session.
 - `403 Forbidden`: permission denied.
@@ -36,95 +36,95 @@ The server maps gRPC errors to HTTP status codes. Important cases:
   sent as `event: error` frames after stream headers are written.
 - `429 Too Many Requests`: resource exhausted.
 - `503 Service Unavailable`: downstream service unavailable.
- 
+
 ## Authentication
- 
+
 ### Register
- 
+
 `POST /auth/register`
- 
+
 Body:
- 
+
 ```json
 {
   "email": "user@example.com",
   "password": "password"
 }
 ```
- 
+
 Creates the user, issues a session cookie, and returns `201 Created`.
- 
+
 ### Login
- 
+
 `POST /auth/login`
- 
+
 Body:
- 
+
 ```json
 {
   "email": "user@example.com",
   "password": "password"
 }
 ```
- 
+
 Issues a session cookie and returns `201 Created`.
- 
+
 ### Logout
- 
+
 `POST /auth/logout`
- 
+
 Deletes the session and CSRF cookies and returns `204 No Content`.
  
 ### Validate Session
- 
+
 `POST /auth/validate`
- 
+
 Returns `200 OK` when the current session and CSRF token are valid.
- 
+
 ## Users
- 
+
 ### Get Current User
- 
+
 `GET /users`
- 
+
 Returns the current user's profile and preference data.
- 
+
 ### Update Current User
- 
+
 `PUT /users`
- 
+
 Body:
- 
+
 ```json
 {
   "notification_preference": "ALL"
 }
 ```
- 
+
 Returns `204 No Content`. The current handler accepts a `password` field in the
 shape but only forwards notification preference updates.
- 
+
 ## Workflows
- 
+
 Workflow kinds:
- 
+
 - `HEARTBEAT`: no execution logs and `log_retention` must be disabled.
 - `CONTAINER`: executes a container workload and may retain logs.
- 
+
 Build statuses:
- 
+
 - `QUEUED`
 - `STARTED`
 - `COMPLETED`
 - `FAILED`
 - `CANCELED`
- 
+
 ### List Workflows
- 
+
 `GET /workflows`
- 
+
 Query parameters:
- 
+
 - `cursor`: pagination cursor.
 - `query`: text query.
 - `kind`: `HEARTBEAT` or `CONTAINER`.
@@ -132,17 +132,17 @@ Query parameters:
 - `terminated`: boolean string.
 - `interval_min`: minimum interval in minutes.
 - `interval_max`: maximum interval in minutes.
- 
+
 Response includes `workflows` and `cursor`.
- 
+
 ### Create Workflow
- 
+
 `POST /workflows`
- 
+
 Requires `Idempotency-Key`.
- 
+
 Body:
- 
+
 ```json
 {
   "name": "nightly-report",
@@ -153,26 +153,25 @@ Body:
   "log_retention": true
 }
 ```
- 
+
 Fields:
- 
+
 - `name`: display name.
 - `payload`: workflow-kind-specific JSON string.
 - `kind`: `HEARTBEAT` or `CONTAINER`.
 - `interval`: schedule interval in minutes.
-- `max_consecutive_job_failures_allowed`: failure threshold before workflow
-  behavior changes.
+- `max_consecutive_job_failures_allowed`: failure threshold before workflow behavior changes.
 - `log_retention`: optional. `CONTAINER` defaults to retained logs when unset;
   `HEARTBEAT` persists with retention disabled.
- 
+
 Returns `201 Created` with the workflow ID.
- 
+
 ### Get Workflow
- 
+
 `GET /workflows/{workflow_id}`
- 
+
 Returns workflow fields including:
- 
+
 - `id`
 - `name`
 - `payload`
@@ -186,15 +185,15 @@ Returns workflow fields including:
 - `terminated_at`
 - `log_retention`
 - `generation`
- 
+
 ### Update Workflow
- 
+
 `PUT /workflows/{workflow_id}`
- 
+
 Requires `Idempotency-Key`.
- 
+
 Body:
- 
+
 ```json
 {
   "name": "nightly-report",
@@ -203,65 +202,65 @@ Body:
   "max_consecutive_job_failures_allowed": 3
 }
 ```
- 
+
 Returns `204 No Content`.
- 
+
 ### Terminate Workflow
- 
+
 `PATCH /workflows/{workflow_id}`
- 
+
 Terminates the workflow and returns `204 No Content`.
- 
+
 ### Delete Workflow
- 
+
 `DELETE /workflows/{workflow_id}`
- 
+
 Deletes a terminated workflow and returns `204 No Content`. Active workflows or
 workflows with active jobs can fail with `412 Precondition Failed`.
- 
+
 ## Jobs
- 
+
 Job statuses:
- 
+
 - `PENDING`
 - `QUEUED`
 - `RUNNING`
 - `COMPLETED`
 - `FAILED`
 - `CANCELED`
- 
+
 Job triggers:
- 
+
 - `AUTOMATIC`
 - `MANUAL`
- 
+
 ### List Jobs
- 
+
 `GET /workflows/{workflow_id}/jobs`
- 
+
 Query parameters:
- 
+
 - `cursor`: pagination cursor.
 - `status`: job status filter.
 - `trigger`: `AUTOMATIC` or `MANUAL`.
- 
+
 Response includes `jobs` and `cursor`. Job entries include `attempts` in list
 responses.
- 
+
 ### Manual Schedule
- 
+
 `POST /workflows/{workflow_id}/jobs/schedule`
- 
+
 Requires `Idempotency-Key`.
- 
+
 Schedules an immediate manual job and returns `201 Created` with the job ID.
- 
+
 ### Get Job
- 
+
 `GET /workflows/{workflow_id}/jobs/{job_id}`
- 
+
 Returns:
- 
+
 - `id`
 - `workflow_id`
 - `status`
@@ -271,115 +270,132 @@ Returns:
 - `completed_at`
 - `created_at`
 - `updated_at`
- 
+
 Lease metadata such as lease tokens is internal to worker gRPC APIs and is not
 returned by the public HTTP job detail route.
- 
+
 ## Job Logs
- 
+
 Log streams:
- 
+
 - `stdout`
 - `stderr`
 - omit `stream` for all streams.
- 
+
 Log APIs are available only when the workflow supports logs and log retention is
 enabled. `HEARTBEAT` workflows do not produce execution logs. If retention is
 disabled, retained log read/search routes return `412 Precondition Failed`; live
 SSE streams report the failure as an `event: error` frame.
- 
+
 ### Get Logs
- 
+
 `GET /workflows/{workflow_id}/jobs/{job_id}/logs`
- 
+
 Query parameters:
- 
+
 - `cursor`: pagination cursor.
- 
+
 Returns retained logs from ClickHouse in descending sequence order: latest logs
 first, older logs on later cursor pages.
- 
+
 ### Search Logs
- 
+
 `GET /workflows/{workflow_id}/jobs/{job_id}/logs/search`
- 
+
 Query parameters:
- 
+
 - `cursor`: pagination cursor.
 - `stream`: `stdout` or `stderr`.
 - `q`: message search text.
- 
+
 If `q` is omitted, the route returns filtered retained logs by stream. If `q` is
 present, it searches retained logs through Meilisearch. Results are returned in
 descending sequence order: latest logs first, older logs on later cursor pages.
- 
+
 ### Download Raw Logs
- 
+
 `GET /workflows/{workflow_id}/jobs/{job_id}/logs/raw`
- 
-Streams retained logs as `text/plain` for terminal jobs. Non-terminal jobs return
-`400 Bad Request`. Raw downloads are streamed in ascending sequence order so the
-file reads oldest to newest.
- 
+
+Query parameters:
+
+- `format`: `txt`, `json`, or `jsonl`. Defaults to `txt`.
+- `stream`: `stdout` or `stderr`. Omit to include all streams.
+- `q`: message search text. When present, matching retained logs are fetched through Meilisearch without search highlight markers.
+
+Streams retained logs for terminal jobs: `COMPLETED`, `FAILED`, and `CANCELED`.
+Non-terminal jobs return `400 Bad Request`. Downloads are streamed in ascending
+sequence order so the file reads oldest to newest, even though the dashboard log
+viewer displays latest logs first.
+
+Download formats:
+
+- `txt`: `text/plain`; writes each raw log message on its own line.
+- `json`: `application/json`; streams one JSON envelope containing job metadata, active filters, and a `logs` array.
+- `jsonl`: `application/x-ndjson`; streams one JSON object per log line.
+
+JSON and JSONL log objects include `timestamp`, `sequence_num`, `stream`,
+`event_id`, and `message_raw`. If the log message is valid JSON, `message_json`
+is also included with the parsed JSON value.
+
 ### Stream Live Logs
- 
+
 `GET /workflows/{workflow_id}/jobs/{job_id}/events`
- 
+
 Streams Server-Sent Events for a running job. Production Nginx has a dedicated
 no-buffering proxy location for this route:
- 
+
 `/api/workflows/{workflow_id}/jobs/{job_id}/events`
- 
+
 After the SSE headers are sent, stream-open and stream-receive failures are sent
 as `event: error` frames on the `text/event-stream` response. For example, a
 non-running job or disabled log retention is reported as an SSE error event
 rather than an HTTP `412 Precondition Failed` response.
- 
+
 ## Notifications
- 
+
 ### List Notifications
- 
+
 `GET /notifications`
- 
+
 Query parameters:
- 
+
 - `cursor`: pagination cursor.
- 
+
 Returns notifications for the current user.
- 
+
 ### Mark Notifications Read
- 
+
 `PUT /notifications`
- 
+
 Body:
- 
+
 ```json
 {
   "ids": ["notification-id"]
 }
 ```
- 
+
 Returns `204 No Content`.
- 
+
 ## Analytics
- 
+
 ### User Analytics
- 
+
 `GET /analytics`
- 
+
 Returns current-user aggregate totals:
- 
+
 - `total_workflows`
 - `total_jobs`
 - `total_joblogs`
 - `total_job_execution_duration`
- 
+
 ### Workflow Analytics
- 
+
 `GET /analytics/{workflow_id}`
- 
+
 Returns workflow aggregate totals:
- 
+
 - `workflow_id`
 - `total_job_execution_duration`
 - `total_jobs`

--- a/internal/model/jobs/jobs.go
+++ b/internal/model/jobs/jobs.go
@@ -1,15 +1,15 @@
 package jobs
- 
+
 import (
 	"database/sql"
 	"time"
- 
+
 	jobspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
 )
- 
+
 // JobStatus represents the status of the scheduled job.
 type JobStatus string
- 
+
 // JobStatuses for the scheduled job.
 const (
 	JobStatusPending   JobStatus = "PENDING"
@@ -19,40 +19,40 @@ const (
 	JobStatusFailed    JobStatus = "FAILED"
 	JobStatusCanceled  JobStatus = "CANCELED"
 )
- 
+
 // ToString converts the JobStatus to its string representation.
 func (s JobStatus) ToString() string {
 	return string(s)
 }
- 
+
 // FailureKind represents whether a job failure belongs to user code/configuration or system infrastructure.
 type FailureKind string
- 
+
 // FailureKinds for terminal job failures.
 const (
 	FailureKindUser   FailureKind = "USER"
 	FailureKindSystem FailureKind = "SYSTEM"
 )
- 
+
 // ToString converts the FailureKind to its string representation.
 func (f FailureKind) ToString() string {
 	return string(f)
 }
- 
+
 // JobTrigger represents the trigger type of the job.
 type JobTrigger string
- 
+
 // JobTriggers for the scheduled job.
 const (
 	JobTriggerAutomatic JobTrigger = "AUTOMATIC"
 	JobTriggerManual    JobTrigger = "MANUAL"
 )
- 
+
 // ToString converts the JobTrigger to its string representation.
 func (t JobTrigger) ToString() string {
 	return string(t)
 }
- 
+
 // GetJobResponse represents the response of GetJob.
 type GetJobResponse struct {
 	ID          string       `db:"id"`
@@ -65,7 +65,7 @@ type GetJobResponse struct {
 	CreatedAt   time.Time    `db:"created_at"`
 	UpdatedAt   time.Time    `db:"updated_at"`
 }
- 
+
 // ToProto converts the GetJobResponse to its protobuf representation.
 func (r *GetJobResponse) ToProto() *jobspb.GetJobResponse {
 	var startedAt, completedAt string
@@ -75,7 +75,7 @@ func (r *GetJobResponse) ToProto() *jobspb.GetJobResponse {
 	if r.CompletedAt.Valid {
 		completedAt = r.CompletedAt.Time.Format(time.RFC3339Nano)
 	}
- 
+
 	return &jobspb.GetJobResponse{
 		Id:          r.ID,
 		WorkflowId:  r.WorkflowID,
@@ -88,7 +88,7 @@ func (r *GetJobResponse) ToProto() *jobspb.GetJobResponse {
 		UpdatedAt:   r.UpdatedAt.Format(time.RFC3339Nano),
 	}
 }
- 
+
 // GetJobByIDResponse represents the response of GetJobByID.
 type GetJobByIDResponse struct {
 	ID          string         `db:"id"`
@@ -104,7 +104,7 @@ type GetJobByIDResponse struct {
 	CreatedAt   time.Time      `db:"created_at"`
 	UpdatedAt   time.Time      `db:"updated_at"`
 }
- 
+
 // ToProto converts the GetJobByIDResponse to its protobuf representation.
 func (r *GetJobByIDResponse) ToProto() *jobspb.GetJobByIDResponse {
 	var startedAt, completedAt string
@@ -114,7 +114,7 @@ func (r *GetJobByIDResponse) ToProto() *jobspb.GetJobByIDResponse {
 	if r.CompletedAt.Valid {
 		completedAt = r.CompletedAt.Time.Format(time.RFC3339Nano)
 	}
- 
+
 	return &jobspb.GetJobByIDResponse{
 		Id:          r.ID,
 		WorkflowId:  r.WorkflowID,
@@ -129,7 +129,7 @@ func (r *GetJobByIDResponse) ToProto() *jobspb.GetJobByIDResponse {
 		UpdatedAt:   r.UpdatedAt.Format(time.RFC3339Nano),
 	}
 }
- 
+
 // ScheduledJobEntry represents the scheduled job entry.
 type ScheduledJobEntry struct {
 	EventKey           string
@@ -139,7 +139,7 @@ type ScheduledJobEntry struct {
 	DispatchAttempt    int32
 	WorkflowGeneration int64
 }
- 
+
 // ClaimedJob represents a job claimed by an execution worker.
 type ClaimedJob struct {
 	ID               string    `db:"id"`
@@ -151,7 +151,7 @@ type ClaimedJob struct {
 	Attempts         int32     `db:"attempts"`
 	LeaseToken       string    `db:"lease_token"`
 }
- 
+
 // ToClaimJobProto converts a ClaimedJob to a ClaimJobResponse.
 func (j *ClaimedJob) ToClaimJobProto(claimed bool, reason string) *jobspb.ClaimJobResponse {
 	if j == nil {
@@ -160,7 +160,7 @@ func (j *ClaimedJob) ToClaimJobProto(claimed bool, reason string) *jobspb.ClaimJ
 			Reason:  reason,
 		}
 	}
- 
+
 	return &jobspb.ClaimJobResponse{
 		Claimed:          claimed,
 		Reason:           reason,
@@ -174,7 +174,7 @@ func (j *ClaimedJob) ToClaimJobProto(claimed bool, reason string) *jobspb.ClaimJ
 		LeaseToken:       j.LeaseToken,
 	}
 }
- 
+
 // ExpiredJobLease represents a running job with an expired lease.
 type ExpiredJobLease struct {
 	ID           string         `db:"id"`
@@ -188,7 +188,7 @@ type ExpiredJobLease struct {
 	Attempts     int32          `db:"attempts"`
 	LogRetention bool           `db:"log_retention"`
 }
- 
+
 // ToProto converts an ExpiredJobLease to its protobuf representation.
 func (j *ExpiredJobLease) ToProto() *jobspb.ExpiredJobLease {
 	return &jobspb.ExpiredJobLease{
@@ -204,7 +204,7 @@ func (j *ExpiredJobLease) ToProto() *jobspb.ExpiredJobLease {
 		LogRetention: j.LogRetention,
 	}
 }
- 
+
 // JobLog represents the log of the job.
 type JobLog struct {
 	EventID     string    `db:"event_id"`
@@ -213,7 +213,7 @@ type JobLog struct {
 	SequenceNum uint32    `db:"sequence_num"`
 	Stream      string    `db:"stream"` // "stdout" or "stderr"
 }
- 
+
 // ToProto converts the JobLog to its protobuf representation.
 func (l *JobLog) ToProto() *jobspb.Log {
 	return &jobspb.Log{
@@ -224,22 +224,22 @@ func (l *JobLog) ToProto() *jobspb.Log {
 		EventId:     l.EventID,
 	}
 }
- 
+
 // JobLogsSortOrder represents retained job log ordering.
 type JobLogsSortOrder int
- 
+
 // Job log sort orders.
 const (
 	JobLogsSortOrderUnspecified JobLogsSortOrder = 0
 	JobLogsSortOrderDesc        JobLogsSortOrder = 1
 	JobLogsSortOrderAsc         JobLogsSortOrder = 2
 )
- 
+
 // GetJobLogsFilters represents the filters for filtering job logs.
 type GetJobLogsFilters struct {
 	Stream int `validate:"required,min=1,max=3"`
 }
- 
+
 // GetJobLogsResponse represents the response of GetJobLogs.
 type GetJobLogsResponse struct {
 	ID             string
@@ -248,7 +248,7 @@ type GetJobLogsResponse struct {
 	Cursor         string
 	HighlightToken string
 }
- 
+
 // ToProto converts the GetJobLogsResponse to its protobuf representation.
 func (r *GetJobLogsResponse) ToProto() *jobspb.GetJobLogsResponse {
 	jobLogs := make([]*jobspb.Log, len(r.JobLogs))
@@ -256,7 +256,7 @@ func (r *GetJobLogsResponse) ToProto() *jobspb.GetJobLogsResponse {
 		l := r.JobLogs[i]
 		jobLogs[i] = l.ToProto()
 	}
- 
+
 	return &jobspb.GetJobLogsResponse{
 		Id:             r.ID,
 		WorkflowId:     r.WorkflowID,
@@ -265,19 +265,19 @@ func (r *GetJobLogsResponse) ToProto() *jobspb.GetJobLogsResponse {
 		HighlightToken: r.HighlightToken,
 	}
 }
- 
+
 // SearchJobLogsFilters represents the filters for searching job logs.
 type SearchJobLogsFilters struct {
 	Stream  int    `validate:"required,min=1,max=3"`
 	Message string `validate:"required"`
 }
- 
+
 // SearchJobLogsOptions represents non-filter options for searching job logs.
 type SearchJobLogsOptions struct {
 	SortOrder        JobLogsSortOrder
 	DisableHighlight bool
 }
- 
+
 // JobByWorkflowIDResponse represents the response of ListJobsByID.
 type JobByWorkflowIDResponse struct {
 	ID          string         `db:"id"`
@@ -292,26 +292,26 @@ type JobByWorkflowIDResponse struct {
 	CreatedAt   time.Time      `db:"created_at"`
 	UpdatedAt   time.Time      `db:"updated_at"`
 }
- 
+
 // ListJobsFilters represents the filters for listing jobs.
 type ListJobsFilters struct {
 	Status  string `validate:"omitempty"`
 	Trigger string `validate:"omitempty"`
 }
- 
+
 // ListJobsResponse represents the response of ListJobsByID.
 type ListJobsResponse struct {
 	Jobs   []*JobByWorkflowIDResponse
 	Cursor string
 }
- 
+
 // ToProto converts the ListJobsResponse to its protobuf representation.
 // It takes an internalService boolean to determine if the some fields.
 func (r *ListJobsResponse) ToProto(internalService bool) *jobspb.ListJobsResponse {
 	jobs := make([]*jobspb.JobsResponse, len(r.Jobs))
 	for i := range r.Jobs {
 		j := r.Jobs[i]
- 
+
 		var startedAt, completedAt string
 		if j.StartedAt.Valid {
 			startedAt = j.StartedAt.Time.Format(time.RFC3339Nano)
@@ -319,7 +319,7 @@ func (r *ListJobsResponse) ToProto(internalService bool) *jobspb.ListJobsRespons
 		if j.CompletedAt.Valid {
 			completedAt = j.CompletedAt.Time.Format(time.RFC3339Nano)
 		}
- 
+
 		jobs[i] = &jobspb.JobsResponse{
 			Id:          j.ID,
 			WorkflowId:  j.WorkflowID,
@@ -332,12 +332,12 @@ func (r *ListJobsResponse) ToProto(internalService bool) *jobspb.ListJobsRespons
 			UpdatedAt:   j.UpdatedAt.Format(time.RFC3339Nano),
 			Attempts:    j.Attempts,
 		}
- 
+
 		if internalService {
 			jobs[i].ContainerId = j.ContainerID.String
 		}
 	}
- 
+
 	return &jobspb.ListJobsResponse{
 		Jobs:   jobs,
 		Cursor: r.Cursor,

--- a/internal/model/jobs/jobs.go
+++ b/internal/model/jobs/jobs.go
@@ -1,15 +1,15 @@
 package jobs
-
+ 
 import (
 	"database/sql"
 	"time"
-
+ 
 	jobspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
 )
-
+ 
 // JobStatus represents the status of the scheduled job.
 type JobStatus string
-
+ 
 // JobStatuses for the scheduled job.
 const (
 	JobStatusPending   JobStatus = "PENDING"
@@ -19,40 +19,40 @@ const (
 	JobStatusFailed    JobStatus = "FAILED"
 	JobStatusCanceled  JobStatus = "CANCELED"
 )
-
+ 
 // ToString converts the JobStatus to its string representation.
 func (s JobStatus) ToString() string {
 	return string(s)
 }
-
+ 
 // FailureKind represents whether a job failure belongs to user code/configuration or system infrastructure.
 type FailureKind string
-
+ 
 // FailureKinds for terminal job failures.
 const (
 	FailureKindUser   FailureKind = "USER"
 	FailureKindSystem FailureKind = "SYSTEM"
 )
-
+ 
 // ToString converts the FailureKind to its string representation.
 func (f FailureKind) ToString() string {
 	return string(f)
 }
-
+ 
 // JobTrigger represents the trigger type of the job.
 type JobTrigger string
-
+ 
 // JobTriggers for the scheduled job.
 const (
 	JobTriggerAutomatic JobTrigger = "AUTOMATIC"
 	JobTriggerManual    JobTrigger = "MANUAL"
 )
-
+ 
 // ToString converts the JobTrigger to its string representation.
 func (t JobTrigger) ToString() string {
 	return string(t)
 }
-
+ 
 // GetJobResponse represents the response of GetJob.
 type GetJobResponse struct {
 	ID          string       `db:"id"`
@@ -65,7 +65,7 @@ type GetJobResponse struct {
 	CreatedAt   time.Time    `db:"created_at"`
 	UpdatedAt   time.Time    `db:"updated_at"`
 }
-
+ 
 // ToProto converts the GetJobResponse to its protobuf representation.
 func (r *GetJobResponse) ToProto() *jobspb.GetJobResponse {
 	var startedAt, completedAt string
@@ -75,7 +75,7 @@ func (r *GetJobResponse) ToProto() *jobspb.GetJobResponse {
 	if r.CompletedAt.Valid {
 		completedAt = r.CompletedAt.Time.Format(time.RFC3339Nano)
 	}
-
+ 
 	return &jobspb.GetJobResponse{
 		Id:          r.ID,
 		WorkflowId:  r.WorkflowID,
@@ -88,7 +88,7 @@ func (r *GetJobResponse) ToProto() *jobspb.GetJobResponse {
 		UpdatedAt:   r.UpdatedAt.Format(time.RFC3339Nano),
 	}
 }
-
+ 
 // GetJobByIDResponse represents the response of GetJobByID.
 type GetJobByIDResponse struct {
 	ID          string         `db:"id"`
@@ -104,7 +104,7 @@ type GetJobByIDResponse struct {
 	CreatedAt   time.Time      `db:"created_at"`
 	UpdatedAt   time.Time      `db:"updated_at"`
 }
-
+ 
 // ToProto converts the GetJobByIDResponse to its protobuf representation.
 func (r *GetJobByIDResponse) ToProto() *jobspb.GetJobByIDResponse {
 	var startedAt, completedAt string
@@ -114,7 +114,7 @@ func (r *GetJobByIDResponse) ToProto() *jobspb.GetJobByIDResponse {
 	if r.CompletedAt.Valid {
 		completedAt = r.CompletedAt.Time.Format(time.RFC3339Nano)
 	}
-
+ 
 	return &jobspb.GetJobByIDResponse{
 		Id:          r.ID,
 		WorkflowId:  r.WorkflowID,
@@ -129,7 +129,7 @@ func (r *GetJobByIDResponse) ToProto() *jobspb.GetJobByIDResponse {
 		UpdatedAt:   r.UpdatedAt.Format(time.RFC3339Nano),
 	}
 }
-
+ 
 // ScheduledJobEntry represents the scheduled job entry.
 type ScheduledJobEntry struct {
 	EventKey           string
@@ -139,7 +139,7 @@ type ScheduledJobEntry struct {
 	DispatchAttempt    int32
 	WorkflowGeneration int64
 }
-
+ 
 // ClaimedJob represents a job claimed by an execution worker.
 type ClaimedJob struct {
 	ID               string    `db:"id"`
@@ -151,7 +151,7 @@ type ClaimedJob struct {
 	Attempts         int32     `db:"attempts"`
 	LeaseToken       string    `db:"lease_token"`
 }
-
+ 
 // ToClaimJobProto converts a ClaimedJob to a ClaimJobResponse.
 func (j *ClaimedJob) ToClaimJobProto(claimed bool, reason string) *jobspb.ClaimJobResponse {
 	if j == nil {
@@ -160,7 +160,7 @@ func (j *ClaimedJob) ToClaimJobProto(claimed bool, reason string) *jobspb.ClaimJ
 			Reason:  reason,
 		}
 	}
-
+ 
 	return &jobspb.ClaimJobResponse{
 		Claimed:          claimed,
 		Reason:           reason,
@@ -174,7 +174,7 @@ func (j *ClaimedJob) ToClaimJobProto(claimed bool, reason string) *jobspb.ClaimJ
 		LeaseToken:       j.LeaseToken,
 	}
 }
-
+ 
 // ExpiredJobLease represents a running job with an expired lease.
 type ExpiredJobLease struct {
 	ID           string         `db:"id"`
@@ -188,7 +188,7 @@ type ExpiredJobLease struct {
 	Attempts     int32          `db:"attempts"`
 	LogRetention bool           `db:"log_retention"`
 }
-
+ 
 // ToProto converts an ExpiredJobLease to its protobuf representation.
 func (j *ExpiredJobLease) ToProto() *jobspb.ExpiredJobLease {
 	return &jobspb.ExpiredJobLease{
@@ -204,7 +204,7 @@ func (j *ExpiredJobLease) ToProto() *jobspb.ExpiredJobLease {
 		LogRetention: j.LogRetention,
 	}
 }
-
+ 
 // JobLog represents the log of the job.
 type JobLog struct {
 	EventID     string    `db:"event_id"`
@@ -213,7 +213,7 @@ type JobLog struct {
 	SequenceNum uint32    `db:"sequence_num"`
 	Stream      string    `db:"stream"` // "stdout" or "stderr"
 }
-
+ 
 // ToProto converts the JobLog to its protobuf representation.
 func (l *JobLog) ToProto() *jobspb.Log {
 	return &jobspb.Log{
@@ -224,30 +224,31 @@ func (l *JobLog) ToProto() *jobspb.Log {
 		EventId:     l.EventID,
 	}
 }
-
+ 
 // JobLogsSortOrder represents retained job log ordering.
 type JobLogsSortOrder int
-
+ 
 // Job log sort orders.
 const (
 	JobLogsSortOrderUnspecified JobLogsSortOrder = 0
 	JobLogsSortOrderDesc        JobLogsSortOrder = 1
 	JobLogsSortOrderAsc         JobLogsSortOrder = 2
 )
-
+ 
 // GetJobLogsFilters represents the filters for filtering job logs.
 type GetJobLogsFilters struct {
 	Stream int `validate:"required,min=1,max=3"`
 }
-
+ 
 // GetJobLogsResponse represents the response of GetJobLogs.
 type GetJobLogsResponse struct {
-	ID         string
-	WorkflowID string
-	JobLogs    []*JobLog
-	Cursor     string
+	ID             string
+	WorkflowID     string
+	JobLogs        []*JobLog
+	Cursor         string
+	HighlightToken string
 }
-
+ 
 // ToProto converts the GetJobLogsResponse to its protobuf representation.
 func (r *GetJobLogsResponse) ToProto() *jobspb.GetJobLogsResponse {
 	jobLogs := make([]*jobspb.Log, len(r.JobLogs))
@@ -255,21 +256,28 @@ func (r *GetJobLogsResponse) ToProto() *jobspb.GetJobLogsResponse {
 		l := r.JobLogs[i]
 		jobLogs[i] = l.ToProto()
 	}
-
+ 
 	return &jobspb.GetJobLogsResponse{
-		Id:         r.ID,
-		WorkflowId: r.WorkflowID,
-		Logs:       jobLogs,
-		Cursor:     r.Cursor,
+		Id:             r.ID,
+		WorkflowId:     r.WorkflowID,
+		Logs:           jobLogs,
+		Cursor:         r.Cursor,
+		HighlightToken: r.HighlightToken,
 	}
 }
-
+ 
 // SearchJobLogsFilters represents the filters for searching job logs.
 type SearchJobLogsFilters struct {
 	Stream  int    `validate:"required,min=1,max=3"`
 	Message string `validate:"required"`
 }
-
+ 
+// SearchJobLogsOptions represents non-filter options for searching job logs.
+type SearchJobLogsOptions struct {
+	SortOrder        JobLogsSortOrder
+	DisableHighlight bool
+}
+ 
 // JobByWorkflowIDResponse represents the response of ListJobsByID.
 type JobByWorkflowIDResponse struct {
 	ID          string         `db:"id"`
@@ -284,26 +292,26 @@ type JobByWorkflowIDResponse struct {
 	CreatedAt   time.Time      `db:"created_at"`
 	UpdatedAt   time.Time      `db:"updated_at"`
 }
-
+ 
 // ListJobsFilters represents the filters for listing jobs.
 type ListJobsFilters struct {
 	Status  string `validate:"omitempty"`
 	Trigger string `validate:"omitempty"`
 }
-
+ 
 // ListJobsResponse represents the response of ListJobsByID.
 type ListJobsResponse struct {
 	Jobs   []*JobByWorkflowIDResponse
 	Cursor string
 }
-
+ 
 // ToProto converts the ListJobsResponse to its protobuf representation.
 // It takes an internalService boolean to determine if the some fields.
 func (r *ListJobsResponse) ToProto(internalService bool) *jobspb.ListJobsResponse {
 	jobs := make([]*jobspb.JobsResponse, len(r.Jobs))
 	for i := range r.Jobs {
 		j := r.Jobs[i]
-
+ 
 		var startedAt, completedAt string
 		if j.StartedAt.Valid {
 			startedAt = j.StartedAt.Time.Format(time.RFC3339Nano)
@@ -311,7 +319,7 @@ func (r *ListJobsResponse) ToProto(internalService bool) *jobspb.ListJobsRespons
 		if j.CompletedAt.Valid {
 			completedAt = j.CompletedAt.Time.Format(time.RFC3339Nano)
 		}
-
+ 
 		jobs[i] = &jobspb.JobsResponse{
 			Id:          j.ID,
 			WorkflowId:  j.WorkflowID,
@@ -324,12 +332,12 @@ func (r *ListJobsResponse) ToProto(internalService bool) *jobspb.ListJobsRespons
 			UpdatedAt:   j.UpdatedAt.Format(time.RFC3339Nano),
 			Attempts:    j.Attempts,
 		}
-
+ 
 		if internalService {
 			jobs[i].ContainerId = j.ContainerID.String
 		}
 	}
-
+ 
 	return &jobspb.ListJobsResponse{
 		Jobs:   jobs,
 		Cursor: r.Cursor,

--- a/internal/repository/jobs/jobs.go
+++ b/internal/repository/jobs/jobs.go
@@ -1,29 +1,31 @@
 package jobs
-
+ 
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 	"time"
-
+ 
 	"go.opentelemetry.io/otel"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
+ 
 	"github.com/jackc/pgx/v5"
 	"github.com/meilisearch/meilisearch-go"
 	goredis "github.com/redis/go-redis/v9"
-
+ 
 	workflowspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/workflows"
-
+ 
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/clickhouse"
@@ -33,30 +35,35 @@ import (
 	"github.com/hitesh22rana/chronoverse/internal/pkg/redis"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
-
+ 
 const (
 	authSubject           = "internal/jobs"
 	delimiter             = '$'
 	jobStatusUpdateBuffer = time.Minute // 1 minute
+ 
+	jobLogsHighlightTokenBytes = 16
+	jobLogsHighlightStart      = "__CV_HL_START_"
+	jobLogsHighlightEnd        = "__CV_HL_END_"
+	jobLogsHighlightSuffix     = "__"
 )
-
+ 
 type jobLogsCursor struct {
 	SequenceNum uint32 `json:"sequence_num"`
 	Stream      string `json:"stream,omitempty"`
 	EventID     string `json:"event_id,omitempty"`
 }
-
+ 
 // Services represents the services used by the executor.
 type Services struct {
 	Workflows workflowspb.WorkflowsServiceClient
 }
-
+ 
 // Config represents the repository constants configuration.
 type Config struct {
 	FetchLimit     int
 	LogsFetchLimit int
 }
-
+ 
 // Repository provides jobs repository.
 type Repository struct {
 	tp   trace.Tracer
@@ -68,7 +75,7 @@ type Repository struct {
 	ms   meilisearch.ServiceManager
 	svc  *Services
 }
-
+ 
 // New creates a new jobs repository.
 func New(cfg *Config, auth auth.IAuth, pg *postgres.Postgres, rdb *redis.Store, ch *clickhouse.Client, ms meilisearch.ServiceManager, svc *Services) *Repository {
 	return &Repository{
@@ -82,7 +89,7 @@ func New(cfg *Config, auth auth.IAuth, pg *postgres.Postgres, rdb *redis.Store, 
 		svc:  svc,
 	}
 }
-
+ 
 // ScheduleJob schedules a job.
 func (r *Repository) ScheduleJob(
 	ctx context.Context,
@@ -101,13 +108,13 @@ func (r *Repository) ScheduleJob(
 		}
 		span.End()
 	}()
-
+ 
 	scheduledAtTime, err := parseTime(scheduledAt)
 	if err != nil {
 		err = status.Errorf(codes.InvalidArgument, "invalid scheduled_at time format: %v", err)
 		return "", err
 	}
-
+ 
 	idempotencyKey, automaticIdempotencyKeyProvided := normalizeScheduleJobIdempotencyKey(
 		workflowID,
 		scheduledAtTime,
@@ -126,7 +133,7 @@ func (r *Repository) ScheduleJob(
 	if err != nil {
 		return "", err
 	}
-
+ 
 	row := r.pg.QueryRow(ctx, query, args...)
 	if err = row.Scan(&jobID); err != nil {
 		switch {
@@ -140,14 +147,14 @@ func (r *Repository) ScheduleJob(
 			err = status.Errorf(codes.FailedPrecondition, "workflow generation mismatch or workflow is not schedulable")
 			return "", err
 		}
-
+ 
 		err = status.Errorf(codes.Internal, "failed to insert job: %v", err)
 		return "", err
 	}
-
+ 
 	return jobID, nil
 }
-
+ 
 func normalizeScheduleJobIdempotencyKey(
 	workflowID string,
 	scheduledAt time.Time,
@@ -158,10 +165,10 @@ func normalizeScheduleJobIdempotencyKey(
 	if trigger == jobsmodel.JobTriggerAutomatic.ToString() && !automaticIdempotencyKeyProvided {
 		idempotencyKey = idempotency.JobDispatchEventKey(fmt.Sprintf("%s:%s", workflowID, scheduledAt.Format(time.RFC3339Nano)))
 	}
-
+ 
 	return idempotencyKey, automaticIdempotencyKeyProvided
 }
-
+ 
 func scheduleJobInsertStatement(
 	workflowID,
 	userID string,
@@ -175,7 +182,7 @@ func scheduleJobInsertStatement(
 	if trigger == jobsmodel.JobTriggerAutomatic.ToString() && workflowGeneration > 0 {
 		args = append(args, workflowGeneration)
 	}
-
+ 
 	switch {
 	case trigger == jobsmodel.JobTriggerManual.ToString():
 		return fmt.Sprintf(`
@@ -212,12 +219,12 @@ func scheduleJobInsertStatement(
 		return "", nil, status.Errorf(codes.InvalidArgument, "invalid job trigger: %s", trigger)
 	}
 }
-
+ 
 func automaticScheduleGuardSQL(workflowGeneration int64) string {
 	if workflowGeneration <= 0 {
 		return ""
 	}
-
+ 
 	return fmt.Sprintf(`
             FROM %s AS w
             WHERE w.id = $1
@@ -228,7 +235,7 @@ func automaticScheduleGuardSQL(workflowGeneration int64) string {
             FOR SHARE
     `, postgres.TableWorkflows)
 }
-
+ 
 // UpdateJobStatus updates the job details.
 func (r *Repository) UpdateJobStatus(ctx context.Context, jobID, containerID, jobStatus string) (err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.UpdateJobStatus")
@@ -239,12 +246,12 @@ func (r *Repository) UpdateJobStatus(ctx context.Context, jobID, containerID, jo
 		}
 		span.End()
 	}()
-
+ 
 	query := fmt.Sprintf(`
     UPDATE %s
     SET status = $1`, postgres.TableJobs)
 	args := []any{jobStatus}
-
+ 
 	switch jobStatus {
 	case jobsmodel.JobStatusRunning.ToString():
 		if containerID == "" {
@@ -277,7 +284,7 @@ func (r *Repository) UpdateJobStatus(ctx context.Context, jobID, containerID, jo
 		query += ` WHERE id = $2;`
 		args = append(args, jobID)
 	}
-
+ 
 	// Execute the query
 	ct, err := r.pg.Exec(ctx, query, args...)
 	//nolint:gocritic // Ifelse is used to handle different error types
@@ -292,24 +299,24 @@ func (r *Repository) UpdateJobStatus(ctx context.Context, jobID, containerID, jo
 			err = status.Errorf(codes.InvalidArgument, "invalid job ID: %v", err)
 			return err
 		}
-
+ 
 		err = status.Errorf(codes.Internal, "failed to update job: %v", err)
 		return err
 	}
-
+ 
 	if ct.RowsAffected() == 0 {
 		if jobStatus == jobsmodel.JobStatusCanceled.ToString() {
 			err = status.Errorf(codes.FailedPrecondition, "job not found or not cancellable")
 			return err
 		}
-
+ 
 		err = status.Errorf(codes.NotFound, "job not found")
 		return err
 	}
-
+ 
 	return nil
 }
-
+ 
 // GetJob returns the job details by ID and Job ID and user ID.
 func (r *Repository) GetJob(ctx context.Context, jobID, workflowID, userID string) (res *jobsmodel.GetJobResponse, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.GetJob")
@@ -320,14 +327,14 @@ func (r *Repository) GetJob(ctx context.Context, jobID, workflowID, userID strin
 		}
 		span.End()
 	}()
-
+ 
 	query := fmt.Sprintf(`
         SELECT id, workflow_id, status, trigger, scheduled_at, started_at, completed_at, created_at, updated_at
         FROM %s
         WHERE id = $1 AND workflow_id = $2 AND user_id = $3
         LIMIT 1;
     `, postgres.TableJobs)
-
+ 
 	rows, err := r.pg.Query(ctx, query, jobID, workflowID, userID)
 	if errors.Is(err, context.DeadlineExceeded) {
 		err = status.Error(codes.DeadlineExceeded, err.Error())
@@ -336,7 +343,7 @@ func (r *Repository) GetJob(ctx context.Context, jobID, workflowID, userID strin
 		err = status.Error(codes.Canceled, err.Error())
 		return nil, err
 	}
-
+ 
 	res, err = pgx.CollectExactlyOneRow(rows, pgx.RowToAddrOfStructByName[jobsmodel.GetJobResponse])
 	if err != nil {
 		if r.pg.IsNoRows(err) {
@@ -346,14 +353,14 @@ func (r *Repository) GetJob(ctx context.Context, jobID, workflowID, userID strin
 			err = status.Errorf(codes.InvalidArgument, "invalid job ID: %v", err)
 			return nil, err
 		}
-
+ 
 		err = status.Errorf(codes.Internal, "failed to get job: %v", err)
 		return nil, err
 	}
-
+ 
 	return res, nil
 }
-
+ 
 // GetJobByID returns the job details by ID.
 func (r *Repository) GetJobByID(ctx context.Context, jobID string) (res *jobsmodel.GetJobByIDResponse, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.GetJobByID")
@@ -364,14 +371,14 @@ func (r *Repository) GetJobByID(ctx context.Context, jobID string) (res *jobsmod
 		}
 		span.End()
 	}()
-
+ 
 	query := fmt.Sprintf(`
         SELECT id, workflow_id, container_id, user_id, status, trigger, scheduled_at, started_at, completed_at, attempts, created_at, updated_at
         FROM %s
         WHERE id = $1
         LIMIT 1;
     `, postgres.TableJobs)
-
+ 
 	rows, err := r.pg.Query(ctx, query, jobID)
 	if errors.Is(err, context.DeadlineExceeded) {
 		err = status.Error(codes.DeadlineExceeded, err.Error())
@@ -380,7 +387,7 @@ func (r *Repository) GetJobByID(ctx context.Context, jobID string) (res *jobsmod
 		err = status.Error(codes.Canceled, err.Error())
 		return nil, err
 	}
-
+ 
 	res, err = pgx.CollectExactlyOneRow(rows, pgx.RowToAddrOfStructByName[jobsmodel.GetJobByIDResponse])
 	if err != nil {
 		if r.pg.IsNoRows(err) {
@@ -390,14 +397,14 @@ func (r *Repository) GetJobByID(ctx context.Context, jobID string) (res *jobsmod
 			err = status.Errorf(codes.InvalidArgument, "invalid job ID: %v", err)
 			return nil, err
 		}
-
+ 
 		err = status.Errorf(codes.Internal, "failed to get job: %v", err)
 		return nil, err
 	}
-
+ 
 	return res, nil
 }
-
+ 
 // GetJobLogs returns the job logs by ID.
 //
 //nolint:gocyclo  // This function is complex due to the nature of having two separate queries.
@@ -418,14 +425,14 @@ func (r *Repository) GetJobLogs(
 		}
 		span.End()
 	}()
-
+ 
 	// Issue necessary headers and tokens for authorization
 	ctx, ctxErr := r.withAuthorization(ctx)
 	if ctxErr != nil {
 		err = ctxErr
 		return nil, "", err
 	}
-
+ 
 	// Validate workflow retention policy
 	workflow, workflowErr := r.svc.Workflows.GetWorkflow(ctx, &workflowspb.GetWorkflowRequest{
 		Id:     workflowID,
@@ -439,7 +446,7 @@ func (r *Repository) GetJobLogs(
 		err = status.Errorf(codes.FailedPrecondition, "logs retention is disabled for workflow: %s", workflowID)
 		return nil, "", err
 	}
-
+ 
 	ascending := sortOrder == jobsmodel.JobLogsSortOrderAsc
 	logQueryArgs := []any{jobID, workflowID, userID}
 	logsQuery := fmt.Sprintf(`
@@ -447,21 +454,21 @@ func (r *Repository) GetJobLogs(
     FROM %s
     WHERE job_id = $1 AND workflow_id = $2 AND user_id = $3
     `, clickhouse.TableJobLogs)
-
+ 
 	switch getJobLogsFilters.Stream {
 	case 1:
 		logsQuery += ` AND stream = 'stdout'`
 	case 2:
 		logsQuery += ` AND stream = 'stderr'`
 	}
-
+ 
 	if cursor != "" {
 		logsCursor, _err := extractDataFromGetJobLogsCursor(cursor)
 		if _err != nil {
 			err = _err
 			return nil, "", err
 		}
-
+ 
 		sequenceOperator := "<"
 		if ascending {
 			sequenceOperator = ">"
@@ -473,7 +480,7 @@ func (r *Repository) GetJobLogs(
             )`
 		logQueryArgs = append(logQueryArgs, logsCursor.SequenceNum, logsCursor.Stream, logsCursor.EventID)
 	}
-
+ 
 	sequenceDirection := "DESC"
 	if ascending {
 		sequenceDirection = "ASC"
@@ -484,14 +491,14 @@ func (r *Repository) GetJobLogs(
     LIMIT 1 BY event_id
     LIMIT %d;
     `, sequenceDirection, r.cfg.LogsFetchLimit+1)
-
+ 
 	statusQueryArgs := []any{jobID, workflowID, userID}
 	statusQuery := fmt.Sprintf(`
         SELECT status, completed_at
         FROM %s
         WHERE id = $1 AND workflow_id = $2 AND user_id = $3
     `, postgres.TableJobs)
-
+ 
 	eg, egCtx := errgroup.WithContext(ctx)
 	var (
 		logs          []*jobsmodel.JobLog
@@ -499,7 +506,7 @@ func (r *Repository) GetJobLogs(
 		fetchedStatus string
 		completedAt   sql.NullTime
 	)
-
+ 
 	eg.Go(func() error {
 		rows, qErr := r.ch.Query(egCtx, logsQuery, logQueryArgs...)
 		if qErr != nil {
@@ -511,7 +518,7 @@ func (r *Repository) GetJobLogs(
 			return status.Errorf(codes.NotFound, "no logs found for job: %v", qErr)
 		}
 		defer rows.Close()
-
+ 
 		tmp := make([]*jobsmodel.JobLog, 0, r.cfg.LogsFetchLimit+1)
 		tmpCursors := make([]jobLogsCursor, 0, r.cfg.LogsFetchLimit+1)
 		for rows.Next() {
@@ -541,7 +548,7 @@ func (r *Repository) GetJobLogs(
 		if rowsErr := rows.Err(); rowsErr != nil {
 			return status.Errorf(codes.Internal, "rows error: %v", rowsErr)
 		}
-
+ 
 		// Check if there are more logs
 		if len(tmp) > r.cfg.LogsFetchLimit {
 			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
@@ -550,10 +557,10 @@ func (r *Repository) GetJobLogs(
 		logs = tmp
 		return nil
 	})
-
+ 
 	eg.Go(func() error {
 		row := r.pg.QueryRow(egCtx, statusQuery, statusQueryArgs...)
-
+ 
 		//nolint:gocritic // Ifelse is used to handle different error types
 		if scanErr := row.Scan(&fetchedStatus, &completedAt); scanErr != nil {
 			if errors.Is(scanErr, context.DeadlineExceeded) {
@@ -565,25 +572,25 @@ func (r *Repository) GetJobLogs(
 			} else if r.pg.IsInvalidTextRepresentation(scanErr) {
 				return status.Errorf(codes.InvalidArgument, "invalid job ID: %v", scanErr)
 			}
-
+ 
 			return status.Errorf(codes.Internal, "failed to get job: %v", scanErr)
 		}
-
+ 
 		return nil
 	})
-
+ 
 	err = eg.Wait()
 	if err != nil {
 		return nil, "", err
 	}
-
+ 
 	// Buffer-based status override:
 	// If the job just completed within the buffer window, we may not have all logs yet.
 	// Treat it as "RUNNING" temporarily.
 	if completedAt.Valid && time.Since(completedAt.Time) <= jobStatusUpdateBuffer {
 		fetchedStatus = jobsmodel.JobStatusRunning.ToString()
 	}
-
+ 
 	return &jobsmodel.GetJobLogsResponse{
 		ID:         jobID,
 		WorkflowID: workflowID,
@@ -591,7 +598,7 @@ func (r *Repository) GetJobLogs(
 		Cursor:     encodeJobLogsCursor(nextCursor),
 	}, fetchedStatus, nil
 }
-
+ 
 // StreamJobLogs returns a subscription to stream job logs.
 func (r *Repository) StreamJobLogs(ctx context.Context, jobID, workflowID, userID string) (sub *goredis.PubSub, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.StreamJobLogs")
@@ -602,14 +609,14 @@ func (r *Repository) StreamJobLogs(ctx context.Context, jobID, workflowID, userI
 		}
 		span.End()
 	}()
-
+ 
 	// Issue necessary headers and tokens for authorization
 	ctx, ctxErr := r.withAuthorization(ctx)
 	if ctxErr != nil {
 		err = ctxErr
 		return nil, err
 	}
-
+ 
 	// Validate workflow retention policy
 	workflow, workflowErr := r.svc.Workflows.GetWorkflow(ctx, &workflowspb.GetWorkflowRequest{
 		Id:     workflowID,
@@ -623,7 +630,7 @@ func (r *Repository) StreamJobLogs(ctx context.Context, jobID, workflowID, userI
 		err = status.Errorf(codes.FailedPrecondition, "logs retention is disabled for workflow: %s", workflowID)
 		return nil, err
 	}
-
+ 
 	// Validate whether the user has access to the job
 	query := fmt.Sprintf(`
         SELECT id, status
@@ -649,20 +656,20 @@ func (r *Repository) StreamJobLogs(ctx context.Context, jobID, workflowID, userI
 			err = status.Errorf(codes.InvalidArgument, "invalid job ID: %v", err)
 			return nil, err
 		}
-
+ 
 		err = status.Errorf(codes.Internal, "failed to validate job: %v", err)
 		return nil, err
 	}
-
+ 
 	if jobStatus != jobsmodel.JobStatusRunning.ToString() {
 		err = status.Errorf(codes.FailedPrecondition, "job is not running: %s", jobStatus)
 		return nil, err
 	}
-
+ 
 	// Subscribe to job-specific channel
 	return r.rdb.Subscribe(ctx, redis.GetJobLogsChannel(jobID)), nil
 }
-
+ 
 // SearchJobLogs returns the filtered logs of a job.
 //
 //nolint:gocyclo // This function is complex and has multiple responsibilities.
@@ -673,6 +680,7 @@ func (r *Repository) SearchJobLogs(
 	userID,
 	cursor string,
 	searchJobLogsFilters *jobsmodel.SearchJobLogsFilters,
+	options jobsmodel.SearchJobLogsOptions,
 ) (res *jobsmodel.GetJobLogsResponse, jobStatus string, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.SearchJobLogs")
 	defer func() {
@@ -682,14 +690,14 @@ func (r *Repository) SearchJobLogs(
 		}
 		span.End()
 	}()
-
+ 
 	// Issue necessary headers and tokens for authorization
 	ctx, ctxErr := r.withAuthorization(ctx)
 	if ctxErr != nil {
 		err = ctxErr
 		return nil, "", err
 	}
-
+ 
 	// Validate workflow retention policy
 	workflow, workflowErr := r.svc.Workflows.GetWorkflow(ctx, &workflowspb.GetWorkflowRequest{
 		Id:     workflowID,
@@ -703,43 +711,52 @@ func (r *Repository) SearchJobLogs(
 		err = status.Errorf(codes.FailedPrecondition, "logs retention is disabled for workflow: %s", workflowID)
 		return nil, "", err
 	}
-
+ 
 	filter := fmt.Sprintf(
 		`user_id = %q AND workflow_id = %q AND job_id = %q`,
 		userID,
 		workflowID,
 		jobID,
 	)
-
+ 
 	switch searchJobLogsFilters.Stream {
 	case 1:
 		filter += fmt.Sprintf(` AND stream = %q`, "stdout")
 	case 2:
 		filter += fmt.Sprintf(` AND stream = %q`, "stderr")
 	}
-
+ 
+	ascending := options.SortOrder == jobsmodel.JobLogsSortOrderAsc
+ 
 	if cursor != "" {
 		logsCursor, _err := extractDataFromGetJobLogsCursor(cursor)
 		if _err != nil {
 			err = _err
 			return nil, "", err
 		}
-
+ 
+		sequenceOperator := "<"
+		idOperator := ">="
+		if ascending {
+			sequenceOperator = ">"
+		}
 		filter += fmt.Sprintf(
-			` AND (sequence_num < %d OR (sequence_num = %d AND id >= %q))`,
+			` AND (sequence_num %s %d OR (sequence_num = %d AND id %s %q))`,
+			sequenceOperator,
 			logsCursor.SequenceNum,
 			logsCursor.SequenceNum,
+			idOperator,
 			logsCursor.EventID,
 		)
 	}
-
+ 
 	statusQueryArgs := []any{jobID, workflowID, userID}
 	statusQuery := fmt.Sprintf(`
         SELECT status, completed_at
         FROM %s
         WHERE id = $1 AND workflow_id = $2 AND user_id = $3
     `, postgres.TableJobs)
-
+ 
 	eg, egCtx := errgroup.WithContext(ctx)
 	var (
 		logs          []*jobsmodel.JobLog
@@ -747,24 +764,26 @@ func (r *Repository) SearchJobLogs(
 		fetchedStatus string
 		completedAt   sql.NullTime
 	)
-
+	highlightToken := ""
+	if !options.DisableHighlight {
+		var tokenErr error
+		highlightToken, tokenErr = newJobLogsHighlightToken()
+		if tokenErr != nil {
+			err = tokenErr
+			return nil, "", err
+		}
+	}
+ 
 	eg.Go(func() error {
 		searchRes, searchErr := r.ms.Index(meilisearchpkg.IndexJobLogs).SearchWithContext(
 			egCtx,
 			searchJobLogsFilters.Message,
-			&meilisearch.SearchRequest{
-				Filter:                filter,
-				AttributesToRetrieve:  []string{"id", "event_id", "message", "sequence_num", "stream", "timestamp"},
-				AttributesToHighlight: []string{"message"},
-				AttributesToSearchOn:  []string{"message"},
-				Sort:                  []string{"sequence_num:desc", "id:asc"},
-				Limit:                 int64(r.cfg.LogsFetchLimit + 1),
-			},
+			newJobLogsSearchRequest(filter, highlightToken, int64(r.cfg.LogsFetchLimit+1), options),
 		)
 		if searchErr != nil {
 			return status.Errorf(codes.Internal, "failed to search job logs: %v", searchErr)
 		}
-
+ 
 		tmp := make([]*jobsmodel.JobLog, 0, len(searchRes.Hits))
 		tmpCursors := make([]jobLogsCursor, 0, len(searchRes.Hits))
 		for _, hit := range searchRes.Hits {
@@ -772,7 +791,7 @@ func (r *Repository) SearchJobLogs(
 			if scanErr != nil {
 				return scanErr
 			}
-
+ 
 			log := &jobsmodel.JobLog{}
 			if ts, ok := source["timestamp"].(string); ok {
 				parsed, scanErr := time.Parse(time.RFC3339Nano, ts)
@@ -781,16 +800,16 @@ func (r *Repository) SearchJobLogs(
 				}
 				log.Timestamp = parsed
 			}
-
+ 
 			log.EventID = searchHitString(source, "event_id")
 			if log.EventID == "" {
 				log.EventID = searchHitString(source, "id")
 			}
-
+ 
 			if msg, ok := source["message"].(string); ok {
 				log.Message = msg
 			}
-
+ 
 			switch sn := source["sequence_num"].(type) {
 			case string:
 				snVal, scanErr := strconv.ParseUint(sn, 10, 32)
@@ -801,11 +820,11 @@ func (r *Repository) SearchJobLogs(
 			case float64:
 				log.SequenceNum = uint32(sn)
 			}
-
+ 
 			if stream, ok := source["stream"].(string); ok {
 				log.Stream = stream
 			}
-
+ 
 			tmp = append(tmp, log)
 			tmpCursors = append(tmpCursors, jobLogsCursor{
 				SequenceNum: log.SequenceNum,
@@ -813,7 +832,7 @@ func (r *Repository) SearchJobLogs(
 				EventID:     searchHitString(source, "id"),
 			})
 		}
-
+ 
 		// Check if there are more logs
 		if len(tmp) > r.cfg.LogsFetchLimit {
 			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
@@ -822,10 +841,10 @@ func (r *Repository) SearchJobLogs(
 		logs = tmp
 		return nil
 	})
-
+ 
 	eg.Go(func() error {
 		row := r.pg.QueryRow(egCtx, statusQuery, statusQueryArgs...)
-
+ 
 		//nolint:gocritic // Ifelse is used to handle different error types
 		if scanErr := row.Scan(&fetchedStatus, &completedAt); scanErr != nil {
 			if errors.Is(scanErr, context.DeadlineExceeded) {
@@ -837,33 +856,34 @@ func (r *Repository) SearchJobLogs(
 			} else if r.pg.IsInvalidTextRepresentation(scanErr) {
 				return status.Errorf(codes.InvalidArgument, "invalid job ID: %v", scanErr)
 			}
-
+ 
 			return status.Errorf(codes.Internal, "failed to get job: %v", scanErr)
 		}
-
+ 
 		return nil
 	})
-
+ 
 	err = eg.Wait()
 	if err != nil {
 		return nil, "", err
 	}
-
+ 
 	// Buffer-based status override:
 	// If the job just completed within the buffer window, we may not have all logs yet.
 	// Treat it as "RUNNING" temporarily.
 	if completedAt.Valid && time.Since(completedAt.Time) <= jobStatusUpdateBuffer {
 		fetchedStatus = jobsmodel.JobStatusRunning.ToString()
 	}
-
+ 
 	return &jobsmodel.GetJobLogsResponse{
-		ID:         jobID,
-		WorkflowID: workflowID,
-		JobLogs:    logs,
-		Cursor:     encodeJobLogsCursor(nextCursor),
+		ID:             jobID,
+		WorkflowID:     workflowID,
+		JobLogs:        logs,
+		Cursor:         encodeJobLogsCursor(nextCursor),
+		HighlightToken: highlightToken,
 	}, fetchedStatus, nil
 }
-
+ 
 // ListJobs returns jobs.
 func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor string, filters *jobsmodel.ListJobsFilters) (res *jobsmodel.ListJobsResponse, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.ListJobs")
@@ -874,7 +894,7 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 		}
 		span.End()
 	}()
-
+ 
 	// Add the cursor to the query
 	query := fmt.Sprintf(`
         SELECT id, workflow_id, container_id, status, trigger, attempts, scheduled_at, started_at, completed_at, created_at, updated_at
@@ -884,7 +904,7 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 	args := []any{workflowID, userID}
 	// This is used to track the parameter index for the query dynamically
 	paramIndex := 3
-
+ 
 	// Apply filters if provided
 	if filters != nil {
 		if filters.Status != "" {
@@ -892,27 +912,27 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 			args = append(args, filters.Status)
 			paramIndex++
 		}
-
+ 
 		if filters.Trigger != "" {
 			query += fmt.Sprintf(` AND trigger = $%d`, paramIndex)
 			args = append(args, filters.Trigger)
 			paramIndex++
 		}
 	}
-
+ 
 	if cursor != "" {
 		id, createdAt, _err := extractDataFromListJobsCursor(cursor)
 		if _err != nil {
 			err = _err
 			return nil, err
 		}
-
+ 
 		query += fmt.Sprintf(` AND (created_at, id) <= ($%d, $%d)`, paramIndex, paramIndex+1)
 		args = append(args, createdAt, id)
 	}
-
+ 
 	query += fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT %d;`, r.cfg.FetchLimit+1)
-
+ 
 	rows, err := r.pg.Query(ctx, query, args...)
 	if errors.Is(err, context.DeadlineExceeded) {
 		err = status.Error(codes.DeadlineExceeded, err.Error())
@@ -921,18 +941,18 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 		err = status.Error(codes.Canceled, err.Error())
 		return nil, err
 	}
-
+ 
 	data, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[jobsmodel.JobByWorkflowIDResponse])
 	if err != nil {
 		if r.pg.IsInvalidTextRepresentation(err) {
 			err = status.Errorf(codes.InvalidArgument, "invalid job ID: %v", err)
 			return nil, err
 		}
-
+ 
 		err = status.Errorf(codes.Internal, "failed to list all jobs: %v", err)
 		return nil, err
 	}
-
+ 
 	// Check if there are more jobs
 	cursor = ""
 	if len(data) > r.cfg.FetchLimit {
@@ -944,65 +964,103 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 		)
 		data = data[:r.cfg.FetchLimit]
 	}
-
+ 
 	return &jobsmodel.ListJobsResponse{
 		Jobs:   data,
 		Cursor: encodeListJobsCursor(cursor),
 	}, nil
 }
-
+ 
 // withAuthorization issues the necessary headers and tokens for authorization.
 func (r *Repository) withAuthorization(ctx context.Context) (context.Context, error) {
 	return auth.WithInternalServiceAuthorization(ctx, r.auth, authSubject)
 }
-
+ 
 // parseTime parses the time.
 func parseTime(t string) (time.Time, error) {
 	return time.Parse(time.RFC3339Nano, t)
 }
-
+ 
 // encodeJobLogsCursor encodes the cursor for descending log pagination.
 func encodeJobLogsCursor(cursor jobLogsCursor) string {
 	if cursor.SequenceNum == 0 && cursor.Stream == "" && cursor.EventID == "" {
 		return ""
 	}
-
+ 
 	payload, err := json.Marshal(cursor)
 	if err != nil {
 		return ""
 	}
-
+ 
 	return base64.StdEncoding.EncodeToString(payload)
 }
-
+ 
 // encodeListJobsCursor encodes the cursor.
 func encodeListJobsCursor(cursor string) string {
 	if cursor == "" {
 		return ""
 	}
-
+ 
 	return base64.StdEncoding.EncodeToString([]byte(cursor))
 }
-
+ 
+func newJobLogsHighlightToken() (string, error) {
+	token := make([]byte, jobLogsHighlightTokenBytes)
+	if _, err := rand.Read(token); err != nil {
+		return "", status.Errorf(codes.Internal, "failed to generate log highlight token: %v", err)
+	}
+ 
+	return hex.EncodeToString(token), nil
+}
+ 
+func jobLogsHighlightTags(token string) (startTag, endTag string) {
+	return jobLogsHighlightStart + token + jobLogsHighlightSuffix,
+		jobLogsHighlightEnd + token + jobLogsHighlightSuffix
+}
+ 
+func newJobLogsSearchRequest(filter, highlightToken string, limit int64, options jobsmodel.SearchJobLogsOptions) *meilisearch.SearchRequest {
+	sequenceDirection := "desc"
+	if options.SortOrder == jobsmodel.JobLogsSortOrderAsc {
+		sequenceDirection = "asc"
+	}
+ 
+	req := &meilisearch.SearchRequest{
+		Filter:               filter,
+		AttributesToRetrieve: []string{"id", "event_id", "message", "sequence_num", "stream", "timestamp"},
+		AttributesToSearchOn: []string{"message"},
+		Sort:                 []string{"sequence_num:" + sequenceDirection, "id:asc"},
+		Limit:                limit,
+	}
+ 
+	if !options.DisableHighlight {
+		highlightPreTag, highlightPostTag := jobLogsHighlightTags(highlightToken)
+		req.AttributesToHighlight = []string{"message"}
+		req.HighlightPreTag = highlightPreTag
+		req.HighlightPostTag = highlightPostTag
+	}
+ 
+	return req
+}
+ 
 // extractDataFromGetJobLogsCursor extracts the data from the cursor.
 func extractDataFromGetJobLogsCursor(cursor string) (jobLogsCursor, error) {
 	decodedBytes, err := base64.StdEncoding.DecodeString(cursor)
 	if err != nil {
 		return jobLogsCursor{}, status.Errorf(codes.InvalidArgument, "invalid cursor: %v", err)
 	}
-
+ 
 	var logsCursor jobLogsCursor
 	if err = json.Unmarshal(decodedBytes, &logsCursor); err != nil {
 		return jobLogsCursor{}, status.Errorf(codes.InvalidArgument, "invalid cursor format: %v", err)
 	}
-
+ 
 	if logsCursor.Stream == "" || logsCursor.EventID == "" {
 		return jobLogsCursor{}, status.Errorf(codes.InvalidArgument, "invalid cursor format")
 	}
-
+ 
 	return logsCursor, nil
 }
-
+ 
 func searchHitString(source map[string]any, field string) string {
 	if source == nil {
 		return ""
@@ -1011,29 +1069,29 @@ func searchHitString(source map[string]any, field string) string {
 	if !ok {
 		return ""
 	}
-
+ 
 	return value
 }
-
+ 
 func searchHitSource(hit map[string]json.RawMessage) (map[string]any, error) {
 	source := make(map[string]any)
 	for k, v := range hit {
 		if k == "_formatted" {
 			continue
 		}
-
+ 
 		var val any
 		if err := json.Unmarshal(v, &val); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to unmarshal data: %v", err)
 		}
 		source[k] = val
 	}
-
+ 
 	formattedRaw, ok := hit["_formatted"]
 	if !ok {
 		return source, nil
 	}
-
+ 
 	var formatted map[string]any
 	if err := json.Unmarshal(formattedRaw, &formatted); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to unmarshal data: %v", err)
@@ -1041,21 +1099,21 @@ func searchHitSource(hit map[string]json.RawMessage) (map[string]any, error) {
 	if msg, ok := formatted["message"].(string); ok {
 		source["message"] = msg
 	}
-
+ 
 	return source, nil
 }
-
+ 
 // extractDataFromListJobsCursor extracts the data from the cursor.
 func extractDataFromListJobsCursor(cursor string) (string, time.Time, error) {
 	parts := bytes.Split([]byte(cursor), []byte{delimiter})
 	if len(parts) != 2 {
 		return "", time.Time{}, status.Error(codes.InvalidArgument, "invalid cursor: expected two parts")
 	}
-
+ 
 	createdAt, err := time.Parse(time.RFC3339Nano, string(parts[1]))
 	if err != nil {
 		return "", time.Time{}, status.Errorf(codes.InvalidArgument, "invalid timestamp: %v", err)
 	}
-
+ 
 	return string(parts[0]), createdAt, nil
 }

--- a/internal/repository/jobs/jobs.go
+++ b/internal/repository/jobs/jobs.go
@@ -1,5 +1,5 @@
 package jobs
- 
+
 import (
 	"bytes"
 	"context"
@@ -12,20 +12,20 @@ import (
 	"fmt"
 	"strconv"
 	"time"
- 
+
 	"go.opentelemetry.io/otel"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
- 
+
 	"github.com/jackc/pgx/v5"
 	"github.com/meilisearch/meilisearch-go"
 	goredis "github.com/redis/go-redis/v9"
- 
+
 	workflowspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/workflows"
- 
+
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/clickhouse"
@@ -35,35 +35,35 @@ import (
 	"github.com/hitesh22rana/chronoverse/internal/pkg/redis"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
- 
+
 const (
 	authSubject           = "internal/jobs"
 	delimiter             = '$'
 	jobStatusUpdateBuffer = time.Minute // 1 minute
- 
+
 	jobLogsHighlightTokenBytes = 16
 	jobLogsHighlightStart      = "__CV_HL_START_"
 	jobLogsHighlightEnd        = "__CV_HL_END_"
 	jobLogsHighlightSuffix     = "__"
 )
- 
+
 type jobLogsCursor struct {
 	SequenceNum uint32 `json:"sequence_num"`
 	Stream      string `json:"stream,omitempty"`
 	EventID     string `json:"event_id,omitempty"`
 }
- 
+
 // Services represents the services used by the executor.
 type Services struct {
 	Workflows workflowspb.WorkflowsServiceClient
 }
- 
+
 // Config represents the repository constants configuration.
 type Config struct {
 	FetchLimit     int
 	LogsFetchLimit int
 }
- 
+
 // Repository provides jobs repository.
 type Repository struct {
 	tp   trace.Tracer
@@ -75,7 +75,7 @@ type Repository struct {
 	ms   meilisearch.ServiceManager
 	svc  *Services
 }
- 
+
 // New creates a new jobs repository.
 func New(cfg *Config, auth auth.IAuth, pg *postgres.Postgres, rdb *redis.Store, ch *clickhouse.Client, ms meilisearch.ServiceManager, svc *Services) *Repository {
 	return &Repository{
@@ -89,7 +89,7 @@ func New(cfg *Config, auth auth.IAuth, pg *postgres.Postgres, rdb *redis.Store, 
 		svc:  svc,
 	}
 }
- 
+
 // ScheduleJob schedules a job.
 func (r *Repository) ScheduleJob(
 	ctx context.Context,
@@ -108,13 +108,13 @@ func (r *Repository) ScheduleJob(
 		}
 		span.End()
 	}()
- 
+
 	scheduledAtTime, err := parseTime(scheduledAt)
 	if err != nil {
 		err = status.Errorf(codes.InvalidArgument, "invalid scheduled_at time format: %v", err)
 		return "", err
 	}
- 
+
 	idempotencyKey, automaticIdempotencyKeyProvided := normalizeScheduleJobIdempotencyKey(
 		workflowID,
 		scheduledAtTime,
@@ -133,7 +133,7 @@ func (r *Repository) ScheduleJob(
 	if err != nil {
 		return "", err
 	}
- 
+
 	row := r.pg.QueryRow(ctx, query, args...)
 	if err = row.Scan(&jobID); err != nil {
 		switch {
@@ -147,14 +147,14 @@ func (r *Repository) ScheduleJob(
 			err = status.Errorf(codes.FailedPrecondition, "workflow generation mismatch or workflow is not schedulable")
 			return "", err
 		}
- 
+
 		err = status.Errorf(codes.Internal, "failed to insert job: %v", err)
 		return "", err
 	}
- 
+
 	return jobID, nil
 }
- 
+
 func normalizeScheduleJobIdempotencyKey(
 	workflowID string,
 	scheduledAt time.Time,
@@ -165,10 +165,10 @@ func normalizeScheduleJobIdempotencyKey(
 	if trigger == jobsmodel.JobTriggerAutomatic.ToString() && !automaticIdempotencyKeyProvided {
 		idempotencyKey = idempotency.JobDispatchEventKey(fmt.Sprintf("%s:%s", workflowID, scheduledAt.Format(time.RFC3339Nano)))
 	}
- 
+
 	return idempotencyKey, automaticIdempotencyKeyProvided
 }
- 
+
 func scheduleJobInsertStatement(
 	workflowID,
 	userID string,
@@ -182,7 +182,7 @@ func scheduleJobInsertStatement(
 	if trigger == jobsmodel.JobTriggerAutomatic.ToString() && workflowGeneration > 0 {
 		args = append(args, workflowGeneration)
 	}
- 
+
 	switch {
 	case trigger == jobsmodel.JobTriggerManual.ToString():
 		return fmt.Sprintf(`
@@ -219,12 +219,12 @@ func scheduleJobInsertStatement(
 		return "", nil, status.Errorf(codes.InvalidArgument, "invalid job trigger: %s", trigger)
 	}
 }
- 
+
 func automaticScheduleGuardSQL(workflowGeneration int64) string {
 	if workflowGeneration <= 0 {
 		return ""
 	}
- 
+
 	return fmt.Sprintf(`
             FROM %s AS w
             WHERE w.id = $1
@@ -235,7 +235,7 @@ func automaticScheduleGuardSQL(workflowGeneration int64) string {
             FOR SHARE
     `, postgres.TableWorkflows)
 }
- 
+
 // UpdateJobStatus updates the job details.
 func (r *Repository) UpdateJobStatus(ctx context.Context, jobID, containerID, jobStatus string) (err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.UpdateJobStatus")
@@ -246,12 +246,12 @@ func (r *Repository) UpdateJobStatus(ctx context.Context, jobID, containerID, jo
 		}
 		span.End()
 	}()
- 
+
 	query := fmt.Sprintf(`
     UPDATE %s
     SET status = $1`, postgres.TableJobs)
 	args := []any{jobStatus}
- 
+
 	switch jobStatus {
 	case jobsmodel.JobStatusRunning.ToString():
 		if containerID == "" {
@@ -284,7 +284,7 @@ func (r *Repository) UpdateJobStatus(ctx context.Context, jobID, containerID, jo
 		query += ` WHERE id = $2;`
 		args = append(args, jobID)
 	}
- 
+
 	// Execute the query
 	ct, err := r.pg.Exec(ctx, query, args...)
 	//nolint:gocritic // Ifelse is used to handle different error types
@@ -299,24 +299,24 @@ func (r *Repository) UpdateJobStatus(ctx context.Context, jobID, containerID, jo
 			err = status.Errorf(codes.InvalidArgument, "invalid job ID: %v", err)
 			return err
 		}
- 
+
 		err = status.Errorf(codes.Internal, "failed to update job: %v", err)
 		return err
 	}
- 
+
 	if ct.RowsAffected() == 0 {
 		if jobStatus == jobsmodel.JobStatusCanceled.ToString() {
 			err = status.Errorf(codes.FailedPrecondition, "job not found or not cancellable")
 			return err
 		}
- 
+
 		err = status.Errorf(codes.NotFound, "job not found")
 		return err
 	}
- 
+
 	return nil
 }
- 
+
 // GetJob returns the job details by ID and Job ID and user ID.
 func (r *Repository) GetJob(ctx context.Context, jobID, workflowID, userID string) (res *jobsmodel.GetJobResponse, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.GetJob")
@@ -327,14 +327,14 @@ func (r *Repository) GetJob(ctx context.Context, jobID, workflowID, userID strin
 		}
 		span.End()
 	}()
- 
+
 	query := fmt.Sprintf(`
         SELECT id, workflow_id, status, trigger, scheduled_at, started_at, completed_at, created_at, updated_at
         FROM %s
         WHERE id = $1 AND workflow_id = $2 AND user_id = $3
         LIMIT 1;
     `, postgres.TableJobs)
- 
+
 	rows, err := r.pg.Query(ctx, query, jobID, workflowID, userID)
 	if errors.Is(err, context.DeadlineExceeded) {
 		err = status.Error(codes.DeadlineExceeded, err.Error())
@@ -343,7 +343,7 @@ func (r *Repository) GetJob(ctx context.Context, jobID, workflowID, userID strin
 		err = status.Error(codes.Canceled, err.Error())
 		return nil, err
 	}
- 
+
 	res, err = pgx.CollectExactlyOneRow(rows, pgx.RowToAddrOfStructByName[jobsmodel.GetJobResponse])
 	if err != nil {
 		if r.pg.IsNoRows(err) {
@@ -353,14 +353,14 @@ func (r *Repository) GetJob(ctx context.Context, jobID, workflowID, userID strin
 			err = status.Errorf(codes.InvalidArgument, "invalid job ID: %v", err)
 			return nil, err
 		}
- 
+
 		err = status.Errorf(codes.Internal, "failed to get job: %v", err)
 		return nil, err
 	}
- 
+
 	return res, nil
 }
- 
+
 // GetJobByID returns the job details by ID.
 func (r *Repository) GetJobByID(ctx context.Context, jobID string) (res *jobsmodel.GetJobByIDResponse, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.GetJobByID")
@@ -371,14 +371,14 @@ func (r *Repository) GetJobByID(ctx context.Context, jobID string) (res *jobsmod
 		}
 		span.End()
 	}()
- 
+
 	query := fmt.Sprintf(`
         SELECT id, workflow_id, container_id, user_id, status, trigger, scheduled_at, started_at, completed_at, attempts, created_at, updated_at
         FROM %s
         WHERE id = $1
         LIMIT 1;
     `, postgres.TableJobs)
- 
+
 	rows, err := r.pg.Query(ctx, query, jobID)
 	if errors.Is(err, context.DeadlineExceeded) {
 		err = status.Error(codes.DeadlineExceeded, err.Error())
@@ -387,7 +387,7 @@ func (r *Repository) GetJobByID(ctx context.Context, jobID string) (res *jobsmod
 		err = status.Error(codes.Canceled, err.Error())
 		return nil, err
 	}
- 
+
 	res, err = pgx.CollectExactlyOneRow(rows, pgx.RowToAddrOfStructByName[jobsmodel.GetJobByIDResponse])
 	if err != nil {
 		if r.pg.IsNoRows(err) {
@@ -397,14 +397,14 @@ func (r *Repository) GetJobByID(ctx context.Context, jobID string) (res *jobsmod
 			err = status.Errorf(codes.InvalidArgument, "invalid job ID: %v", err)
 			return nil, err
 		}
- 
+
 		err = status.Errorf(codes.Internal, "failed to get job: %v", err)
 		return nil, err
 	}
- 
+
 	return res, nil
 }
- 
+
 // GetJobLogs returns the job logs by ID.
 //
 //nolint:gocyclo  // This function is complex due to the nature of having two separate queries.
@@ -425,14 +425,14 @@ func (r *Repository) GetJobLogs(
 		}
 		span.End()
 	}()
- 
+
 	// Issue necessary headers and tokens for authorization
 	ctx, ctxErr := r.withAuthorization(ctx)
 	if ctxErr != nil {
 		err = ctxErr
 		return nil, "", err
 	}
- 
+
 	// Validate workflow retention policy
 	workflow, workflowErr := r.svc.Workflows.GetWorkflow(ctx, &workflowspb.GetWorkflowRequest{
 		Id:     workflowID,
@@ -446,7 +446,7 @@ func (r *Repository) GetJobLogs(
 		err = status.Errorf(codes.FailedPrecondition, "logs retention is disabled for workflow: %s", workflowID)
 		return nil, "", err
 	}
- 
+
 	ascending := sortOrder == jobsmodel.JobLogsSortOrderAsc
 	logQueryArgs := []any{jobID, workflowID, userID}
 	logsQuery := fmt.Sprintf(`
@@ -454,21 +454,21 @@ func (r *Repository) GetJobLogs(
     FROM %s
     WHERE job_id = $1 AND workflow_id = $2 AND user_id = $3
     `, clickhouse.TableJobLogs)
- 
+
 	switch getJobLogsFilters.Stream {
 	case 1:
 		logsQuery += ` AND stream = 'stdout'`
 	case 2:
 		logsQuery += ` AND stream = 'stderr'`
 	}
- 
+
 	if cursor != "" {
 		logsCursor, _err := extractDataFromGetJobLogsCursor(cursor)
 		if _err != nil {
 			err = _err
 			return nil, "", err
 		}
- 
+
 		sequenceOperator := "<"
 		if ascending {
 			sequenceOperator = ">"
@@ -480,7 +480,7 @@ func (r *Repository) GetJobLogs(
             )`
 		logQueryArgs = append(logQueryArgs, logsCursor.SequenceNum, logsCursor.Stream, logsCursor.EventID)
 	}
- 
+
 	sequenceDirection := "DESC"
 	if ascending {
 		sequenceDirection = "ASC"
@@ -491,14 +491,14 @@ func (r *Repository) GetJobLogs(
     LIMIT 1 BY event_id
     LIMIT %d;
     `, sequenceDirection, r.cfg.LogsFetchLimit+1)
- 
+
 	statusQueryArgs := []any{jobID, workflowID, userID}
 	statusQuery := fmt.Sprintf(`
         SELECT status, completed_at
         FROM %s
         WHERE id = $1 AND workflow_id = $2 AND user_id = $3
     `, postgres.TableJobs)
- 
+
 	eg, egCtx := errgroup.WithContext(ctx)
 	var (
 		logs          []*jobsmodel.JobLog
@@ -506,7 +506,7 @@ func (r *Repository) GetJobLogs(
 		fetchedStatus string
 		completedAt   sql.NullTime
 	)
- 
+
 	eg.Go(func() error {
 		rows, qErr := r.ch.Query(egCtx, logsQuery, logQueryArgs...)
 		if qErr != nil {
@@ -518,7 +518,7 @@ func (r *Repository) GetJobLogs(
 			return status.Errorf(codes.NotFound, "no logs found for job: %v", qErr)
 		}
 		defer rows.Close()
- 
+
 		tmp := make([]*jobsmodel.JobLog, 0, r.cfg.LogsFetchLimit+1)
 		tmpCursors := make([]jobLogsCursor, 0, r.cfg.LogsFetchLimit+1)
 		for rows.Next() {
@@ -548,7 +548,7 @@ func (r *Repository) GetJobLogs(
 		if rowsErr := rows.Err(); rowsErr != nil {
 			return status.Errorf(codes.Internal, "rows error: %v", rowsErr)
 		}
- 
+
 		// Check if there are more logs
 		if len(tmp) > r.cfg.LogsFetchLimit {
 			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
@@ -557,10 +557,10 @@ func (r *Repository) GetJobLogs(
 		logs = tmp
 		return nil
 	})
- 
+
 	eg.Go(func() error {
 		row := r.pg.QueryRow(egCtx, statusQuery, statusQueryArgs...)
- 
+
 		//nolint:gocritic // Ifelse is used to handle different error types
 		if scanErr := row.Scan(&fetchedStatus, &completedAt); scanErr != nil {
 			if errors.Is(scanErr, context.DeadlineExceeded) {
@@ -572,25 +572,25 @@ func (r *Repository) GetJobLogs(
 			} else if r.pg.IsInvalidTextRepresentation(scanErr) {
 				return status.Errorf(codes.InvalidArgument, "invalid job ID: %v", scanErr)
 			}
- 
+
 			return status.Errorf(codes.Internal, "failed to get job: %v", scanErr)
 		}
- 
+
 		return nil
 	})
- 
+
 	err = eg.Wait()
 	if err != nil {
 		return nil, "", err
 	}
- 
+
 	// Buffer-based status override:
 	// If the job just completed within the buffer window, we may not have all logs yet.
 	// Treat it as "RUNNING" temporarily.
 	if completedAt.Valid && time.Since(completedAt.Time) <= jobStatusUpdateBuffer {
 		fetchedStatus = jobsmodel.JobStatusRunning.ToString()
 	}
- 
+
 	return &jobsmodel.GetJobLogsResponse{
 		ID:         jobID,
 		WorkflowID: workflowID,
@@ -598,7 +598,7 @@ func (r *Repository) GetJobLogs(
 		Cursor:     encodeJobLogsCursor(nextCursor),
 	}, fetchedStatus, nil
 }
- 
+
 // StreamJobLogs returns a subscription to stream job logs.
 func (r *Repository) StreamJobLogs(ctx context.Context, jobID, workflowID, userID string) (sub *goredis.PubSub, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.StreamJobLogs")
@@ -609,14 +609,14 @@ func (r *Repository) StreamJobLogs(ctx context.Context, jobID, workflowID, userI
 		}
 		span.End()
 	}()
- 
+
 	// Issue necessary headers and tokens for authorization
 	ctx, ctxErr := r.withAuthorization(ctx)
 	if ctxErr != nil {
 		err = ctxErr
 		return nil, err
 	}
- 
+
 	// Validate workflow retention policy
 	workflow, workflowErr := r.svc.Workflows.GetWorkflow(ctx, &workflowspb.GetWorkflowRequest{
 		Id:     workflowID,
@@ -630,7 +630,7 @@ func (r *Repository) StreamJobLogs(ctx context.Context, jobID, workflowID, userI
 		err = status.Errorf(codes.FailedPrecondition, "logs retention is disabled for workflow: %s", workflowID)
 		return nil, err
 	}
- 
+
 	// Validate whether the user has access to the job
 	query := fmt.Sprintf(`
         SELECT id, status
@@ -656,20 +656,20 @@ func (r *Repository) StreamJobLogs(ctx context.Context, jobID, workflowID, userI
 			err = status.Errorf(codes.InvalidArgument, "invalid job ID: %v", err)
 			return nil, err
 		}
- 
+
 		err = status.Errorf(codes.Internal, "failed to validate job: %v", err)
 		return nil, err
 	}
- 
+
 	if jobStatus != jobsmodel.JobStatusRunning.ToString() {
 		err = status.Errorf(codes.FailedPrecondition, "job is not running: %s", jobStatus)
 		return nil, err
 	}
- 
+
 	// Subscribe to job-specific channel
 	return r.rdb.Subscribe(ctx, redis.GetJobLogsChannel(jobID)), nil
 }
- 
+
 // SearchJobLogs returns the filtered logs of a job.
 //
 //nolint:gocyclo // This function is complex and has multiple responsibilities.
@@ -690,14 +690,14 @@ func (r *Repository) SearchJobLogs(
 		}
 		span.End()
 	}()
- 
+
 	// Issue necessary headers and tokens for authorization
 	ctx, ctxErr := r.withAuthorization(ctx)
 	if ctxErr != nil {
 		err = ctxErr
 		return nil, "", err
 	}
- 
+
 	// Validate workflow retention policy
 	workflow, workflowErr := r.svc.Workflows.GetWorkflow(ctx, &workflowspb.GetWorkflowRequest{
 		Id:     workflowID,
@@ -711,30 +711,30 @@ func (r *Repository) SearchJobLogs(
 		err = status.Errorf(codes.FailedPrecondition, "logs retention is disabled for workflow: %s", workflowID)
 		return nil, "", err
 	}
- 
+
 	filter := fmt.Sprintf(
 		`user_id = %q AND workflow_id = %q AND job_id = %q`,
 		userID,
 		workflowID,
 		jobID,
 	)
- 
+
 	switch searchJobLogsFilters.Stream {
 	case 1:
 		filter += fmt.Sprintf(` AND stream = %q`, "stdout")
 	case 2:
 		filter += fmt.Sprintf(` AND stream = %q`, "stderr")
 	}
- 
+
 	ascending := options.SortOrder == jobsmodel.JobLogsSortOrderAsc
- 
+
 	if cursor != "" {
 		logsCursor, _err := extractDataFromGetJobLogsCursor(cursor)
 		if _err != nil {
 			err = _err
 			return nil, "", err
 		}
- 
+
 		sequenceOperator := "<"
 		idOperator := ">="
 		if ascending {
@@ -749,14 +749,14 @@ func (r *Repository) SearchJobLogs(
 			logsCursor.EventID,
 		)
 	}
- 
+
 	statusQueryArgs := []any{jobID, workflowID, userID}
 	statusQuery := fmt.Sprintf(`
         SELECT status, completed_at
         FROM %s
         WHERE id = $1 AND workflow_id = $2 AND user_id = $3
     `, postgres.TableJobs)
- 
+
 	eg, egCtx := errgroup.WithContext(ctx)
 	var (
 		logs          []*jobsmodel.JobLog
@@ -773,7 +773,7 @@ func (r *Repository) SearchJobLogs(
 			return nil, "", err
 		}
 	}
- 
+
 	eg.Go(func() error {
 		searchRes, searchErr := r.ms.Index(meilisearchpkg.IndexJobLogs).SearchWithContext(
 			egCtx,
@@ -783,7 +783,7 @@ func (r *Repository) SearchJobLogs(
 		if searchErr != nil {
 			return status.Errorf(codes.Internal, "failed to search job logs: %v", searchErr)
 		}
- 
+
 		tmp := make([]*jobsmodel.JobLog, 0, len(searchRes.Hits))
 		tmpCursors := make([]jobLogsCursor, 0, len(searchRes.Hits))
 		for _, hit := range searchRes.Hits {
@@ -791,7 +791,7 @@ func (r *Repository) SearchJobLogs(
 			if scanErr != nil {
 				return scanErr
 			}
- 
+
 			log := &jobsmodel.JobLog{}
 			if ts, ok := source["timestamp"].(string); ok {
 				parsed, scanErr := time.Parse(time.RFC3339Nano, ts)
@@ -800,16 +800,16 @@ func (r *Repository) SearchJobLogs(
 				}
 				log.Timestamp = parsed
 			}
- 
+
 			log.EventID = searchHitString(source, "event_id")
 			if log.EventID == "" {
 				log.EventID = searchHitString(source, "id")
 			}
- 
+
 			if msg, ok := source["message"].(string); ok {
 				log.Message = msg
 			}
- 
+
 			switch sn := source["sequence_num"].(type) {
 			case string:
 				snVal, scanErr := strconv.ParseUint(sn, 10, 32)
@@ -820,11 +820,11 @@ func (r *Repository) SearchJobLogs(
 			case float64:
 				log.SequenceNum = uint32(sn)
 			}
- 
+
 			if stream, ok := source["stream"].(string); ok {
 				log.Stream = stream
 			}
- 
+
 			tmp = append(tmp, log)
 			tmpCursors = append(tmpCursors, jobLogsCursor{
 				SequenceNum: log.SequenceNum,
@@ -832,7 +832,7 @@ func (r *Repository) SearchJobLogs(
 				EventID:     searchHitString(source, "id"),
 			})
 		}
- 
+
 		// Check if there are more logs
 		if len(tmp) > r.cfg.LogsFetchLimit {
 			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
@@ -841,10 +841,10 @@ func (r *Repository) SearchJobLogs(
 		logs = tmp
 		return nil
 	})
- 
+
 	eg.Go(func() error {
 		row := r.pg.QueryRow(egCtx, statusQuery, statusQueryArgs...)
- 
+
 		//nolint:gocritic // Ifelse is used to handle different error types
 		if scanErr := row.Scan(&fetchedStatus, &completedAt); scanErr != nil {
 			if errors.Is(scanErr, context.DeadlineExceeded) {
@@ -856,25 +856,25 @@ func (r *Repository) SearchJobLogs(
 			} else if r.pg.IsInvalidTextRepresentation(scanErr) {
 				return status.Errorf(codes.InvalidArgument, "invalid job ID: %v", scanErr)
 			}
- 
+
 			return status.Errorf(codes.Internal, "failed to get job: %v", scanErr)
 		}
- 
+
 		return nil
 	})
- 
+
 	err = eg.Wait()
 	if err != nil {
 		return nil, "", err
 	}
- 
+
 	// Buffer-based status override:
 	// If the job just completed within the buffer window, we may not have all logs yet.
 	// Treat it as "RUNNING" temporarily.
 	if completedAt.Valid && time.Since(completedAt.Time) <= jobStatusUpdateBuffer {
 		fetchedStatus = jobsmodel.JobStatusRunning.ToString()
 	}
- 
+
 	return &jobsmodel.GetJobLogsResponse{
 		ID:             jobID,
 		WorkflowID:     workflowID,
@@ -883,7 +883,7 @@ func (r *Repository) SearchJobLogs(
 		HighlightToken: highlightToken,
 	}, fetchedStatus, nil
 }
- 
+
 // ListJobs returns jobs.
 func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor string, filters *jobsmodel.ListJobsFilters) (res *jobsmodel.ListJobsResponse, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.ListJobs")
@@ -894,7 +894,7 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 		}
 		span.End()
 	}()
- 
+
 	// Add the cursor to the query
 	query := fmt.Sprintf(`
         SELECT id, workflow_id, container_id, status, trigger, attempts, scheduled_at, started_at, completed_at, created_at, updated_at
@@ -904,7 +904,7 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 	args := []any{workflowID, userID}
 	// This is used to track the parameter index for the query dynamically
 	paramIndex := 3
- 
+
 	// Apply filters if provided
 	if filters != nil {
 		if filters.Status != "" {
@@ -912,27 +912,27 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 			args = append(args, filters.Status)
 			paramIndex++
 		}
- 
+
 		if filters.Trigger != "" {
 			query += fmt.Sprintf(` AND trigger = $%d`, paramIndex)
 			args = append(args, filters.Trigger)
 			paramIndex++
 		}
 	}
- 
+
 	if cursor != "" {
 		id, createdAt, _err := extractDataFromListJobsCursor(cursor)
 		if _err != nil {
 			err = _err
 			return nil, err
 		}
- 
+
 		query += fmt.Sprintf(` AND (created_at, id) <= ($%d, $%d)`, paramIndex, paramIndex+1)
 		args = append(args, createdAt, id)
 	}
- 
+
 	query += fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT %d;`, r.cfg.FetchLimit+1)
- 
+
 	rows, err := r.pg.Query(ctx, query, args...)
 	if errors.Is(err, context.DeadlineExceeded) {
 		err = status.Error(codes.DeadlineExceeded, err.Error())
@@ -941,18 +941,18 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 		err = status.Error(codes.Canceled, err.Error())
 		return nil, err
 	}
- 
+
 	data, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[jobsmodel.JobByWorkflowIDResponse])
 	if err != nil {
 		if r.pg.IsInvalidTextRepresentation(err) {
 			err = status.Errorf(codes.InvalidArgument, "invalid job ID: %v", err)
 			return nil, err
 		}
- 
+
 		err = status.Errorf(codes.Internal, "failed to list all jobs: %v", err)
 		return nil, err
 	}
- 
+
 	// Check if there are more jobs
 	cursor = ""
 	if len(data) > r.cfg.FetchLimit {
@@ -964,66 +964,66 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 		)
 		data = data[:r.cfg.FetchLimit]
 	}
- 
+
 	return &jobsmodel.ListJobsResponse{
 		Jobs:   data,
 		Cursor: encodeListJobsCursor(cursor),
 	}, nil
 }
- 
+
 // withAuthorization issues the necessary headers and tokens for authorization.
 func (r *Repository) withAuthorization(ctx context.Context) (context.Context, error) {
 	return auth.WithInternalServiceAuthorization(ctx, r.auth, authSubject)
 }
- 
+
 // parseTime parses the time.
 func parseTime(t string) (time.Time, error) {
 	return time.Parse(time.RFC3339Nano, t)
 }
- 
+
 // encodeJobLogsCursor encodes the cursor for descending log pagination.
 func encodeJobLogsCursor(cursor jobLogsCursor) string {
 	if cursor.SequenceNum == 0 && cursor.Stream == "" && cursor.EventID == "" {
 		return ""
 	}
- 
+
 	payload, err := json.Marshal(cursor)
 	if err != nil {
 		return ""
 	}
- 
+
 	return base64.StdEncoding.EncodeToString(payload)
 }
- 
+
 // encodeListJobsCursor encodes the cursor.
 func encodeListJobsCursor(cursor string) string {
 	if cursor == "" {
 		return ""
 	}
- 
+
 	return base64.StdEncoding.EncodeToString([]byte(cursor))
 }
- 
+
 func newJobLogsHighlightToken() (string, error) {
 	token := make([]byte, jobLogsHighlightTokenBytes)
 	if _, err := rand.Read(token); err != nil {
 		return "", status.Errorf(codes.Internal, "failed to generate log highlight token: %v", err)
 	}
- 
+
 	return hex.EncodeToString(token), nil
 }
- 
+
 func jobLogsHighlightTags(token string) (startTag, endTag string) {
 	return jobLogsHighlightStart + token + jobLogsHighlightSuffix,
 		jobLogsHighlightEnd + token + jobLogsHighlightSuffix
 }
- 
+
 func newJobLogsSearchRequest(filter, highlightToken string, limit int64, options jobsmodel.SearchJobLogsOptions) *meilisearch.SearchRequest {
 	sequenceDirection := "desc"
 	if options.SortOrder == jobsmodel.JobLogsSortOrderAsc {
 		sequenceDirection = "asc"
 	}
- 
+
 	req := &meilisearch.SearchRequest{
 		Filter:               filter,
 		AttributesToRetrieve: []string{"id", "event_id", "message", "sequence_num", "stream", "timestamp"},
@@ -1031,36 +1031,36 @@ func newJobLogsSearchRequest(filter, highlightToken string, limit int64, options
 		Sort:                 []string{"sequence_num:" + sequenceDirection, "id:asc"},
 		Limit:                limit,
 	}
- 
+
 	if !options.DisableHighlight {
 		highlightPreTag, highlightPostTag := jobLogsHighlightTags(highlightToken)
 		req.AttributesToHighlight = []string{"message"}
 		req.HighlightPreTag = highlightPreTag
 		req.HighlightPostTag = highlightPostTag
 	}
- 
+
 	return req
 }
- 
+
 // extractDataFromGetJobLogsCursor extracts the data from the cursor.
 func extractDataFromGetJobLogsCursor(cursor string) (jobLogsCursor, error) {
 	decodedBytes, err := base64.StdEncoding.DecodeString(cursor)
 	if err != nil {
 		return jobLogsCursor{}, status.Errorf(codes.InvalidArgument, "invalid cursor: %v", err)
 	}
- 
+
 	var logsCursor jobLogsCursor
 	if err = json.Unmarshal(decodedBytes, &logsCursor); err != nil {
 		return jobLogsCursor{}, status.Errorf(codes.InvalidArgument, "invalid cursor format: %v", err)
 	}
- 
+
 	if logsCursor.Stream == "" || logsCursor.EventID == "" {
 		return jobLogsCursor{}, status.Errorf(codes.InvalidArgument, "invalid cursor format")
 	}
- 
+
 	return logsCursor, nil
 }
- 
+
 func searchHitString(source map[string]any, field string) string {
 	if source == nil {
 		return ""
@@ -1069,29 +1069,29 @@ func searchHitString(source map[string]any, field string) string {
 	if !ok {
 		return ""
 	}
- 
+
 	return value
 }
- 
+
 func searchHitSource(hit map[string]json.RawMessage) (map[string]any, error) {
 	source := make(map[string]any)
 	for k, v := range hit {
 		if k == "_formatted" {
 			continue
 		}
- 
+
 		var val any
 		if err := json.Unmarshal(v, &val); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to unmarshal data: %v", err)
 		}
 		source[k] = val
 	}
- 
+
 	formattedRaw, ok := hit["_formatted"]
 	if !ok {
 		return source, nil
 	}
- 
+
 	var formatted map[string]any
 	if err := json.Unmarshal(formattedRaw, &formatted); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to unmarshal data: %v", err)
@@ -1099,21 +1099,21 @@ func searchHitSource(hit map[string]json.RawMessage) (map[string]any, error) {
 	if msg, ok := formatted["message"].(string); ok {
 		source["message"] = msg
 	}
- 
+
 	return source, nil
 }
- 
+
 // extractDataFromListJobsCursor extracts the data from the cursor.
 func extractDataFromListJobsCursor(cursor string) (string, time.Time, error) {
 	parts := bytes.Split([]byte(cursor), []byte{delimiter})
 	if len(parts) != 2 {
 		return "", time.Time{}, status.Error(codes.InvalidArgument, "invalid cursor: expected two parts")
 	}
- 
+
 	createdAt, err := time.Parse(time.RFC3339Nano, string(parts[1]))
 	if err != nil {
 		return "", time.Time{}, status.Errorf(codes.InvalidArgument, "invalid timestamp: %v", err)
 	}
- 
+
 	return string(parts[0]), createdAt, nil
 }

--- a/internal/repository/jobs/jobs_test.go
+++ b/internal/repository/jobs/jobs_test.go
@@ -1,22 +1,25 @@
 //nolint:testpackage // Tests unexported cursor helpers directly.
 package jobs
-
+ 
 import (
+	"regexp"
 	"testing"
+ 
+	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 )
-
+ 
 func TestJobLogsCursorRoundTrip(t *testing.T) {
 	want := jobLogsCursor{
 		SequenceNum: 42,
 		Stream:      "stdout",
 		EventID:     "log:job:stdout:42",
 	}
-
+ 
 	encoded := encodeJobLogsCursor(want)
 	if encoded == "" {
 		t.Fatal("expected encoded cursor")
 	}
-
+ 
 	got, err := extractDataFromGetJobLogsCursor(encoded)
 	if err != nil {
 		t.Fatalf("expected cursor to decode: %v", err)
@@ -25,9 +28,62 @@ func TestJobLogsCursorRoundTrip(t *testing.T) {
 		t.Fatalf("unexpected cursor: got %+v want %+v", got, want)
 	}
 }
-
+ 
 func TestEncodeJobLogsCursorEmpty(t *testing.T) {
 	if got := encodeJobLogsCursor(jobLogsCursor{}); got != "" {
 		t.Fatalf("expected empty cursor, got %q", got)
+	}
+}
+ 
+func TestNewJobLogsHighlightToken(t *testing.T) {
+	got, err := newJobLogsHighlightToken()
+	if err != nil {
+		t.Fatalf("expected token generation to succeed: %v", err)
+	}
+ 
+	if !regexp.MustCompile(`^[a-f0-9]{32}$`).MatchString(got) {
+		t.Fatalf("unexpected highlight token format: %q", got)
+	}
+}
+ 
+func TestNewJobLogsSearchRequestUsesTokenScopedHighlightTags(t *testing.T) {
+	const token = "0123456789abcdef0123456789abcdef"
+ 
+	got := newJobLogsSearchRequest("job_id = \"job_id\"", token, 201, jobsmodel.SearchJobLogsOptions{})
+ 
+	if got.HighlightPreTag != "__CV_HL_START_"+token+"__" {
+		t.Fatalf("unexpected highlight pre tag: %q", got.HighlightPreTag)
+	}
+	if got.HighlightPostTag != "__CV_HL_END_"+token+"__" {
+		t.Fatalf("unexpected highlight post tag: %q", got.HighlightPostTag)
+	}
+	if got.Limit != 201 {
+		t.Fatalf("unexpected limit: got %d want %d", got.Limit, 201)
+	}
+	if len(got.AttributesToHighlight) != 1 || got.AttributesToHighlight[0] != "message" {
+		t.Fatalf("unexpected attributes to highlight: %+v", got.AttributesToHighlight)
+	}
+}
+ 
+func TestNewJobLogsSearchRequestSupportsAscendingSort(t *testing.T) {
+	got := newJobLogsSearchRequest("job_id = \"job_id\"", "", 201, jobsmodel.SearchJobLogsOptions{
+		SortOrder: jobsmodel.JobLogsSortOrderAsc,
+	})
+ 
+	if len(got.Sort) != 2 || got.Sort[0] != "sequence_num:asc" || got.Sort[1] != "id:asc" {
+		t.Fatalf("unexpected sort: %+v", got.Sort)
+	}
+}
+ 
+func TestNewJobLogsSearchRequestCanDisableHighlights(t *testing.T) {
+	got := newJobLogsSearchRequest("job_id = \"job_id\"", "", 201, jobsmodel.SearchJobLogsOptions{
+		DisableHighlight: true,
+	})
+ 
+	if len(got.AttributesToHighlight) != 0 {
+		t.Fatalf("unexpected attributes to highlight: %+v", got.AttributesToHighlight)
+	}
+	if got.HighlightPreTag != "" || got.HighlightPostTag != "" {
+		t.Fatalf("unexpected highlight tags: pre=%q post=%q", got.HighlightPreTag, got.HighlightPostTag)
 	}
 }

--- a/internal/repository/jobs/jobs_test.go
+++ b/internal/repository/jobs/jobs_test.go
@@ -1,25 +1,25 @@
 //nolint:testpackage // Tests unexported cursor helpers directly.
 package jobs
- 
+
 import (
 	"regexp"
 	"testing"
- 
+
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 )
- 
+
 func TestJobLogsCursorRoundTrip(t *testing.T) {
 	want := jobLogsCursor{
 		SequenceNum: 42,
 		Stream:      "stdout",
 		EventID:     "log:job:stdout:42",
 	}
- 
+
 	encoded := encodeJobLogsCursor(want)
 	if encoded == "" {
 		t.Fatal("expected encoded cursor")
 	}
- 
+
 	got, err := extractDataFromGetJobLogsCursor(encoded)
 	if err != nil {
 		t.Fatalf("expected cursor to decode: %v", err)
@@ -28,29 +28,29 @@ func TestJobLogsCursorRoundTrip(t *testing.T) {
 		t.Fatalf("unexpected cursor: got %+v want %+v", got, want)
 	}
 }
- 
+
 func TestEncodeJobLogsCursorEmpty(t *testing.T) {
 	if got := encodeJobLogsCursor(jobLogsCursor{}); got != "" {
 		t.Fatalf("expected empty cursor, got %q", got)
 	}
 }
- 
+
 func TestNewJobLogsHighlightToken(t *testing.T) {
 	got, err := newJobLogsHighlightToken()
 	if err != nil {
 		t.Fatalf("expected token generation to succeed: %v", err)
 	}
- 
+
 	if !regexp.MustCompile(`^[a-f0-9]{32}$`).MatchString(got) {
 		t.Fatalf("unexpected highlight token format: %q", got)
 	}
 }
- 
+
 func TestNewJobLogsSearchRequestUsesTokenScopedHighlightTags(t *testing.T) {
 	const token = "0123456789abcdef0123456789abcdef"
- 
+
 	got := newJobLogsSearchRequest("job_id = \"job_id\"", token, 201, jobsmodel.SearchJobLogsOptions{})
- 
+
 	if got.HighlightPreTag != "__CV_HL_START_"+token+"__" {
 		t.Fatalf("unexpected highlight pre tag: %q", got.HighlightPreTag)
 	}
@@ -64,22 +64,22 @@ func TestNewJobLogsSearchRequestUsesTokenScopedHighlightTags(t *testing.T) {
 		t.Fatalf("unexpected attributes to highlight: %+v", got.AttributesToHighlight)
 	}
 }
- 
+
 func TestNewJobLogsSearchRequestSupportsAscendingSort(t *testing.T) {
 	got := newJobLogsSearchRequest("job_id = \"job_id\"", "", 201, jobsmodel.SearchJobLogsOptions{
 		SortOrder: jobsmodel.JobLogsSortOrderAsc,
 	})
- 
+
 	if len(got.Sort) != 2 || got.Sort[0] != "sequence_num:asc" || got.Sort[1] != "id:asc" {
 		t.Fatalf("unexpected sort: %+v", got.Sort)
 	}
 }
- 
+
 func TestNewJobLogsSearchRequestCanDisableHighlights(t *testing.T) {
 	got := newJobLogsSearchRequest("job_id = \"job_id\"", "", 201, jobsmodel.SearchJobLogsOptions{
 		DisableHighlight: true,
 	})
- 
+
 	if len(got.AttributesToHighlight) != 0 {
 		t.Fatalf("unexpected attributes to highlight: %+v", got.AttributesToHighlight)
 	}

--- a/internal/server/jobs_handlers.go
+++ b/internal/server/jobs_handlers.go
@@ -13,6 +13,23 @@ import (
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 )
 
+const (
+	jobLogsDownloadFormatText  = "txt"
+	jobLogsDownloadFormatJSON  = "json"
+	jobLogsDownloadFormatJSONL = "jsonl"
+	jobLogsDownloadStreamAll   = "all"
+)
+
+type jobLogsDownloadRequest struct {
+	WorkflowID  string
+	JobID       string
+	UserID      string
+	Format      string
+	Stream      jobspb.LogStream
+	StreamName  string
+	SearchQuery string
+}
+
 // handleListJobs handles the list jobs by job ID request.
 func (s *Server) handleListJobs(w http.ResponseWriter, r *http.Request) {
 	// Get the job ID from the path	parameters
@@ -329,80 +346,154 @@ func setJobLogsCacheControl(w http.ResponseWriter, requestCursor, responseCursor
 
 // handleDownloadJobLogs streams job logs to the client for download.
 func (s *Server) handleDownloadJobLogs(w http.ResponseWriter, r *http.Request) {
-	workflowID := r.PathValue("workflow_id")
-	if workflowID == "" {
-		http.Error(w, "workflow ID not found", http.StatusBadRequest)
-		return
-	}
-	jobID := r.PathValue("job_id")
-	if jobID == "" {
-		http.Error(w, "job ID not found", http.StatusBadRequest)
-		return
-	}
-	value := r.Context().Value(userIDKey{})
-	if value == nil {
-		http.Error(w, "user ID not found", http.StatusBadRequest)
-		return
-	}
-	userID, ok := value.(string)
-	if !ok || userID == "" {
-		http.Error(w, "user ID not found", http.StatusBadRequest)
+	downloadReq, ok := parseJobLogsDownloadRequest(w, r)
+	if !ok {
 		return
 	}
 
-	// Check job status
-	res, err := s.jobsClient.GetJob(r.Context(), &jobspb.GetJobRequest{
-		Id:         jobID,
-		WorkflowId: workflowID,
-		UserId:     userID,
-	})
-	if err != nil {
-		handleError(w, err, "failed to get job")
-		return
-	}
-	// Precondition check
-	if res.GetStatus() != "COMPLETED" && res.GetStatus() != "FAILED" {
-		http.Error(w, "job is not yet completed", http.StatusBadRequest)
+	if !s.ensureJobLogsDownloadReady(w, r, &downloadReq) {
 		return
 	}
 
-	// Set headers for file download
-	w.Header().Set("Content-Type", "text/plain")
-	w.Header().Set("Content-Disposition", `attachment; filename="`+jobID+`-logs.txt"`)
+	setJobLogsDownloadHeaders(w, &downloadReq)
 
-	// Response controller for streaming
 	rc, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
 		return
 	}
 
+	if downloadReq.Format == jobLogsDownloadFormatJSON {
+		headerErr := writeJobLogsDownloadJSONHeader(w, &downloadReq)
+		if headerErr != nil {
+			http.Error(w, "failed to write logs", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	downloadFailed := s.streamJobLogsDownload(w, r, rc, &downloadReq)
+	if downloadReq.Format == jobLogsDownloadFormatJSON && !downloadFailed {
+		fmt.Fprint(w, "]}")
+		rc.Flush()
+	}
+}
+
+func parseJobLogsDownloadRequest(w http.ResponseWriter, r *http.Request) (jobLogsDownloadRequest, bool) {
+	workflowID := r.PathValue("workflow_id")
+	if workflowID == "" {
+		http.Error(w, "workflow ID not found", http.StatusBadRequest)
+		return jobLogsDownloadRequest{}, false
+	}
+	jobID := r.PathValue("job_id")
+	if jobID == "" {
+		http.Error(w, "job ID not found", http.StatusBadRequest)
+		return jobLogsDownloadRequest{}, false
+	}
+	value := r.Context().Value(userIDKey{})
+	if value == nil {
+		http.Error(w, "user ID not found", http.StatusBadRequest)
+		return jobLogsDownloadRequest{}, false
+	}
+	userID, ok := value.(string)
+	if !ok || userID == "" {
+		http.Error(w, "user ID not found", http.StatusBadRequest)
+		return jobLogsDownloadRequest{}, false
+	}
+
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = jobLogsDownloadFormatText
+	}
+	if !isValidJobLogsDownloadFormat(format) {
+		http.Error(w, "invalid download format", http.StatusBadRequest)
+		return jobLogsDownloadRequest{}, false
+	}
+
+	streamParam := r.URL.Query().Get("stream")
+	stream, err := getJobLogsStreamType(streamParam)
+	if err != nil {
+		http.Error(w, "invalid log stream type", http.StatusBadRequest)
+		return jobLogsDownloadRequest{}, false
+	}
+	streamName := streamParam
+	if streamName == "" {
+		streamName = jobLogsDownloadStreamAll
+	}
+
+	return jobLogsDownloadRequest{
+		WorkflowID:  workflowID,
+		JobID:       jobID,
+		UserID:      userID,
+		Format:      format,
+		Stream:      stream,
+		StreamName:  streamName,
+		SearchQuery: r.URL.Query().Get("q"),
+	}, true
+}
+
+func isValidJobLogsDownloadFormat(format string) bool {
+	return format == jobLogsDownloadFormatText ||
+		format == jobLogsDownloadFormatJSON ||
+		format == jobLogsDownloadFormatJSONL
+}
+
+func (s *Server) ensureJobLogsDownloadReady(
+	w http.ResponseWriter,
+	r *http.Request,
+	downloadReq *jobLogsDownloadRequest,
+) bool {
+	res, err := s.jobsClient.GetJob(r.Context(), &jobspb.GetJobRequest{
+		Id:         downloadReq.JobID,
+		WorkflowId: downloadReq.WorkflowID,
+		UserId:     downloadReq.UserID,
+	})
+	if err != nil {
+		handleError(w, err, "failed to get job")
+		return false
+	}
+
+	if !isTerminalJobStatus(res.GetStatus()) {
+		http.Error(w, "job is not yet completed", http.StatusBadRequest)
+		return false
+	}
+
+	return true
+}
+
+func setJobLogsDownloadHeaders(w http.ResponseWriter, downloadReq *jobLogsDownloadRequest) {
+	switch downloadReq.Format {
+	case jobLogsDownloadFormatJSON:
+		w.Header().Set("Content-Type", "application/json")
+	case jobLogsDownloadFormatJSONL:
+		w.Header().Set("Content-Type", "application/x-ndjson")
+	default:
+		w.Header().Set("Content-Type", "text/plain")
+	}
+	w.Header().Set("Content-Disposition", `attachment; filename="`+downloadReq.JobID+`-logs.`+downloadReq.Format+`"`)
+}
+
+func (s *Server) streamJobLogsDownload(
+	w http.ResponseWriter,
+	r *http.Request,
+	rc http.Flusher,
+	downloadReq *jobLogsDownloadRequest,
+) (downloadFailed bool) {
 	cursor := ""
+	isFirstJSONLog := true
 	for {
-		res, err := s.jobsClient.GetJobLogs(r.Context(), &jobspb.GetJobLogsRequest{
-			Id:         jobID,
-			WorkflowId: workflowID,
-			UserId:     userID,
-			Cursor:     cursor,
-			SortOrder:  jobspb.LogSortOrder_LOG_SORT_ORDER_ASC,
-			Filters: &jobspb.GetJobLogsFilters{
-				Stream: jobspb.LogStream_LOG_STREAM_ALL,
-			},
-		})
+		res, err := s.fetchJobLogsDownloadPage(r, downloadReq, cursor)
 		if err != nil {
-			// Handle fetch error
-			fmt.Fprintf(w, "\n--- ERROR: failed to fetch logs ---\n%s\n", err.Error())
+			writeJobLogsDownloadError(w, downloadReq.Format, "failed to fetch logs", err)
 			rc.Flush()
-			break
+			return true
 		}
 
-		// Write logs to response
 		for _, log := range res.GetLogs() {
-			if _, err := w.Write([]byte(log.Message + "\n")); err != nil {
-				// Handle write error
-				fmt.Fprintf(w, "\n--- ERROR: failed to write log ---\n%s\n", err.Error())
+			writeErr := writeJobLogsDownloadLog(w, downloadReq.Format, log, &isFirstJSONLog)
+			if writeErr != nil {
+				writeJobLogsDownloadError(w, downloadReq.Format, "failed to write log", writeErr)
 				rc.Flush()
-				break
+				return true
 			}
 		}
 		rc.Flush()
@@ -411,6 +502,144 @@ func (s *Server) handleDownloadJobLogs(w http.ResponseWriter, r *http.Request) {
 		if cursor == "" {
 			break
 		}
+	}
+
+	return false
+}
+
+func (s *Server) fetchJobLogsDownloadPage(
+	r *http.Request,
+	downloadReq *jobLogsDownloadRequest,
+	cursor string,
+) (*jobspb.GetJobLogsResponse, error) {
+	if downloadReq.SearchQuery == "" {
+		return s.jobsClient.GetJobLogs(r.Context(), &jobspb.GetJobLogsRequest{
+			Id:         downloadReq.JobID,
+			WorkflowId: downloadReq.WorkflowID,
+			UserId:     downloadReq.UserID,
+			Cursor:     cursor,
+			SortOrder:  jobspb.LogSortOrder_LOG_SORT_ORDER_ASC,
+			Filters: &jobspb.GetJobLogsFilters{
+				Stream: downloadReq.Stream,
+			},
+		})
+	}
+
+	return s.jobsClient.SearchJobLogs(r.Context(), &jobspb.SearchJobLogsRequest{
+		Id:               downloadReq.JobID,
+		WorkflowId:       downloadReq.WorkflowID,
+		UserId:           downloadReq.UserID,
+		Cursor:           cursor,
+		SortOrder:        jobspb.LogSortOrder_LOG_SORT_ORDER_ASC,
+		DisableHighlight: true,
+		Filters: &jobspb.SearchJobLogsFilters{
+			Stream:  downloadReq.Stream,
+			Message: downloadReq.SearchQuery,
+		},
+	})
+}
+
+type jobLogsDownloadJSONHeader struct {
+	ID         string                    `json:"id"`
+	WorkflowID string                    `json:"workflow_id"`
+	Filters    jobLogsDownloadJSONFilter `json:"filters"`
+}
+
+type jobLogsDownloadJSONFilter struct {
+	Query  string `json:"q"`
+	Stream string `json:"stream"`
+}
+
+type jobLogsDownloadLog struct {
+	Timestamp   string           `json:"timestamp"`
+	SequenceNum uint32           `json:"sequence_num"`
+	Stream      string           `json:"stream"`
+	EventID     string           `json:"event_id"`
+	MessageRaw  string           `json:"message_raw"`
+	MessageJSON *json.RawMessage `json:"message_json,omitempty"`
+}
+
+func writeJobLogsDownloadJSONHeader(w io.Writer, downloadReq *jobLogsDownloadRequest) error {
+	header, err := json.Marshal(jobLogsDownloadJSONHeader{
+		ID:         downloadReq.JobID,
+		WorkflowID: downloadReq.WorkflowID,
+		Filters: jobLogsDownloadJSONFilter{
+			Query:  downloadReq.SearchQuery,
+			Stream: downloadReq.StreamName,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, writeErr := w.Write(header[:len(header)-1]); writeErr != nil {
+		return writeErr
+	}
+	_, writeErr := w.Write([]byte(`,"logs":[`))
+	return writeErr
+}
+
+func newJobLogsDownloadLog(log *jobspb.Log) jobLogsDownloadLog {
+	entry := jobLogsDownloadLog{
+		Timestamp:   log.GetTimestamp(),
+		SequenceNum: log.GetSequenceNum(),
+		Stream:      log.GetStream(),
+		EventID:     log.GetEventId(),
+		MessageRaw:  log.GetMessage(),
+	}
+
+	if json.Valid([]byte(log.GetMessage())) {
+		raw := json.RawMessage(log.GetMessage())
+		entry.MessageJSON = &raw
+	}
+
+	return entry
+}
+
+func writeJobLogsDownloadLog(w io.Writer, format string, log *jobspb.Log, isFirstJSONLog *bool) error {
+	switch format {
+	case jobLogsDownloadFormatJSON:
+		if !*isFirstJSONLog {
+			if _, err := w.Write([]byte(",")); err != nil {
+				return err
+			}
+		}
+		*isFirstJSONLog = false
+		encoded, err := json.Marshal(newJobLogsDownloadLog(log))
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(encoded)
+		return err
+	case jobLogsDownloadFormatJSONL:
+		return json.NewEncoder(w).Encode(newJobLogsDownloadLog(log))
+	default:
+		_, err := w.Write([]byte(log.GetMessage() + "\n"))
+		return err
+	}
+}
+
+func writeJobLogsDownloadError(w io.Writer, format, message string, err error) {
+	switch format {
+	case jobLogsDownloadFormatJSON:
+		encoded, jsonErr := json.Marshal(map[string]string{
+			"message": message,
+			"error":   err.Error(),
+		})
+		if jsonErr != nil {
+			return
+		}
+		fmt.Fprintf(w, `],"error":%s}`, encoded)
+	case jobLogsDownloadFormatJSONL:
+		encodeErr := json.NewEncoder(w).Encode(map[string]string{
+			"message": message,
+			"error":   err.Error(),
+		})
+		if encodeErr != nil {
+			return
+		}
+	default:
+		fmt.Fprintf(w, "\n--- ERROR: %s ---\n%s\n", message, err.Error())
 	}
 }
 

--- a/internal/server/jobs_handlers_test.go
+++ b/internal/server/jobs_handlers_test.go
@@ -3,8 +3,10 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -15,10 +17,21 @@ import (
 type fakeJobsServiceClient struct {
 	jobspb.JobsServiceClient
 
+	getJobResponse        *jobspb.GetJobResponse
+	getJobRequest         *jobspb.GetJobRequest
 	getJobLogsResponse    *jobspb.GetJobLogsResponse
 	getJobLogsRequest     *jobspb.GetJobLogsRequest
 	searchJobLogsResponse *jobspb.GetJobLogsResponse
 	searchJobLogsRequest  *jobspb.SearchJobLogsRequest
+}
+
+func (f *fakeJobsServiceClient) GetJob(_ context.Context, req *jobspb.GetJobRequest, _ ...grpc.CallOption) (*jobspb.GetJobResponse, error) {
+	f.getJobRequest = req
+	if f.getJobResponse != nil {
+		return f.getJobResponse, nil
+	}
+
+	return &jobspb.GetJobResponse{Status: "COMPLETED"}, nil
 }
 
 func (f *fakeJobsServiceClient) GetJobLogs(_ context.Context, req *jobspb.GetJobLogsRequest, _ ...grpc.CallOption) (*jobspb.GetJobLogsResponse, error) {
@@ -139,6 +152,171 @@ func TestHandleSearchJobLogsCacheControl(t *testing.T) {
 				t.Fatal("expected SearchJobLogs to be called")
 			}
 		})
+	}
+}
+
+func TestHandleDownloadJobLogsRawTextUsesAscendingGetLogs(t *testing.T) {
+	client := &fakeJobsServiceClient{
+		getJobResponse: &jobspb.GetJobResponse{Status: "COMPLETED"},
+		getJobLogsResponse: &jobspb.GetJobLogsResponse{
+			Logs: []*jobspb.Log{
+				{
+					Timestamp:   "2026-06-05T12:00:00Z",
+					Message:     `{"id":1}`,
+					SequenceNum: 1,
+					Stream:      "stdout",
+					EventId:     "event-1",
+				},
+			},
+		},
+	}
+	s := &Server{jobsClient: client}
+
+	req := newJobLogsHandlerRequest("/workflows/workflow_id/jobs/job_id/logs/raw?stream=stdout")
+	res := httptest.NewRecorder()
+	s.handleDownloadJobLogs(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
+	}
+	if got := res.Body.String(); got != "{\"id\":1}\n" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+	if client.getJobLogsRequest == nil {
+		t.Fatal("expected GetJobLogs to be called")
+	}
+	if client.getJobLogsRequest.GetSortOrder() != jobspb.LogSortOrder_LOG_SORT_ORDER_ASC {
+		t.Fatalf("unexpected sort order: %v", client.getJobLogsRequest.GetSortOrder())
+	}
+	if client.getJobLogsRequest.GetFilters().GetStream() != jobspb.LogStream_LOG_STREAM_STDOUT {
+		t.Fatalf("unexpected stream: %v", client.getJobLogsRequest.GetFilters().GetStream())
+	}
+}
+
+func TestHandleDownloadJobLogsAllowsCanceledJobWithLogs(t *testing.T) {
+	client := &fakeJobsServiceClient{
+		getJobResponse: &jobspb.GetJobResponse{Status: "CANCELED"},
+		getJobLogsResponse: &jobspb.GetJobLogsResponse{
+			Logs: []*jobspb.Log{
+				{
+					Message:     "canceled job log",
+					SequenceNum: 1,
+					Stream:      "stdout",
+					EventId:     "event-1",
+				},
+			},
+		},
+	}
+	s := &Server{jobsClient: client}
+
+	req := newJobLogsHandlerRequest("/workflows/workflow_id/jobs/job_id/logs/raw")
+	res := httptest.NewRecorder()
+	s.handleDownloadJobLogs(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
+	}
+	if got := res.Body.String(); got != "canceled job log\n" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestHandleDownloadJobLogsSearchJSONLUsesAscendingSearchWithoutHighlights(t *testing.T) {
+	client := &fakeJobsServiceClient{
+		getJobResponse: &jobspb.GetJobResponse{Status: "FAILED"},
+		searchJobLogsResponse: &jobspb.GetJobLogsResponse{
+			Logs: []*jobspb.Log{
+				{
+					Timestamp:   "2026-06-05T12:00:00Z",
+					Message:     `{"id":1}`,
+					SequenceNum: 1,
+					Stream:      "stderr",
+					EventId:     "event-1",
+				},
+			},
+		},
+	}
+	s := &Server{jobsClient: client}
+
+	req := newJobLogsHandlerRequest("/workflows/workflow_id/jobs/job_id/logs/raw?format=jsonl&q=error&stream=stderr")
+	res := httptest.NewRecorder()
+	s.handleDownloadJobLogs(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
+	}
+	if client.searchJobLogsRequest == nil {
+		t.Fatal("expected SearchJobLogs to be called")
+	}
+	if client.searchJobLogsRequest.GetSortOrder() != jobspb.LogSortOrder_LOG_SORT_ORDER_ASC {
+		t.Fatalf("unexpected sort order: %v", client.searchJobLogsRequest.GetSortOrder())
+	}
+	if !client.searchJobLogsRequest.GetDisableHighlight() {
+		t.Fatal("expected highlights to be disabled")
+	}
+	if client.searchJobLogsRequest.GetFilters().GetMessage() != "error" {
+		t.Fatalf("unexpected query: %q", client.searchJobLogsRequest.GetFilters().GetMessage())
+	}
+	if client.searchJobLogsRequest.GetFilters().GetStream() != jobspb.LogStream_LOG_STREAM_STDERR {
+		t.Fatalf("unexpected stream: %v", client.searchJobLogsRequest.GetFilters().GetStream())
+	}
+
+	var line map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Body.String())), &line); err != nil {
+		t.Fatalf("expected valid JSONL object: %v", err)
+	}
+	if line["message_raw"] != `{"id":1}` {
+		t.Fatalf("unexpected message_raw: %v", line["message_raw"])
+	}
+	if _, ok := line["message_json"]; !ok {
+		t.Fatal("expected message_json for parseable JSON message")
+	}
+}
+
+func TestHandleDownloadJobLogsJSONEscapesFilterControlCharacters(t *testing.T) {
+	client := &fakeJobsServiceClient{
+		getJobResponse:        &jobspb.GetJobResponse{Status: "COMPLETED"},
+		searchJobLogsResponse: &jobspb.GetJobLogsResponse{},
+	}
+	s := &Server{jobsClient: client}
+
+	req := newJobLogsHandlerRequest("/workflows/workflow_id/jobs/job_id/logs/raw?format=json&q=%1F")
+	res := httptest.NewRecorder()
+	s.handleDownloadJobLogs(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
+	}
+
+	var body struct {
+		Filters struct {
+			Query string `json:"q"`
+		} `json:"filters"`
+		Logs []map[string]any `json:"logs"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected valid JSON body, got %q: %v", res.Body.String(), err)
+	}
+	if body.Filters.Query != "\x1f" {
+		t.Fatalf("unexpected query: %q", body.Filters.Query)
+	}
+	if len(body.Logs) != 0 {
+		t.Fatalf("expected no logs, got %d", len(body.Logs))
+	}
+}
+
+func TestHandleDownloadJobLogsRejectsInvalidFormat(t *testing.T) {
+	client := &fakeJobsServiceClient{
+		getJobResponse: &jobspb.GetJobResponse{Status: "COMPLETED"},
+	}
+	s := &Server{jobsClient: client}
+
+	req := newJobLogsHandlerRequest("/workflows/workflow_id/jobs/job_id/logs/raw?format=csv")
+	res := httptest.NewRecorder()
+	s.handleDownloadJobLogs(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, res.Code)
 	}
 }
 

--- a/internal/service/jobs/jobs.go
+++ b/internal/service/jobs/jobs.go
@@ -1,7 +1,7 @@
 //go:generate mockgen -source=$GOFILE -package=$GOPACKAGE -destination=./mock/$GOFILE
- 
+
 package jobs
- 
+
 import (
 	"context"
 	"encoding/base64"
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
- 
+
 	"github.com/go-playground/validator/v10"
 	goredis "github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
@@ -19,21 +19,21 @@ import (
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
- 
+
 	jobspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
- 
+
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/redis"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
- 
+
 const (
 	defaultExpirationTTL      = time.Minute * 30
 	jobLogSearchExpirationTTL = time.Minute * 15
 	cacheTimeout              = time.Second * 5
 )
- 
+
 // Repository provides job related operations.
 type Repository interface {
 	ScheduleJob(ctx context.Context, workflowID, userID, scheduledAt, trigger, idempotencyKey string, workflowGeneration int64) (string, error)
@@ -58,13 +58,13 @@ type Repository interface {
 	) (*jobsmodel.GetJobLogsResponse, string, error)
 	ListJobs(ctx context.Context, workflowID, userID, cursor string, filters *jobsmodel.ListJobsFilters) (*jobsmodel.ListJobsResponse, error)
 }
- 
+
 // Cache provides cache related operations.
 type Cache interface {
 	Set(ctx context.Context, key string, value any, expiration time.Duration) error
 	Get(ctx context.Context, key string, dest any) (any, error)
 }
- 
+
 // Service provides job related operations.
 type Service struct {
 	validator *validator.Validate
@@ -73,7 +73,7 @@ type Service struct {
 	cache     Cache
 	sf        singleflight.Group
 }
- 
+
 // New creates a new jobs-service.
 func New(validator *validator.Validate, repo Repository, cache Cache) *Service {
 	return &Service{
@@ -83,7 +83,7 @@ func New(validator *validator.Validate, repo Repository, cache Cache) *Service {
 		cache:     cache,
 	}
 }
- 
+
 // ScheduleJobRequest holds the request parameters for scheduling a job.
 type ScheduleJobRequest struct {
 	WorkflowID         string `validate:"required"`
@@ -93,7 +93,7 @@ type ScheduleJobRequest struct {
 	IdempotencyKey     string `validate:"omitempty"`
 	WorkflowGeneration int64  `validate:"omitempty,min=0"`
 }
- 
+
 // ScheduleJob schedules a job.
 func (s *Service) ScheduleJob(ctx context.Context, req *jobspb.ScheduleJobRequest) (jobID string, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.ScheduleJob")
@@ -104,7 +104,7 @@ func (s *Service) ScheduleJob(ctx context.Context, req *jobspb.ScheduleJobReques
 		}
 		span.End()
 	}()
- 
+
 	// Validate the request
 	err = s.validator.Struct(&ScheduleJobRequest{
 		WorkflowID:         req.GetWorkflowId(),
@@ -118,23 +118,23 @@ func (s *Service) ScheduleJob(ctx context.Context, req *jobspb.ScheduleJobReques
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return "", status.Error(codes.InvalidArgument, err.Error())
 	}
- 
+
 	// Validate the scheduled time
 	err = validateTime(req.GetScheduledAt())
 	if err != nil {
 		return "", err
 	}
- 
+
 	// Validate the job trigger
 	err = validateJobTrigger(req.GetTrigger())
 	if err != nil {
 		return "", err
 	}
- 
+
 	if req.GetTrigger() == jobsmodel.JobTriggerManual.ToString() && req.GetIdempotencyKey() == "" {
 		return "", status.Error(codes.InvalidArgument, "idempotency key is required for manual jobs")
 	}
- 
+
 	// Schedule the job
 	res, err := s.repo.ScheduleJob(
 		ctx,
@@ -148,17 +148,17 @@ func (s *Service) ScheduleJob(ctx context.Context, req *jobspb.ScheduleJobReques
 	if err != nil {
 		return "", err
 	}
- 
+
 	return res, nil
 }
- 
+
 // UpdateJobStatusRequest holds the request parameters for updating a scheduled job status.
 type UpdateJobStatusRequest struct {
 	ID          string `validate:"required"`
 	ContainerID string `validate:"omitempty"`
 	Status      string `validate:"required"`
 }
- 
+
 // UpdateJobStatus updates the scheduled job status.
 func (s *Service) UpdateJobStatus(ctx context.Context, req *jobspb.UpdateJobStatusRequest) (err error) {
 	ctx, span := s.tp.Start(ctx, "Service.UpdateJobStatus")
@@ -169,7 +169,7 @@ func (s *Service) UpdateJobStatus(ctx context.Context, req *jobspb.UpdateJobStat
 		}
 		span.End()
 	}()
- 
+
 	// Validate the request
 	err = s.validator.Struct(&UpdateJobStatusRequest{
 		ID:          req.GetId(),
@@ -180,13 +180,13 @@ func (s *Service) UpdateJobStatus(ctx context.Context, req *jobspb.UpdateJobStat
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return err
 	}
- 
+
 	// Validate the job status
 	err = validateJobStatus(req.GetStatus())
 	if err != nil {
 		return err
 	}
- 
+
 	// Update the scheduled job status
 	err = s.repo.UpdateJobStatus(
 		ctx,
@@ -194,10 +194,10 @@ func (s *Service) UpdateJobStatus(ctx context.Context, req *jobspb.UpdateJobStat
 		req.GetContainerId(),
 		req.GetStatus(),
 	)
- 
+
 	return err
 }
- 
+
 // ClaimJobRequest holds the request parameters for claiming a job.
 type ClaimJobRequest struct {
 	ID                   string `validate:"required"`
@@ -206,7 +206,7 @@ type ClaimJobRequest struct {
 	LeaseDurationSeconds int32  `validate:"required,min=1"`
 	DispatchAttempt      int32  `validate:"required,min=1"`
 }
- 
+
 // ClaimJob atomically claims a queued job for execution.
 func (s *Service) ClaimJob(ctx context.Context, req *jobspb.ClaimJobRequest) (res *jobspb.ClaimJobResponse, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.ClaimJob")
@@ -217,7 +217,7 @@ func (s *Service) ClaimJob(ctx context.Context, req *jobspb.ClaimJobRequest) (re
 		}
 		span.End()
 	}()
- 
+
 	err = s.validator.Struct(&ClaimJobRequest{
 		ID:                   req.GetId(),
 		WorkflowID:           req.GetWorkflowId(),
@@ -228,7 +228,7 @@ func (s *Service) ClaimJob(ctx context.Context, req *jobspb.ClaimJobRequest) (re
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
- 
+
 	claimed, ok, reason, err := s.repo.ClaimJob(
 		ctx,
 		req.GetId(),
@@ -240,17 +240,17 @@ func (s *Service) ClaimJob(ctx context.Context, req *jobspb.ClaimJobRequest) (re
 	if err != nil {
 		return nil, err
 	}
- 
+
 	return claimed.ToClaimJobProto(ok, reason), nil
 }
- 
+
 // RenewJobLeaseRequest holds the request parameters for renewing a job lease.
 type RenewJobLeaseRequest struct {
 	ID                   string `validate:"required"`
 	LeaseToken           string `validate:"required"`
 	LeaseDurationSeconds int32  `validate:"required,min=1"`
 }
- 
+
 // RenewJobLease renews a running job lease.
 func (s *Service) RenewJobLease(ctx context.Context, req *jobspb.RenewJobLeaseRequest) (err error) {
 	ctx, span := s.tp.Start(ctx, "Service.RenewJobLease")
@@ -261,7 +261,7 @@ func (s *Service) RenewJobLease(ctx context.Context, req *jobspb.RenewJobLeaseRe
 		}
 		span.End()
 	}()
- 
+
 	err = s.validator.Struct(&RenewJobLeaseRequest{
 		ID:                   req.GetId(),
 		LeaseToken:           req.GetLeaseToken(),
@@ -270,17 +270,17 @@ func (s *Service) RenewJobLease(ctx context.Context, req *jobspb.RenewJobLeaseRe
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
- 
+
 	return s.repo.RenewJobLease(ctx, req.GetId(), req.GetLeaseToken(), time.Duration(req.GetLeaseDurationSeconds())*time.Second)
 }
- 
+
 // AttachJobContainerRequest holds the request parameters for attaching a container.
 type AttachJobContainerRequest struct {
 	ID          string `validate:"required"`
 	LeaseToken  string `validate:"required"`
 	ContainerID string `validate:"required"`
 }
- 
+
 // AttachJobContainer attaches a container ID to a running job.
 func (s *Service) AttachJobContainer(ctx context.Context, req *jobspb.AttachJobContainerRequest) (err error) {
 	ctx, span := s.tp.Start(ctx, "Service.AttachJobContainer")
@@ -291,7 +291,7 @@ func (s *Service) AttachJobContainer(ctx context.Context, req *jobspb.AttachJobC
 		}
 		span.End()
 	}()
- 
+
 	err = s.validator.Struct(&AttachJobContainerRequest{
 		ID:          req.GetId(),
 		LeaseToken:  req.GetLeaseToken(),
@@ -300,16 +300,16 @@ func (s *Service) AttachJobContainer(ctx context.Context, req *jobspb.AttachJobC
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
- 
+
 	return s.repo.AttachJobContainer(ctx, req.GetId(), req.GetLeaseToken(), req.GetContainerId())
 }
- 
+
 // CompleteJobRequest holds the request parameters for completing a claimed job.
 type CompleteJobRequest struct {
 	ID         string `validate:"required"`
 	LeaseToken string `validate:"required"`
 }
- 
+
 // CompleteJob completes a running claimed job.
 func (s *Service) CompleteJob(ctx context.Context, req *jobspb.CompleteJobRequest) (err error) {
 	ctx, span := s.tp.Start(ctx, "Service.CompleteJob")
@@ -320,15 +320,15 @@ func (s *Service) CompleteJob(ctx context.Context, req *jobspb.CompleteJobReques
 		}
 		span.End()
 	}()
- 
+
 	err = s.validator.Struct(&CompleteJobRequest{ID: req.GetId(), LeaseToken: req.GetLeaseToken()})
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
- 
+
 	return s.repo.CompleteJob(ctx, req.GetId(), req.GetLeaseToken())
 }
- 
+
 // FailJobRequest holds the request parameters for failing a claimed job.
 type FailJobRequest struct {
 	ID           string `validate:"required"`
@@ -337,7 +337,7 @@ type FailJobRequest struct {
 	ErrorCode    string `validate:"omitempty"`
 	ErrorMessage string `validate:"omitempty"`
 }
- 
+
 // FailJob marks a running claimed job as failed.
 //
 //nolint:dupl // Lease terminal methods intentionally share validation and tracing shape.
@@ -350,7 +350,7 @@ func (s *Service) FailJob(ctx context.Context, req *jobspb.FailJobRequest) (err 
 		}
 		span.End()
 	}()
- 
+
 	err = s.validator.Struct(&FailJobRequest{
 		ID:           req.GetId(),
 		LeaseToken:   req.GetLeaseToken(),
@@ -364,10 +364,10 @@ func (s *Service) FailJob(ctx context.Context, req *jobspb.FailJobRequest) (err 
 	if err := validateFailureKind(req.GetFailureKind()); err != nil {
 		return err
 	}
- 
+
 	return s.repo.FailJob(ctx, req.GetId(), req.GetLeaseToken(), req.GetFailureKind(), req.GetErrorCode(), req.GetErrorMessage())
 }
- 
+
 // CancelClaimedJob cancels a running claimed job.
 func (s *Service) CancelClaimedJob(ctx context.Context, req *jobspb.CancelClaimedJobRequest) (err error) {
 	ctx, span := s.tp.Start(ctx, "Service.CancelClaimedJob")
@@ -378,15 +378,15 @@ func (s *Service) CancelClaimedJob(ctx context.Context, req *jobspb.CancelClaime
 		}
 		span.End()
 	}()
- 
+
 	err = s.validator.Struct(&CompleteJobRequest{ID: req.GetId(), LeaseToken: req.GetLeaseToken()})
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
- 
+
 	return s.repo.CancelClaimedJob(ctx, req.GetId(), req.GetLeaseToken())
 }
- 
+
 // ReleaseJobForRetryRequest holds the request parameters for retrying a claimed job.
 type ReleaseJobForRetryRequest struct {
 	ID            string `validate:"required"`
@@ -395,7 +395,7 @@ type ReleaseJobForRetryRequest struct {
 	ErrorCode     string `validate:"omitempty"`
 	ErrorMessage  string `validate:"omitempty"`
 }
- 
+
 // ReleaseJobForRetry releases a running claimed job back to pending.
 //
 //nolint:dupl // Lease terminal methods intentionally share validation and tracing shape.
@@ -408,7 +408,7 @@ func (s *Service) ReleaseJobForRetry(ctx context.Context, req *jobspb.ReleaseJob
 		}
 		span.End()
 	}()
- 
+
 	err = s.validator.Struct(&ReleaseJobForRetryRequest{
 		ID:            req.GetId(),
 		LeaseToken:    req.GetLeaseToken(),
@@ -422,17 +422,17 @@ func (s *Service) ReleaseJobForRetry(ctx context.Context, req *jobspb.ReleaseJob
 	if err := validateTime(req.GetNextAttemptAt()); err != nil {
 		return err
 	}
- 
+
 	return s.repo.ReleaseJobForRetry(ctx, req.GetId(), req.GetLeaseToken(), req.GetNextAttemptAt(), req.GetErrorCode(), req.GetErrorMessage())
 }
- 
+
 // RecoverExpiredJobLeasesRequest holds the request parameters for lease recovery.
 type RecoverExpiredJobLeasesRequest struct {
 	BatchSize            int32  `validate:"required,min=1"`
 	WorkerID             string `validate:"required"`
 	LeaseDurationSeconds int32  `validate:"required,min=1"`
 }
- 
+
 // RecoverExpiredJobLeases returns expired running job leases for recovery.
 func (s *Service) RecoverExpiredJobLeases(ctx context.Context, req *jobspb.RecoverExpiredJobLeasesRequest) (res []*jobsmodel.ExpiredJobLease, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.RecoverExpiredJobLeases")
@@ -443,7 +443,7 @@ func (s *Service) RecoverExpiredJobLeases(ctx context.Context, req *jobspb.Recov
 		}
 		span.End()
 	}()
- 
+
 	err = s.validator.Struct(&RecoverExpiredJobLeasesRequest{
 		BatchSize:            req.GetBatchSize(),
 		WorkerID:             req.GetWorkerId(),
@@ -452,7 +452,7 @@ func (s *Service) RecoverExpiredJobLeases(ctx context.Context, req *jobspb.Recov
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
- 
+
 	return s.repo.RecoverExpiredJobLeases(
 		ctx,
 		req.GetBatchSize(),
@@ -460,14 +460,14 @@ func (s *Service) RecoverExpiredJobLeases(ctx context.Context, req *jobspb.Recov
 		time.Duration(req.GetLeaseDurationSeconds())*time.Second,
 	)
 }
- 
+
 // GetJobRequest holds the request parameters for getting a scheduled job.
 type GetJobRequest struct {
 	ID         string `validate:"required"`
 	WorkflowID string `validate:"required"`
 	UserID     string `validate:"required"`
 }
- 
+
 // GetJob returns the scheduled job details by ID, job ID, and user ID.
 func (s *Service) GetJob(ctx context.Context, req *jobspb.GetJobRequest) (res *jobsmodel.GetJobResponse, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.GetJob")
@@ -478,7 +478,7 @@ func (s *Service) GetJob(ctx context.Context, req *jobspb.GetJobRequest) (res *j
 		}
 		span.End()
 	}()
- 
+
 	// Validate the request
 	err = s.validator.Struct(&GetJobRequest{
 		ID:         req.GetId(),
@@ -489,21 +489,21 @@ func (s *Service) GetJob(ctx context.Context, req *jobspb.GetJobRequest) (res *j
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
- 
+
 	// Get the scheduled job details
 	res, err = s.repo.GetJob(ctx, req.GetId(), req.GetWorkflowId(), req.GetUserId())
 	if err != nil {
 		return nil, err
 	}
- 
+
 	return res, nil
 }
- 
+
 // GetJobByIDRequest holds the request parameters for getting a scheduled job by ID.
 type GetJobByIDRequest struct {
 	ID string `validate:"required"`
 }
- 
+
 // GetJobByID returns the scheduled job details by ID.
 func (s *Service) GetJobByID(ctx context.Context, req *jobspb.GetJobByIDRequest) (res *jobsmodel.GetJobByIDResponse, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.GetJobByID")
@@ -514,7 +514,7 @@ func (s *Service) GetJobByID(ctx context.Context, req *jobspb.GetJobByIDRequest)
 		}
 		span.End()
 	}()
- 
+
 	// Validate the request
 	err = s.validator.Struct(&GetJobByIDRequest{
 		ID: req.GetId(),
@@ -523,19 +523,19 @@ func (s *Service) GetJobByID(ctx context.Context, req *jobspb.GetJobByIDRequest)
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
- 
+
 	resultCh := s.sf.DoChan(fmt.Sprintf("job_by_id:%s", req.GetId()), func() (any, error) {
 		return s.repo.GetJobByID(ctx, req.GetId())
 	})
- 
+
 	res, err = waitSingleflightResult[*jobsmodel.GetJobByIDResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
- 
+
 	return res, nil
 }
- 
+
 // GetJobLogsRequest holds the request parameters for getting scheduled job logs.
 type GetJobLogsRequest struct {
 	ID         string                       `validate:"required"`
@@ -545,7 +545,7 @@ type GetJobLogsRequest struct {
 	SortOrder  int                          `validate:"omitempty,min=0,max=2"`
 	Filters    *jobsmodel.GetJobLogsFilters `validate:"required"`
 }
- 
+
 // GetJobLogs returns the scheduled job logs.
 func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest) (res *jobsmodel.GetJobLogsResponse, err error) {
 	logger := loggerpkg.FromContext(ctx).With(
@@ -559,7 +559,7 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		}
 		span.End()
 	}()
- 
+
 	var filters *jobsmodel.GetJobLogsFilters
 	if req.GetFilters() != nil {
 		filters = &jobsmodel.GetJobLogsFilters{
@@ -568,7 +568,7 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 	} else {
 		filters = &jobsmodel.GetJobLogsFilters{}
 	}
- 
+
 	// Validate the request
 	err = s.validator.Struct(&GetJobLogsRequest{
 		ID:         req.GetId(),
@@ -582,9 +582,9 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
- 
+
 	sortOrder := normalizeJobLogsSortOrder(jobsmodel.JobLogsSortOrder(req.GetSortOrder()))
- 
+
 	// Check if the job logs are cached
 	cacheKey := fmt.Sprintf(
 		"job_logs:%s:%s:%s:%s:%d",
@@ -608,7 +608,7 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 			return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 		}
 	}
- 
+
 	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
 		_res, jobStatus, _err := s.repo.GetJobLogs(
 			ctx,
@@ -622,14 +622,14 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		if _err != nil {
 			return nil, _err
 		}
- 
+
 		// Cache only stable cursor pages. A cursor page with no response cursor is the current tail,
 		// which can still receive late retained logs while the repo reports the job as running.
 		if isCursorPage && (_res.Cursor != "" || isTerminalJobStatus(jobStatus)) {
 			go func() {
 				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 				defer cancel()
- 
+
 				if setErr := s.cache.Set(bgCtx, cacheKey, _res, defaultExpirationTTL); setErr != nil {
 					logger.Warn("failed to cache job logs",
 						zap.String("user_id", req.GetUserId()),
@@ -646,25 +646,25 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 				}
 			}()
 		}
- 
+
 		return _res, nil
 	})
- 
+
 	res, err = waitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
- 
+
 	return res, nil
 }
- 
+
 // StreamJobLogsRequest holds the request parameters for streaming scheduled job logs.
 type StreamJobLogsRequest struct {
 	ID         string `validate:"required"`
 	WorkflowID string `validate:"required"`
 	UserID     string `validate:"required"`
 }
- 
+
 // StreamJobLogs streams the job logs.
 func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRequest) (ch chan *jobsmodel.JobLog, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.StreamJobLogs")
@@ -675,7 +675,7 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 		}
 		span.End()
 	}()
- 
+
 	// Validate the request
 	err = s.validator.Struct(&StreamJobLogsRequest{
 		ID:         req.GetId(),
@@ -686,14 +686,14 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
- 
+
 	// Stream the scheduled job logs
 	sub, _err := s.repo.StreamJobLogs(ctx, req.GetId(), req.GetWorkflowId(), req.GetUserId())
 	if _err != nil {
 		err = _err
 		return nil, err
 	}
- 
+
 	subscribedChannel := sub.Channel()
 	ch = make(chan *jobsmodel.JobLog)
 	go func() {
@@ -701,7 +701,7 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 		//nolint:errcheck // Ignore error as we are closing the channel
 		defer sub.Unsubscribe(ctx, redis.GetJobLogsChannel(req.GetId()))
 		defer sub.Close()
- 
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -710,17 +710,17 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 				if !ok {
 					return
 				}
- 
+
 				if data == nil {
 					continue
 				}
- 
+
 				payload := data.Payload
 				var log jobsmodel.JobLogEvent
 				if err := json.Unmarshal([]byte(payload), &log); err != nil {
 					continue
 				}
- 
+
 				select {
 				case ch <- &jobsmodel.JobLog{
 					EventID:     log.EventKey,
@@ -735,10 +735,10 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 			}
 		}
 	}()
- 
+
 	return ch, nil
 }
- 
+
 // SearchJobLogsRequest holds the request parameters for getting filtered logs of a job.
 type SearchJobLogsRequest struct {
 	ID         string                          `validate:"required"`
@@ -748,7 +748,7 @@ type SearchJobLogsRequest struct {
 	SortOrder  int                             `validate:"omitempty,min=0,max=2"`
 	Filters    *jobsmodel.SearchJobLogsFilters `validate:"required"`
 }
- 
+
 // SearchJobLogs returns the filtered logs of a job.
 func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRequest) (res *jobsmodel.GetJobLogsResponse, err error) {
 	logger := loggerpkg.FromContext(ctx).With(
@@ -762,7 +762,7 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 		}
 		span.End()
 	}()
- 
+
 	var filters *jobsmodel.SearchJobLogsFilters
 	if req.GetFilters() != nil {
 		filters = &jobsmodel.SearchJobLogsFilters{
@@ -772,7 +772,7 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 	} else {
 		filters = &jobsmodel.SearchJobLogsFilters{}
 	}
- 
+
 	// Validate the struct
 	err = s.validator.Struct(&SearchJobLogsRequest{
 		ID:         req.GetId(),
@@ -786,10 +786,10 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
- 
+
 	sortOrder := normalizeJobLogsSortOrder(jobsmodel.JobLogsSortOrder(req.GetSortOrder()))
 	disableHighlight := req.GetDisableHighlight()
- 
+
 	// Check if the job logs are cached
 	cacheKey := fmt.Sprintf(
 		"job_logs:search:%s:%s:%s:%s:%s:%d:%t",
@@ -815,7 +815,7 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 			return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 		}
 	}
- 
+
 	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
 		_res, jobStatus, _err := s.repo.SearchJobLogs(
 			ctx,
@@ -832,12 +832,12 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 		if _err != nil {
 			return nil, _err
 		}
- 
+
 		if isCursorPage && (_res.Cursor != "" || isTerminalJobStatus(jobStatus)) {
 			go func() {
 				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 				defer cancel()
- 
+
 				if setErr := s.cache.Set(bgCtx, cacheKey, _res, jobLogSearchExpirationTTL); setErr != nil {
 					logger.Warn("failed to cache job logs",
 						zap.String("user_id", req.GetUserId()),
@@ -854,18 +854,18 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 				}
 			}()
 		}
- 
+
 		return _res, nil
 	})
- 
+
 	res, err = waitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
- 
+
 	return res, nil
 }
- 
+
 // ListJobsRequest holds the request parameters for listing scheduled jobs.
 type ListJobsRequest struct {
 	WorkflowID string                     `validate:"required"`
@@ -873,7 +873,7 @@ type ListJobsRequest struct {
 	Cursor     string                     `validate:"omitempty"`
 	Filters    *jobsmodel.ListJobsFilters `validate:"omitempty"`
 }
- 
+
 // ListJobs returns scheduled jobs.
 func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (res *jobsmodel.ListJobsResponse, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.ListJobs")
@@ -884,7 +884,7 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 		}
 		span.End()
 	}()
- 
+
 	var filters *jobsmodel.ListJobsFilters
 	if req.GetFilters() != nil {
 		filters = &jobsmodel.ListJobsFilters{
@@ -894,7 +894,7 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 	} else {
 		filters = &jobsmodel.ListJobsFilters{}
 	}
- 
+
 	// Validate the request
 	err = s.validator.Struct(&ListJobsRequest{
 		WorkflowID: req.GetWorkflowId(),
@@ -906,7 +906,7 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
- 
+
 	// Validate the cursor
 	var cursor string
 	if req.GetCursor() != "" {
@@ -916,13 +916,13 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 			return nil, err
 		}
 	}
- 
+
 	// Validate the filters
 	if err = validateListJobsFilters(filters); err != nil {
 		err = status.Errorf(codes.InvalidArgument, "invalid filters: %v", err)
 		return nil, err
 	}
- 
+
 	listKey := fmt.Sprintf(
 		"jobs:%s:%s:cursor=%s&status=%s&trigger=%s",
 		req.GetUserId(),
@@ -934,24 +934,24 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 	resultCh := s.sf.DoChan(listKey, func() (any, error) {
 		return s.repo.ListJobs(ctx, req.GetWorkflowId(), req.GetUserId(), cursor, filters)
 	})
- 
+
 	res, err = waitSingleflightResult[*jobsmodel.ListJobsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
- 
+
 	return res, nil
 }
- 
+
 func validateTime(t string) error {
 	_, err := time.Parse(time.RFC3339Nano, t)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid time: %v", err)
 	}
- 
+
 	return nil
 }
- 
+
 func validateJobStatus(s string) error {
 	switch s {
 	case jobsmodel.JobStatusPending.ToString(),
@@ -965,7 +965,7 @@ func validateJobStatus(s string) error {
 		return status.Errorf(codes.InvalidArgument, "invalid status: %s", s)
 	}
 }
- 
+
 func validateJobTrigger(t string) error {
 	switch t {
 	case jobsmodel.JobTriggerAutomatic.ToString(),
@@ -975,7 +975,7 @@ func validateJobTrigger(t string) error {
 		return status.Errorf(codes.InvalidArgument, "invalid trigger: %s", t)
 	}
 }
- 
+
 func validateFailureKind(kind string) error {
 	switch kind {
 	case jobsmodel.FailureKindUser.ToString(),
@@ -985,15 +985,15 @@ func validateFailureKind(kind string) error {
 		return status.Errorf(codes.InvalidArgument, "invalid failure kind: %s", kind)
 	}
 }
- 
+
 func normalizeJobLogsSortOrder(sortOrder jobsmodel.JobLogsSortOrder) jobsmodel.JobLogsSortOrder {
 	if sortOrder == jobsmodel.JobLogsSortOrderAsc {
 		return jobsmodel.JobLogsSortOrderAsc
 	}
- 
+
 	return jobsmodel.JobLogsSortOrderDesc
 }
- 
+
 func isTerminalJobStatus(jobStatus string) bool {
 	switch jobStatus {
 	case jobsmodel.JobStatusCompleted.ToString(),
@@ -1004,51 +1004,51 @@ func isTerminalJobStatus(jobStatus string) bool {
 		return false
 	}
 }
- 
+
 func validateListJobsFilters(filters *jobsmodel.ListJobsFilters) error {
 	if filters == nil {
 		return nil
 	}
- 
+
 	if filters.Status != "" {
 		err := validateJobStatus(filters.Status)
 		if err != nil {
 			return err
 		}
 	}
- 
+
 	return nil
 }
- 
+
 func decodeListJobsCursor(token string) (string, error) {
 	decoded, err := base64.StdEncoding.DecodeString(token)
 	if err != nil {
 		return "", err
 	}
- 
+
 	return string(decoded), nil
 }
- 
+
 func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
 	var zero T
- 
+
 	select {
 	case <-ctx.Done():
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
 		}
- 
+
 		return zero, status.Error(codes.Canceled, ctx.Err().Error())
 	case result := <-resultCh:
 		if result.Err != nil {
 			return zero, result.Err
 		}
- 
+
 		typed, ok := result.Val.(T)
 		if !ok {
 			return zero, status.Error(codes.Internal, "invalid singleflight result type")
 		}
- 
+
 		return typed, nil
 	}
 }

--- a/internal/service/jobs/jobs.go
+++ b/internal/service/jobs/jobs.go
@@ -1,7 +1,7 @@
 //go:generate mockgen -source=$GOFILE -package=$GOPACKAGE -destination=./mock/$GOFILE
-
+ 
 package jobs
-
+ 
 import (
 	"context"
 	"encoding/base64"
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
-
+ 
 	"github.com/go-playground/validator/v10"
 	goredis "github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
@@ -19,21 +19,21 @@ import (
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
+ 
 	jobspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
-
+ 
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/redis"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
-
+ 
 const (
 	defaultExpirationTTL      = time.Minute * 30
 	jobLogSearchExpirationTTL = time.Minute * 15
 	cacheTimeout              = time.Second * 5
 )
-
+ 
 // Repository provides job related operations.
 type Repository interface {
 	ScheduleJob(ctx context.Context, workflowID, userID, scheduledAt, trigger, idempotencyKey string, workflowGeneration int64) (string, error)
@@ -50,16 +50,21 @@ type Repository interface {
 	GetJobByID(ctx context.Context, jobID string) (*jobsmodel.GetJobByIDResponse, error)
 	GetJobLogs(ctx context.Context, jobID, workflowID, userID, cursor string, sortOrder jobsmodel.JobLogsSortOrder, filters *jobsmodel.GetJobLogsFilters) (*jobsmodel.GetJobLogsResponse, string, error)
 	StreamJobLogs(ctx context.Context, jobID, workflowID, userID string) (*goredis.PubSub, error)
-	SearchJobLogs(ctx context.Context, jobID, workflowID, userID, cursor string, filters *jobsmodel.SearchJobLogsFilters) (*jobsmodel.GetJobLogsResponse, string, error)
+	SearchJobLogs(
+		ctx context.Context,
+		jobID, workflowID, userID, cursor string,
+		filters *jobsmodel.SearchJobLogsFilters,
+		options jobsmodel.SearchJobLogsOptions,
+	) (*jobsmodel.GetJobLogsResponse, string, error)
 	ListJobs(ctx context.Context, workflowID, userID, cursor string, filters *jobsmodel.ListJobsFilters) (*jobsmodel.ListJobsResponse, error)
 }
-
+ 
 // Cache provides cache related operations.
 type Cache interface {
 	Set(ctx context.Context, key string, value any, expiration time.Duration) error
 	Get(ctx context.Context, key string, dest any) (any, error)
 }
-
+ 
 // Service provides job related operations.
 type Service struct {
 	validator *validator.Validate
@@ -68,7 +73,7 @@ type Service struct {
 	cache     Cache
 	sf        singleflight.Group
 }
-
+ 
 // New creates a new jobs-service.
 func New(validator *validator.Validate, repo Repository, cache Cache) *Service {
 	return &Service{
@@ -78,7 +83,7 @@ func New(validator *validator.Validate, repo Repository, cache Cache) *Service {
 		cache:     cache,
 	}
 }
-
+ 
 // ScheduleJobRequest holds the request parameters for scheduling a job.
 type ScheduleJobRequest struct {
 	WorkflowID         string `validate:"required"`
@@ -88,7 +93,7 @@ type ScheduleJobRequest struct {
 	IdempotencyKey     string `validate:"omitempty"`
 	WorkflowGeneration int64  `validate:"omitempty,min=0"`
 }
-
+ 
 // ScheduleJob schedules a job.
 func (s *Service) ScheduleJob(ctx context.Context, req *jobspb.ScheduleJobRequest) (jobID string, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.ScheduleJob")
@@ -99,7 +104,7 @@ func (s *Service) ScheduleJob(ctx context.Context, req *jobspb.ScheduleJobReques
 		}
 		span.End()
 	}()
-
+ 
 	// Validate the request
 	err = s.validator.Struct(&ScheduleJobRequest{
 		WorkflowID:         req.GetWorkflowId(),
@@ -113,23 +118,23 @@ func (s *Service) ScheduleJob(ctx context.Context, req *jobspb.ScheduleJobReques
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return "", status.Error(codes.InvalidArgument, err.Error())
 	}
-
+ 
 	// Validate the scheduled time
 	err = validateTime(req.GetScheduledAt())
 	if err != nil {
 		return "", err
 	}
-
+ 
 	// Validate the job trigger
 	err = validateJobTrigger(req.GetTrigger())
 	if err != nil {
 		return "", err
 	}
-
+ 
 	if req.GetTrigger() == jobsmodel.JobTriggerManual.ToString() && req.GetIdempotencyKey() == "" {
 		return "", status.Error(codes.InvalidArgument, "idempotency key is required for manual jobs")
 	}
-
+ 
 	// Schedule the job
 	res, err := s.repo.ScheduleJob(
 		ctx,
@@ -143,17 +148,17 @@ func (s *Service) ScheduleJob(ctx context.Context, req *jobspb.ScheduleJobReques
 	if err != nil {
 		return "", err
 	}
-
+ 
 	return res, nil
 }
-
+ 
 // UpdateJobStatusRequest holds the request parameters for updating a scheduled job status.
 type UpdateJobStatusRequest struct {
 	ID          string `validate:"required"`
 	ContainerID string `validate:"omitempty"`
 	Status      string `validate:"required"`
 }
-
+ 
 // UpdateJobStatus updates the scheduled job status.
 func (s *Service) UpdateJobStatus(ctx context.Context, req *jobspb.UpdateJobStatusRequest) (err error) {
 	ctx, span := s.tp.Start(ctx, "Service.UpdateJobStatus")
@@ -164,7 +169,7 @@ func (s *Service) UpdateJobStatus(ctx context.Context, req *jobspb.UpdateJobStat
 		}
 		span.End()
 	}()
-
+ 
 	// Validate the request
 	err = s.validator.Struct(&UpdateJobStatusRequest{
 		ID:          req.GetId(),
@@ -175,13 +180,13 @@ func (s *Service) UpdateJobStatus(ctx context.Context, req *jobspb.UpdateJobStat
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return err
 	}
-
+ 
 	// Validate the job status
 	err = validateJobStatus(req.GetStatus())
 	if err != nil {
 		return err
 	}
-
+ 
 	// Update the scheduled job status
 	err = s.repo.UpdateJobStatus(
 		ctx,
@@ -189,10 +194,10 @@ func (s *Service) UpdateJobStatus(ctx context.Context, req *jobspb.UpdateJobStat
 		req.GetContainerId(),
 		req.GetStatus(),
 	)
-
+ 
 	return err
 }
-
+ 
 // ClaimJobRequest holds the request parameters for claiming a job.
 type ClaimJobRequest struct {
 	ID                   string `validate:"required"`
@@ -201,7 +206,7 @@ type ClaimJobRequest struct {
 	LeaseDurationSeconds int32  `validate:"required,min=1"`
 	DispatchAttempt      int32  `validate:"required,min=1"`
 }
-
+ 
 // ClaimJob atomically claims a queued job for execution.
 func (s *Service) ClaimJob(ctx context.Context, req *jobspb.ClaimJobRequest) (res *jobspb.ClaimJobResponse, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.ClaimJob")
@@ -212,7 +217,7 @@ func (s *Service) ClaimJob(ctx context.Context, req *jobspb.ClaimJobRequest) (re
 		}
 		span.End()
 	}()
-
+ 
 	err = s.validator.Struct(&ClaimJobRequest{
 		ID:                   req.GetId(),
 		WorkflowID:           req.GetWorkflowId(),
@@ -223,7 +228,7 @@ func (s *Service) ClaimJob(ctx context.Context, req *jobspb.ClaimJobRequest) (re
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
-
+ 
 	claimed, ok, reason, err := s.repo.ClaimJob(
 		ctx,
 		req.GetId(),
@@ -235,17 +240,17 @@ func (s *Service) ClaimJob(ctx context.Context, req *jobspb.ClaimJobRequest) (re
 	if err != nil {
 		return nil, err
 	}
-
+ 
 	return claimed.ToClaimJobProto(ok, reason), nil
 }
-
+ 
 // RenewJobLeaseRequest holds the request parameters for renewing a job lease.
 type RenewJobLeaseRequest struct {
 	ID                   string `validate:"required"`
 	LeaseToken           string `validate:"required"`
 	LeaseDurationSeconds int32  `validate:"required,min=1"`
 }
-
+ 
 // RenewJobLease renews a running job lease.
 func (s *Service) RenewJobLease(ctx context.Context, req *jobspb.RenewJobLeaseRequest) (err error) {
 	ctx, span := s.tp.Start(ctx, "Service.RenewJobLease")
@@ -256,7 +261,7 @@ func (s *Service) RenewJobLease(ctx context.Context, req *jobspb.RenewJobLeaseRe
 		}
 		span.End()
 	}()
-
+ 
 	err = s.validator.Struct(&RenewJobLeaseRequest{
 		ID:                   req.GetId(),
 		LeaseToken:           req.GetLeaseToken(),
@@ -265,17 +270,17 @@ func (s *Service) RenewJobLease(ctx context.Context, req *jobspb.RenewJobLeaseRe
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
-
+ 
 	return s.repo.RenewJobLease(ctx, req.GetId(), req.GetLeaseToken(), time.Duration(req.GetLeaseDurationSeconds())*time.Second)
 }
-
+ 
 // AttachJobContainerRequest holds the request parameters for attaching a container.
 type AttachJobContainerRequest struct {
 	ID          string `validate:"required"`
 	LeaseToken  string `validate:"required"`
 	ContainerID string `validate:"required"`
 }
-
+ 
 // AttachJobContainer attaches a container ID to a running job.
 func (s *Service) AttachJobContainer(ctx context.Context, req *jobspb.AttachJobContainerRequest) (err error) {
 	ctx, span := s.tp.Start(ctx, "Service.AttachJobContainer")
@@ -286,7 +291,7 @@ func (s *Service) AttachJobContainer(ctx context.Context, req *jobspb.AttachJobC
 		}
 		span.End()
 	}()
-
+ 
 	err = s.validator.Struct(&AttachJobContainerRequest{
 		ID:          req.GetId(),
 		LeaseToken:  req.GetLeaseToken(),
@@ -295,16 +300,16 @@ func (s *Service) AttachJobContainer(ctx context.Context, req *jobspb.AttachJobC
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
-
+ 
 	return s.repo.AttachJobContainer(ctx, req.GetId(), req.GetLeaseToken(), req.GetContainerId())
 }
-
+ 
 // CompleteJobRequest holds the request parameters for completing a claimed job.
 type CompleteJobRequest struct {
 	ID         string `validate:"required"`
 	LeaseToken string `validate:"required"`
 }
-
+ 
 // CompleteJob completes a running claimed job.
 func (s *Service) CompleteJob(ctx context.Context, req *jobspb.CompleteJobRequest) (err error) {
 	ctx, span := s.tp.Start(ctx, "Service.CompleteJob")
@@ -315,15 +320,15 @@ func (s *Service) CompleteJob(ctx context.Context, req *jobspb.CompleteJobReques
 		}
 		span.End()
 	}()
-
+ 
 	err = s.validator.Struct(&CompleteJobRequest{ID: req.GetId(), LeaseToken: req.GetLeaseToken()})
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
-
+ 
 	return s.repo.CompleteJob(ctx, req.GetId(), req.GetLeaseToken())
 }
-
+ 
 // FailJobRequest holds the request parameters for failing a claimed job.
 type FailJobRequest struct {
 	ID           string `validate:"required"`
@@ -332,7 +337,7 @@ type FailJobRequest struct {
 	ErrorCode    string `validate:"omitempty"`
 	ErrorMessage string `validate:"omitempty"`
 }
-
+ 
 // FailJob marks a running claimed job as failed.
 //
 //nolint:dupl // Lease terminal methods intentionally share validation and tracing shape.
@@ -345,7 +350,7 @@ func (s *Service) FailJob(ctx context.Context, req *jobspb.FailJobRequest) (err 
 		}
 		span.End()
 	}()
-
+ 
 	err = s.validator.Struct(&FailJobRequest{
 		ID:           req.GetId(),
 		LeaseToken:   req.GetLeaseToken(),
@@ -359,10 +364,10 @@ func (s *Service) FailJob(ctx context.Context, req *jobspb.FailJobRequest) (err 
 	if err := validateFailureKind(req.GetFailureKind()); err != nil {
 		return err
 	}
-
+ 
 	return s.repo.FailJob(ctx, req.GetId(), req.GetLeaseToken(), req.GetFailureKind(), req.GetErrorCode(), req.GetErrorMessage())
 }
-
+ 
 // CancelClaimedJob cancels a running claimed job.
 func (s *Service) CancelClaimedJob(ctx context.Context, req *jobspb.CancelClaimedJobRequest) (err error) {
 	ctx, span := s.tp.Start(ctx, "Service.CancelClaimedJob")
@@ -373,15 +378,15 @@ func (s *Service) CancelClaimedJob(ctx context.Context, req *jobspb.CancelClaime
 		}
 		span.End()
 	}()
-
+ 
 	err = s.validator.Struct(&CompleteJobRequest{ID: req.GetId(), LeaseToken: req.GetLeaseToken()})
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
-
+ 
 	return s.repo.CancelClaimedJob(ctx, req.GetId(), req.GetLeaseToken())
 }
-
+ 
 // ReleaseJobForRetryRequest holds the request parameters for retrying a claimed job.
 type ReleaseJobForRetryRequest struct {
 	ID            string `validate:"required"`
@@ -390,7 +395,7 @@ type ReleaseJobForRetryRequest struct {
 	ErrorCode     string `validate:"omitempty"`
 	ErrorMessage  string `validate:"omitempty"`
 }
-
+ 
 // ReleaseJobForRetry releases a running claimed job back to pending.
 //
 //nolint:dupl // Lease terminal methods intentionally share validation and tracing shape.
@@ -403,7 +408,7 @@ func (s *Service) ReleaseJobForRetry(ctx context.Context, req *jobspb.ReleaseJob
 		}
 		span.End()
 	}()
-
+ 
 	err = s.validator.Struct(&ReleaseJobForRetryRequest{
 		ID:            req.GetId(),
 		LeaseToken:    req.GetLeaseToken(),
@@ -417,17 +422,17 @@ func (s *Service) ReleaseJobForRetry(ctx context.Context, req *jobspb.ReleaseJob
 	if err := validateTime(req.GetNextAttemptAt()); err != nil {
 		return err
 	}
-
+ 
 	return s.repo.ReleaseJobForRetry(ctx, req.GetId(), req.GetLeaseToken(), req.GetNextAttemptAt(), req.GetErrorCode(), req.GetErrorMessage())
 }
-
+ 
 // RecoverExpiredJobLeasesRequest holds the request parameters for lease recovery.
 type RecoverExpiredJobLeasesRequest struct {
 	BatchSize            int32  `validate:"required,min=1"`
 	WorkerID             string `validate:"required"`
 	LeaseDurationSeconds int32  `validate:"required,min=1"`
 }
-
+ 
 // RecoverExpiredJobLeases returns expired running job leases for recovery.
 func (s *Service) RecoverExpiredJobLeases(ctx context.Context, req *jobspb.RecoverExpiredJobLeasesRequest) (res []*jobsmodel.ExpiredJobLease, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.RecoverExpiredJobLeases")
@@ -438,7 +443,7 @@ func (s *Service) RecoverExpiredJobLeases(ctx context.Context, req *jobspb.Recov
 		}
 		span.End()
 	}()
-
+ 
 	err = s.validator.Struct(&RecoverExpiredJobLeasesRequest{
 		BatchSize:            req.GetBatchSize(),
 		WorkerID:             req.GetWorkerId(),
@@ -447,7 +452,7 @@ func (s *Service) RecoverExpiredJobLeases(ctx context.Context, req *jobspb.Recov
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
-
+ 
 	return s.repo.RecoverExpiredJobLeases(
 		ctx,
 		req.GetBatchSize(),
@@ -455,14 +460,14 @@ func (s *Service) RecoverExpiredJobLeases(ctx context.Context, req *jobspb.Recov
 		time.Duration(req.GetLeaseDurationSeconds())*time.Second,
 	)
 }
-
+ 
 // GetJobRequest holds the request parameters for getting a scheduled job.
 type GetJobRequest struct {
 	ID         string `validate:"required"`
 	WorkflowID string `validate:"required"`
 	UserID     string `validate:"required"`
 }
-
+ 
 // GetJob returns the scheduled job details by ID, job ID, and user ID.
 func (s *Service) GetJob(ctx context.Context, req *jobspb.GetJobRequest) (res *jobsmodel.GetJobResponse, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.GetJob")
@@ -473,7 +478,7 @@ func (s *Service) GetJob(ctx context.Context, req *jobspb.GetJobRequest) (res *j
 		}
 		span.End()
 	}()
-
+ 
 	// Validate the request
 	err = s.validator.Struct(&GetJobRequest{
 		ID:         req.GetId(),
@@ -484,21 +489,21 @@ func (s *Service) GetJob(ctx context.Context, req *jobspb.GetJobRequest) (res *j
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-
+ 
 	// Get the scheduled job details
 	res, err = s.repo.GetJob(ctx, req.GetId(), req.GetWorkflowId(), req.GetUserId())
 	if err != nil {
 		return nil, err
 	}
-
+ 
 	return res, nil
 }
-
+ 
 // GetJobByIDRequest holds the request parameters for getting a scheduled job by ID.
 type GetJobByIDRequest struct {
 	ID string `validate:"required"`
 }
-
+ 
 // GetJobByID returns the scheduled job details by ID.
 func (s *Service) GetJobByID(ctx context.Context, req *jobspb.GetJobByIDRequest) (res *jobsmodel.GetJobByIDResponse, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.GetJobByID")
@@ -509,7 +514,7 @@ func (s *Service) GetJobByID(ctx context.Context, req *jobspb.GetJobByIDRequest)
 		}
 		span.End()
 	}()
-
+ 
 	// Validate the request
 	err = s.validator.Struct(&GetJobByIDRequest{
 		ID: req.GetId(),
@@ -518,19 +523,19 @@ func (s *Service) GetJobByID(ctx context.Context, req *jobspb.GetJobByIDRequest)
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-
+ 
 	resultCh := s.sf.DoChan(fmt.Sprintf("job_by_id:%s", req.GetId()), func() (any, error) {
 		return s.repo.GetJobByID(ctx, req.GetId())
 	})
-
+ 
 	res, err = waitSingleflightResult[*jobsmodel.GetJobByIDResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
-
+ 
 	return res, nil
 }
-
+ 
 // GetJobLogsRequest holds the request parameters for getting scheduled job logs.
 type GetJobLogsRequest struct {
 	ID         string                       `validate:"required"`
@@ -540,7 +545,7 @@ type GetJobLogsRequest struct {
 	SortOrder  int                          `validate:"omitempty,min=0,max=2"`
 	Filters    *jobsmodel.GetJobLogsFilters `validate:"required"`
 }
-
+ 
 // GetJobLogs returns the scheduled job logs.
 func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest) (res *jobsmodel.GetJobLogsResponse, err error) {
 	logger := loggerpkg.FromContext(ctx).With(
@@ -554,7 +559,7 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		}
 		span.End()
 	}()
-
+ 
 	var filters *jobsmodel.GetJobLogsFilters
 	if req.GetFilters() != nil {
 		filters = &jobsmodel.GetJobLogsFilters{
@@ -563,7 +568,7 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 	} else {
 		filters = &jobsmodel.GetJobLogsFilters{}
 	}
-
+ 
 	// Validate the request
 	err = s.validator.Struct(&GetJobLogsRequest{
 		ID:         req.GetId(),
@@ -577,9 +582,9 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-
+ 
 	sortOrder := normalizeJobLogsSortOrder(jobsmodel.JobLogsSortOrder(req.GetSortOrder()))
-
+ 
 	// Check if the job logs are cached
 	cacheKey := fmt.Sprintf(
 		"job_logs:%s:%s:%s:%s:%d",
@@ -603,7 +608,7 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 			return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 		}
 	}
-
+ 
 	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
 		_res, jobStatus, _err := s.repo.GetJobLogs(
 			ctx,
@@ -617,14 +622,14 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		if _err != nil {
 			return nil, _err
 		}
-
+ 
 		// Cache only stable cursor pages. A cursor page with no response cursor is the current tail,
 		// which can still receive late retained logs while the repo reports the job as running.
 		if isCursorPage && (_res.Cursor != "" || isTerminalJobStatus(jobStatus)) {
 			go func() {
 				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 				defer cancel()
-
+ 
 				if setErr := s.cache.Set(bgCtx, cacheKey, _res, defaultExpirationTTL); setErr != nil {
 					logger.Warn("failed to cache job logs",
 						zap.String("user_id", req.GetUserId()),
@@ -641,25 +646,25 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 				}
 			}()
 		}
-
+ 
 		return _res, nil
 	})
-
+ 
 	res, err = waitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
-
+ 
 	return res, nil
 }
-
+ 
 // StreamJobLogsRequest holds the request parameters for streaming scheduled job logs.
 type StreamJobLogsRequest struct {
 	ID         string `validate:"required"`
 	WorkflowID string `validate:"required"`
 	UserID     string `validate:"required"`
 }
-
+ 
 // StreamJobLogs streams the job logs.
 func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRequest) (ch chan *jobsmodel.JobLog, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.StreamJobLogs")
@@ -670,7 +675,7 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 		}
 		span.End()
 	}()
-
+ 
 	// Validate the request
 	err = s.validator.Struct(&StreamJobLogsRequest{
 		ID:         req.GetId(),
@@ -681,14 +686,14 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-
+ 
 	// Stream the scheduled job logs
 	sub, _err := s.repo.StreamJobLogs(ctx, req.GetId(), req.GetWorkflowId(), req.GetUserId())
 	if _err != nil {
 		err = _err
 		return nil, err
 	}
-
+ 
 	subscribedChannel := sub.Channel()
 	ch = make(chan *jobsmodel.JobLog)
 	go func() {
@@ -696,7 +701,7 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 		//nolint:errcheck // Ignore error as we are closing the channel
 		defer sub.Unsubscribe(ctx, redis.GetJobLogsChannel(req.GetId()))
 		defer sub.Close()
-
+ 
 		for {
 			select {
 			case <-ctx.Done():
@@ -705,17 +710,17 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 				if !ok {
 					return
 				}
-
+ 
 				if data == nil {
 					continue
 				}
-
+ 
 				payload := data.Payload
 				var log jobsmodel.JobLogEvent
 				if err := json.Unmarshal([]byte(payload), &log); err != nil {
 					continue
 				}
-
+ 
 				select {
 				case ch <- &jobsmodel.JobLog{
 					EventID:     log.EventKey,
@@ -730,19 +735,20 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 			}
 		}
 	}()
-
+ 
 	return ch, nil
 }
-
+ 
 // SearchJobLogsRequest holds the request parameters for getting filtered logs of a job.
 type SearchJobLogsRequest struct {
 	ID         string                          `validate:"required"`
 	WorkflowID string                          `validate:"required"`
 	UserID     string                          `validate:"required"`
 	Cursor     string                          `validate:"omitempty"`
+	SortOrder  int                             `validate:"omitempty,min=0,max=2"`
 	Filters    *jobsmodel.SearchJobLogsFilters `validate:"required"`
 }
-
+ 
 // SearchJobLogs returns the filtered logs of a job.
 func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRequest) (res *jobsmodel.GetJobLogsResponse, err error) {
 	logger := loggerpkg.FromContext(ctx).With(
@@ -756,7 +762,7 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 		}
 		span.End()
 	}()
-
+ 
 	var filters *jobsmodel.SearchJobLogsFilters
 	if req.GetFilters() != nil {
 		filters = &jobsmodel.SearchJobLogsFilters{
@@ -766,28 +772,34 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 	} else {
 		filters = &jobsmodel.SearchJobLogsFilters{}
 	}
-
+ 
 	// Validate the struct
 	err = s.validator.Struct(&SearchJobLogsRequest{
 		ID:         req.GetId(),
 		WorkflowID: req.GetWorkflowId(),
 		UserID:     req.GetUserId(),
 		Cursor:     req.GetCursor(),
+		SortOrder:  int(req.GetSortOrder()),
 		Filters:    filters,
 	})
 	if err != nil {
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-
+ 
+	sortOrder := normalizeJobLogsSortOrder(jobsmodel.JobLogsSortOrder(req.GetSortOrder()))
+	disableHighlight := req.GetDisableHighlight()
+ 
 	// Check if the job logs are cached
 	cacheKey := fmt.Sprintf(
-		"job_logs:%s:%s:%s:%s:%s",
+		"job_logs:search:%s:%s:%s:%s:%s:%d:%t",
 		req.GetUserId(),
 		req.GetId(),
 		req.GetCursor(),
 		req.GetFilters().GetMessage(),
 		req.GetFilters().GetStream(),
+		sortOrder,
+		disableHighlight,
 	)
 	isCursorPage := req.GetCursor() != ""
 	if isCursorPage {
@@ -803,7 +815,7 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 			return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 		}
 	}
-
+ 
 	resultCh := s.sf.DoChan(cacheKey, func() (any, error) {
 		_res, jobStatus, _err := s.repo.SearchJobLogs(
 			ctx,
@@ -812,16 +824,20 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 			req.GetUserId(),
 			req.GetCursor(),
 			filters,
+			jobsmodel.SearchJobLogsOptions{
+				SortOrder:        sortOrder,
+				DisableHighlight: disableHighlight,
+			},
 		)
 		if _err != nil {
 			return nil, _err
 		}
-
+ 
 		if isCursorPage && (_res.Cursor != "" || isTerminalJobStatus(jobStatus)) {
 			go func() {
 				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 				defer cancel()
-
+ 
 				if setErr := s.cache.Set(bgCtx, cacheKey, _res, jobLogSearchExpirationTTL); setErr != nil {
 					logger.Warn("failed to cache job logs",
 						zap.String("user_id", req.GetUserId()),
@@ -838,18 +854,18 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 				}
 			}()
 		}
-
+ 
 		return _res, nil
 	})
-
+ 
 	res, err = waitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
-
+ 
 	return res, nil
 }
-
+ 
 // ListJobsRequest holds the request parameters for listing scheduled jobs.
 type ListJobsRequest struct {
 	WorkflowID string                     `validate:"required"`
@@ -857,7 +873,7 @@ type ListJobsRequest struct {
 	Cursor     string                     `validate:"omitempty"`
 	Filters    *jobsmodel.ListJobsFilters `validate:"omitempty"`
 }
-
+ 
 // ListJobs returns scheduled jobs.
 func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (res *jobsmodel.ListJobsResponse, err error) {
 	ctx, span := s.tp.Start(ctx, "Service.ListJobs")
@@ -868,7 +884,7 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 		}
 		span.End()
 	}()
-
+ 
 	var filters *jobsmodel.ListJobsFilters
 	if req.GetFilters() != nil {
 		filters = &jobsmodel.ListJobsFilters{
@@ -878,7 +894,7 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 	} else {
 		filters = &jobsmodel.ListJobsFilters{}
 	}
-
+ 
 	// Validate the request
 	err = s.validator.Struct(&ListJobsRequest{
 		WorkflowID: req.GetWorkflowId(),
@@ -890,7 +906,7 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 		err = status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-
+ 
 	// Validate the cursor
 	var cursor string
 	if req.GetCursor() != "" {
@@ -900,13 +916,13 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 			return nil, err
 		}
 	}
-
+ 
 	// Validate the filters
 	if err = validateListJobsFilters(filters); err != nil {
 		err = status.Errorf(codes.InvalidArgument, "invalid filters: %v", err)
 		return nil, err
 	}
-
+ 
 	listKey := fmt.Sprintf(
 		"jobs:%s:%s:cursor=%s&status=%s&trigger=%s",
 		req.GetUserId(),
@@ -918,24 +934,24 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 	resultCh := s.sf.DoChan(listKey, func() (any, error) {
 		return s.repo.ListJobs(ctx, req.GetWorkflowId(), req.GetUserId(), cursor, filters)
 	})
-
+ 
 	res, err = waitSingleflightResult[*jobsmodel.ListJobsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
-
+ 
 	return res, nil
 }
-
+ 
 func validateTime(t string) error {
 	_, err := time.Parse(time.RFC3339Nano, t)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid time: %v", err)
 	}
-
+ 
 	return nil
 }
-
+ 
 func validateJobStatus(s string) error {
 	switch s {
 	case jobsmodel.JobStatusPending.ToString(),
@@ -949,7 +965,7 @@ func validateJobStatus(s string) error {
 		return status.Errorf(codes.InvalidArgument, "invalid status: %s", s)
 	}
 }
-
+ 
 func validateJobTrigger(t string) error {
 	switch t {
 	case jobsmodel.JobTriggerAutomatic.ToString(),
@@ -959,7 +975,7 @@ func validateJobTrigger(t string) error {
 		return status.Errorf(codes.InvalidArgument, "invalid trigger: %s", t)
 	}
 }
-
+ 
 func validateFailureKind(kind string) error {
 	switch kind {
 	case jobsmodel.FailureKindUser.ToString(),
@@ -969,15 +985,15 @@ func validateFailureKind(kind string) error {
 		return status.Errorf(codes.InvalidArgument, "invalid failure kind: %s", kind)
 	}
 }
-
+ 
 func normalizeJobLogsSortOrder(sortOrder jobsmodel.JobLogsSortOrder) jobsmodel.JobLogsSortOrder {
 	if sortOrder == jobsmodel.JobLogsSortOrderAsc {
 		return jobsmodel.JobLogsSortOrderAsc
 	}
-
+ 
 	return jobsmodel.JobLogsSortOrderDesc
 }
-
+ 
 func isTerminalJobStatus(jobStatus string) bool {
 	switch jobStatus {
 	case jobsmodel.JobStatusCompleted.ToString(),
@@ -988,51 +1004,51 @@ func isTerminalJobStatus(jobStatus string) bool {
 		return false
 	}
 }
-
+ 
 func validateListJobsFilters(filters *jobsmodel.ListJobsFilters) error {
 	if filters == nil {
 		return nil
 	}
-
+ 
 	if filters.Status != "" {
 		err := validateJobStatus(filters.Status)
 		if err != nil {
 			return err
 		}
 	}
-
+ 
 	return nil
 }
-
+ 
 func decodeListJobsCursor(token string) (string, error) {
 	decoded, err := base64.StdEncoding.DecodeString(token)
 	if err != nil {
 		return "", err
 	}
-
+ 
 	return string(decoded), nil
 }
-
+ 
 func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
 	var zero T
-
+ 
 	select {
 	case <-ctx.Done():
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
 		}
-
+ 
 		return zero, status.Error(codes.Canceled, ctx.Err().Error())
 	case result := <-resultCh:
 		if result.Err != nil {
 			return zero, result.Err
 		}
-
+ 
 		typed, ok := result.Val.(T)
 		if !ok {
 			return zero, status.Error(codes.Internal, "invalid singleflight result type")
 		}
-
+ 
 		return typed, nil
 	}
 }

--- a/internal/service/jobs/jobs_test.go
+++ b/internal/service/jobs/jobs_test.go
@@ -1,5 +1,5 @@
 package jobs_test
-
+ 
 import (
 	"context"
 	"database/sql"
@@ -8,34 +8,34 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
+ 
 	"github.com/go-playground/validator/v10"
 	"github.com/go-redis/redismock/v9"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
+ 
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 	"github.com/hitesh22rana/chronoverse/internal/service/jobs"
 	jobsmock "github.com/hitesh22rana/chronoverse/internal/service/jobs/mock"
 	jobspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
 )
-
+ 
 func TestScheduleJob(t *testing.T) {
 	ctrl := gomock.NewController(t)
-
+ 
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
-
+ 
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
-
+ 
 	type want struct {
 		jobID string
 	}
-
+ 
 	// Test cases
 	tests := []struct {
 		name  string
@@ -172,9 +172,9 @@ func TestScheduleJob(t *testing.T) {
 			isErr: true,
 		},
 	}
-
+ 
 	defer ctrl.Finish()
-
+ 
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -185,27 +185,27 @@ func TestScheduleJob(t *testing.T) {
 				}
 				return
 			}
-
+ 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-
+ 
 			assert.Equal(t, jobID, tt.want.jobID)
 		})
 	}
 }
-
+ 
 func TestUpdateJobStatus(t *testing.T) {
 	ctrl := gomock.NewController(t)
-
+ 
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
-
+ 
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
-
+ 
 	// Test cases
 	tests := []struct {
 		name  string
@@ -306,9 +306,9 @@ func TestUpdateJobStatus(t *testing.T) {
 			isErr: true,
 		},
 	}
-
+ 
 	defer ctrl.Finish()
-
+ 
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -319,7 +319,7 @@ func TestUpdateJobStatus(t *testing.T) {
 				}
 				return
 			}
-
+ 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
@@ -327,21 +327,21 @@ func TestUpdateJobStatus(t *testing.T) {
 		})
 	}
 }
-
+ 
 func TestGetJob(t *testing.T) {
 	ctrl := gomock.NewController(t)
-
+ 
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
-
+ 
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
-
+ 
 	type want struct {
 		*jobsmodel.GetJobResponse
 	}
-
+ 
 	var (
 		createdAt   = time.Now()
 		updatedAt   = time.Now()
@@ -355,7 +355,7 @@ func TestGetJob(t *testing.T) {
 			Valid: false,
 		}
 	)
-
+ 
 	// Test cases
 	tests := []struct {
 		name  string
@@ -488,9 +488,9 @@ func TestGetJob(t *testing.T) {
 			isErr: true,
 		},
 	}
-
+ 
 	defer ctrl.Finish()
-
+ 
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -501,31 +501,31 @@ func TestGetJob(t *testing.T) {
 				}
 				return
 			}
-
+ 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-
+ 
 			assert.Equal(t, job, tt.want.GetJobResponse)
 		})
 	}
 }
-
+ 
 func TestGetJobByID(t *testing.T) {
 	ctrl := gomock.NewController(t)
-
+ 
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
-
+ 
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
-
+ 
 	type want struct {
 		*jobsmodel.GetJobByIDResponse
 	}
-
+ 
 	var (
 		createdAt   = time.Now()
 		updatedAt   = time.Now()
@@ -539,7 +539,7 @@ func TestGetJobByID(t *testing.T) {
 			Valid: false,
 		}
 	)
-
+ 
 	// Test cases
 	tests := []struct {
 		name  string
@@ -622,9 +622,9 @@ func TestGetJobByID(t *testing.T) {
 			isErr: true,
 		},
 	}
-
+ 
 	defer ctrl.Finish()
-
+ 
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -635,37 +635,37 @@ func TestGetJobByID(t *testing.T) {
 				}
 				return
 			}
-
+ 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-
+ 
 			assert.Equal(t, job, tt.want.GetJobByIDResponse)
 		})
 	}
 }
-
+ 
 func TestGetJobLogs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-
+ 
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
-
+ 
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
-
+ 
 	type want struct {
 		*jobsmodel.GetJobLogsResponse
 	}
-
+ 
 	var (
 		timestamp               = time.Now()
 		singleflightRepoCalls   int32
 		singleflightReleaseChan chan struct{}
 	)
-
+ 
 	// Test cases
 	tests := []struct {
 		name    string
@@ -1003,7 +1003,7 @@ func TestGetJobLogs(t *testing.T) {
 					jobsmodel.JobLogsSortOrderDesc,
 				)
 				filters := &jobsmodel.GetJobLogsFilters{Stream: int(req.GetFilters().GetStream())}
-
+ 
 				cache.EXPECT().
 					Get(gomock.Any(), cacheKey, gomock.Any()).
 					Return(nil, status.Error(codes.NotFound, "cache miss")).
@@ -1012,7 +1012,7 @@ func TestGetJobLogs(t *testing.T) {
 					Set(gomock.Any(), cacheKey, gomock.Any(), gomock.Any()).
 					Return(nil).
 					AnyTimes()
-
+ 
 				singleflightRepoCalls = 0
 				singleflightReleaseChan = make(chan struct{})
 				repo.EXPECT().
@@ -1036,18 +1036,18 @@ func TestGetJobLogs(t *testing.T) {
 			},
 			execute: func(t *testing.T, req *jobspb.GetJobLogsRequest, want want) {
 				t.Helper()
-
+ 
 				var wg sync.WaitGroup
 				results := make([]*jobsmodel.GetJobLogsResponse, 2)
 				errs := make([]error, 2)
-
+ 
 				for i := range 2 {
 					idx := i
 					wg.Go(func() {
 						results[idx], errs[idx] = s.GetJobLogs(t.Context(), req)
 					})
 				}
-
+ 
 				for range 50 {
 					if atomic.LoadInt32(&singleflightRepoCalls) == 1 {
 						break
@@ -1056,7 +1056,7 @@ func TestGetJobLogs(t *testing.T) {
 				}
 				close(singleflightReleaseChan)
 				wg.Wait()
-
+ 
 				assert.Equal(t, int32(1), atomic.LoadInt32(&singleflightRepoCalls))
 				assert.NoError(t, errs[0])
 				assert.NoError(t, errs[1])
@@ -1184,9 +1184,9 @@ func TestGetJobLogs(t *testing.T) {
 			isErr: true,
 		},
 	}
-
+ 
 	defer ctrl.Finish()
-
+ 
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -1194,7 +1194,7 @@ func TestGetJobLogs(t *testing.T) {
 				tt.execute(t, tt.req, tt.want)
 				return
 			}
-
+ 
 			jobLogs, err := s.GetJobLogs(t.Context(), tt.req)
 			if tt.isErr {
 				if err == nil {
@@ -1202,25 +1202,25 @@ func TestGetJobLogs(t *testing.T) {
 				}
 				return
 			}
-
+ 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-
+ 
 			assert.Equal(t, jobLogs, tt.want.GetJobLogsResponse)
 		})
 	}
 }
-
+ 
 func TestGetJobLogsAscendingSortOrder(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-
+ 
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
 	s := jobs.New(validator.New(), repo, cache)
-
+ 
 	req := &jobspb.GetJobLogsRequest{
 		Id:         "job_id",
 		WorkflowId: "workflow_id",
@@ -1239,12 +1239,12 @@ func TestGetJobLogsAscendingSortOrder(t *testing.T) {
 		req.GetFilters().GetStream(),
 		jobsmodel.JobLogsSortOrderAsc,
 	)
-
+ 
 	cache.EXPECT().Get(gomock.Any(), cacheKey, gomock.Any()).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
 	repo.EXPECT().
 		GetJobLogs(gomock.Any(), req.GetId(), req.GetWorkflowId(), req.GetUserId(), req.GetCursor(), jobsmodel.JobLogsSortOrderAsc, filters).
 		Return(&jobsmodel.GetJobLogsResponse{ID: req.GetId(), WorkflowID: req.GetWorkflowId()}, jobsmodel.JobStatusRunning.ToString(), nil)
-
+ 
 	res, err := s.GetJobLogs(t.Context(), req)
 	if err != nil {
 		t.Fatalf("GetJobLogs() error = %v", err)
@@ -1253,21 +1253,21 @@ func TestGetJobLogsAscendingSortOrder(t *testing.T) {
 		t.Fatalf("unexpected response ID: got %q want %q", res.ID, req.GetId())
 	}
 }
-
+ 
 func TestStreamJobLogs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-
+ 
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
-
+ 
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
-
+ 
 	type want struct {
 		channelType string
 	}
-
+ 
 	// Test cases
 	tests := []struct {
 		name  string
@@ -1286,14 +1286,14 @@ func TestStreamJobLogs(t *testing.T) {
 			mock: func(req *jobspb.StreamJobLogsRequest) {
 				redisMock, _ := redismock.NewClientMock()
 				sub := redisMock.Subscribe(t.Context(), "job_logs")
-
+ 
 				repo.EXPECT().StreamJobLogs(
 					gomock.Any(),
 					req.GetId(),
 					req.GetWorkflowId(),
 					req.GetUserId(),
 				).Return(sub, nil)
-
+ 
 				// Simulate sending logs to the channel
 				go func() {
 					redisMock.Publish(t.Context(), "job_logs", &jobsmodel.JobLog{
@@ -1358,15 +1358,15 @@ func TestStreamJobLogs(t *testing.T) {
 			isErr: true,
 		},
 	}
-
+ 
 	defer ctrl.Finish()
-
+ 
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 			defer cancel()
-
+ 
 			stream, err := s.StreamJobLogs(ctx, tt.req)
 			if tt.isErr {
 				if err == nil {
@@ -1377,17 +1377,17 @@ func TestStreamJobLogs(t *testing.T) {
 				}
 				return
 			}
-
+ 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-
+ 
 			if stream == nil {
 				t.Errorf("expected channel, got nil")
 				return
 			}
-
+ 
 			// Test that the channel is properly typed
 			select {
 			case <-stream:
@@ -1395,13 +1395,13 @@ func TestStreamJobLogs(t *testing.T) {
 			case <-time.After(100 * time.Millisecond):
 				// Channel is not immediately readable (also expected)
 			}
-
+ 
 			// Verify the channel can be closed without panic
 			go func() {
 				time.Sleep(50 * time.Millisecond)
 				cancel() // This should trigger cleanup in the goroutine
 			}()
-
+ 
 			// Try to read from channel with timeout to ensure cleanup works
 			select {
 			case <-stream:
@@ -1411,23 +1411,50 @@ func TestStreamJobLogs(t *testing.T) {
 		})
 	}
 }
-
+ 
+func searchJobLogsCacheKeyForTest(req *jobspb.SearchJobLogsRequest) string {
+	options := searchJobLogsOptionsForTest(req)
+ 
+	return fmt.Sprintf(
+		"job_logs:search:%s:%s:%s:%s:%s:%d:%t",
+		req.GetUserId(),
+		req.GetId(),
+		req.GetCursor(),
+		req.GetFilters().GetMessage(),
+		req.GetFilters().GetStream(),
+		options.SortOrder,
+		options.DisableHighlight,
+	)
+}
+ 
+func searchJobLogsOptionsForTest(req *jobspb.SearchJobLogsRequest) jobsmodel.SearchJobLogsOptions {
+	sortOrder := jobsmodel.JobLogsSortOrderDesc
+	if req.GetSortOrder() == jobspb.LogSortOrder_LOG_SORT_ORDER_ASC {
+		sortOrder = jobsmodel.JobLogsSortOrderAsc
+	}
+ 
+	return jobsmodel.SearchJobLogsOptions{
+		SortOrder:        sortOrder,
+		DisableHighlight: req.GetDisableHighlight(),
+	}
+}
+ 
 func TestSearchJobLogs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-
+ 
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
-
+ 
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
-
+ 
 	type want struct {
 		*jobsmodel.GetJobLogsResponse
 	}
-
+ 
 	timestamp := time.Now()
-
+ 
 	// Test cases
 	tests := []struct {
 		name  string
@@ -1467,14 +1494,7 @@ func TestSearchJobLogs(t *testing.T) {
 						},
 					},
 				}
-				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s:%s",
-					req.GetUserId(),
-					req.GetId(),
-					req.GetCursor(),
-					req.GetFilters().GetMessage(),
-					req.GetFilters().GetStream(),
-				)
+				cacheKey := searchJobLogsCacheKeyForTest(req)
 				var filters *jobsmodel.SearchJobLogsFilters
 				if req.GetFilters() != nil {
 					filters = &jobsmodel.SearchJobLogsFilters{
@@ -1496,6 +1516,7 @@ func TestSearchJobLogs(t *testing.T) {
 					req.GetUserId(),
 					req.GetCursor(),
 					filters,
+					searchJobLogsOptionsForTest(req),
 				).Return(data, "COMPLETED", nil)
 				cache.EXPECT().Set(
 					gomock.Any(),
@@ -1527,6 +1548,66 @@ func TestSearchJobLogs(t *testing.T) {
 			isErr: false,
 		},
 		{
+			name: "success: ascending sort with highlights disabled",
+			req: &jobspb.SearchJobLogsRequest{
+				Id:               "job_id",
+				WorkflowId:       "workflow_id",
+				UserId:           "user_id",
+				Cursor:           "",
+				SortOrder:        jobspb.LogSortOrder_LOG_SORT_ORDER_ASC,
+				DisableHighlight: true,
+				Filters: &jobspb.SearchJobLogsFilters{
+					Stream:  jobspb.LogStream_LOG_STREAM_STDOUT,
+					Message: "message",
+				},
+			},
+			mock: func(req *jobspb.SearchJobLogsRequest) {
+				data := &jobsmodel.GetJobLogsResponse{
+					ID:         req.GetId(),
+					WorkflowID: req.GetWorkflowId(),
+					JobLogs: []*jobsmodel.JobLog{
+						{
+							Timestamp:   timestamp,
+							Message:     "message 1",
+							SequenceNum: 1,
+							Stream:      "stdout",
+						},
+					},
+				}
+				filters := &jobsmodel.SearchJobLogsFilters{
+					Stream:  int(req.GetFilters().GetStream()),
+					Message: req.GetFilters().GetMessage(),
+				}
+				repo.EXPECT().SearchJobLogs(
+					gomock.Any(),
+					req.GetId(),
+					req.GetWorkflowId(),
+					req.GetUserId(),
+					req.GetCursor(),
+					filters,
+					jobsmodel.SearchJobLogsOptions{
+						SortOrder:        jobsmodel.JobLogsSortOrderAsc,
+						DisableHighlight: true,
+					},
+				).Return(data, "COMPLETED", nil)
+			},
+			want: want{
+				&jobsmodel.GetJobLogsResponse{
+					ID:         "job_id",
+					WorkflowID: "workflow_id",
+					JobLogs: []*jobsmodel.JobLog{
+						{
+							Timestamp:   timestamp,
+							Message:     "message 1",
+							SequenceNum: 1,
+							Stream:      "stdout",
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		{
 			name: "success: with cache hit",
 			req: &jobspb.SearchJobLogsRequest{
 				Id:         "job_id",
@@ -1539,14 +1620,7 @@ func TestSearchJobLogs(t *testing.T) {
 				},
 			},
 			mock: func(req *jobspb.SearchJobLogsRequest) {
-				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s:%s",
-					req.GetUserId(),
-					req.GetId(),
-					req.GetCursor(),
-					req.GetFilters().GetMessage(),
-					req.GetFilters().GetStream(),
-				)
+				cacheKey := searchJobLogsCacheKeyForTest(req)
 				cache.EXPECT().Get(gomock.Any(), cacheKey, gomock.Any()).Return(&jobsmodel.GetJobLogsResponse{
 					ID:         "job_id",
 					WorkflowID: "workflow_id",
@@ -1622,14 +1696,7 @@ func TestSearchJobLogs(t *testing.T) {
 					},
 					Cursor: "cursor",
 				}
-				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s:%s",
-					req.GetUserId(),
-					req.GetId(),
-					req.GetCursor(),
-					req.GetFilters().GetMessage(),
-					req.GetFilters().GetStream(),
-				)
+				cacheKey := searchJobLogsCacheKeyForTest(req)
 				var filters *jobsmodel.SearchJobLogsFilters
 				if req.GetFilters() != nil {
 					filters = &jobsmodel.SearchJobLogsFilters{
@@ -1651,6 +1718,7 @@ func TestSearchJobLogs(t *testing.T) {
 					req.GetUserId(),
 					req.GetCursor(),
 					filters,
+					searchJobLogsOptionsForTest(req),
 				).Return(data, "COMPLETED", nil)
 				cache.EXPECT().Set(
 					gomock.Any(),
@@ -1707,14 +1775,7 @@ func TestSearchJobLogs(t *testing.T) {
 						},
 					},
 				}
-				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s:%s",
-					req.GetUserId(),
-					req.GetId(),
-					req.GetCursor(),
-					req.GetFilters().GetMessage(),
-					req.GetFilters().GetStream(),
-				)
+				cacheKey := searchJobLogsCacheKeyForTest(req)
 				filters := &jobsmodel.SearchJobLogsFilters{
 					Stream:  int(req.GetFilters().GetStream()),
 					Message: req.GetFilters().GetMessage(),
@@ -1729,6 +1790,7 @@ func TestSearchJobLogs(t *testing.T) {
 					req.GetUserId(),
 					req.GetCursor(),
 					filters,
+					searchJobLogsOptionsForTest(req),
 				).Return(data, jobsmodel.JobStatusRunning.ToString(), nil)
 			},
 			want: want{
@@ -1772,14 +1834,7 @@ func TestSearchJobLogs(t *testing.T) {
 				},
 			},
 			mock: func(req *jobspb.SearchJobLogsRequest) {
-				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s:%s",
-					req.GetUserId(),
-					req.GetId(),
-					req.GetCursor(),
-					req.GetFilters().GetMessage(),
-					req.GetFilters().GetStream(),
-				)
+				cacheKey := searchJobLogsCacheKeyForTest(req)
 				var filters *jobsmodel.SearchJobLogsFilters
 				if req.GetFilters() != nil {
 					filters = &jobsmodel.SearchJobLogsFilters{
@@ -1801,6 +1856,7 @@ func TestSearchJobLogs(t *testing.T) {
 					req.GetUserId(),
 					req.GetCursor(),
 					filters,
+					searchJobLogsOptionsForTest(req),
 				).Return(nil, "", status.Error(codes.NotFound, "job not found"))
 			},
 			want:  want{},
@@ -1819,14 +1875,7 @@ func TestSearchJobLogs(t *testing.T) {
 				},
 			},
 			mock: func(req *jobspb.SearchJobLogsRequest) {
-				cacheKey := fmt.Sprintf(
-					"job_logs:%s:%s:%s:%s:%s",
-					req.GetUserId(),
-					req.GetId(),
-					req.GetCursor(),
-					req.GetFilters().GetMessage(),
-					req.GetFilters().GetStream(),
-				)
+				cacheKey := searchJobLogsCacheKeyForTest(req)
 				var filters *jobsmodel.SearchJobLogsFilters
 				if req.GetFilters() != nil {
 					filters = &jobsmodel.SearchJobLogsFilters{
@@ -1848,15 +1897,16 @@ func TestSearchJobLogs(t *testing.T) {
 					req.GetUserId(),
 					req.GetCursor(),
 					filters,
+					searchJobLogsOptionsForTest(req),
 				).Return(nil, "", status.Error(codes.Internal, "internal server error"))
 			},
 			want:  want{},
 			isErr: true,
 		},
 	}
-
+ 
 	defer ctrl.Finish()
-
+ 
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -1867,31 +1917,31 @@ func TestSearchJobLogs(t *testing.T) {
 				}
 				return
 			}
-
+ 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-
+ 
 			assert.Equal(t, jobLogs, tt.want.GetJobLogsResponse)
 		})
 	}
 }
-
+ 
 func TestListJobs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-
+ 
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
-
+ 
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
-
+ 
 	type want struct {
 		*jobsmodel.ListJobsResponse
 	}
-
+ 
 	var (
 		createdAt   = time.Now()
 		updatedAt   = time.Now()
@@ -1905,7 +1955,7 @@ func TestListJobs(t *testing.T) {
 			Valid: false,
 		}
 	)
-
+ 
 	// Test cases
 	tests := []struct {
 		name  string
@@ -2068,9 +2118,9 @@ func TestListJobs(t *testing.T) {
 			isErr: true,
 		},
 	}
-
+ 
 	defer ctrl.Finish()
-
+ 
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -2081,12 +2131,12 @@ func TestListJobs(t *testing.T) {
 				}
 				return
 			}
-
+ 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-
+ 
 			assert.Equal(t, len(jobs.Jobs), len(tt.want.ListJobsResponse.Jobs))
 			assert.Equal(t, jobs.Jobs, tt.want.ListJobsResponse.Jobs)
 			assert.Equal(t, jobs.Cursor, tt.want.ListJobsResponse.Cursor)

--- a/internal/service/jobs/jobs_test.go
+++ b/internal/service/jobs/jobs_test.go
@@ -1,5 +1,5 @@
 package jobs_test
- 
+
 import (
 	"context"
 	"database/sql"
@@ -8,34 +8,34 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
- 
+
 	"github.com/go-playground/validator/v10"
 	"github.com/go-redis/redismock/v9"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
- 
+
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 	"github.com/hitesh22rana/chronoverse/internal/service/jobs"
 	jobsmock "github.com/hitesh22rana/chronoverse/internal/service/jobs/mock"
 	jobspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
 )
- 
+
 func TestScheduleJob(t *testing.T) {
 	ctrl := gomock.NewController(t)
- 
+
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
- 
+
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
- 
+
 	type want struct {
 		jobID string
 	}
- 
+
 	// Test cases
 	tests := []struct {
 		name  string
@@ -172,9 +172,9 @@ func TestScheduleJob(t *testing.T) {
 			isErr: true,
 		},
 	}
- 
+
 	defer ctrl.Finish()
- 
+
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -185,27 +185,27 @@ func TestScheduleJob(t *testing.T) {
 				}
 				return
 			}
- 
+
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
- 
+
 			assert.Equal(t, jobID, tt.want.jobID)
 		})
 	}
 }
- 
+
 func TestUpdateJobStatus(t *testing.T) {
 	ctrl := gomock.NewController(t)
- 
+
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
- 
+
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
- 
+
 	// Test cases
 	tests := []struct {
 		name  string
@@ -306,9 +306,9 @@ func TestUpdateJobStatus(t *testing.T) {
 			isErr: true,
 		},
 	}
- 
+
 	defer ctrl.Finish()
- 
+
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -319,7 +319,7 @@ func TestUpdateJobStatus(t *testing.T) {
 				}
 				return
 			}
- 
+
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
@@ -327,21 +327,21 @@ func TestUpdateJobStatus(t *testing.T) {
 		})
 	}
 }
- 
+
 func TestGetJob(t *testing.T) {
 	ctrl := gomock.NewController(t)
- 
+
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
- 
+
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
- 
+
 	type want struct {
 		*jobsmodel.GetJobResponse
 	}
- 
+
 	var (
 		createdAt   = time.Now()
 		updatedAt   = time.Now()
@@ -355,7 +355,7 @@ func TestGetJob(t *testing.T) {
 			Valid: false,
 		}
 	)
- 
+
 	// Test cases
 	tests := []struct {
 		name  string
@@ -488,9 +488,9 @@ func TestGetJob(t *testing.T) {
 			isErr: true,
 		},
 	}
- 
+
 	defer ctrl.Finish()
- 
+
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -501,31 +501,31 @@ func TestGetJob(t *testing.T) {
 				}
 				return
 			}
- 
+
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
- 
+
 			assert.Equal(t, job, tt.want.GetJobResponse)
 		})
 	}
 }
- 
+
 func TestGetJobByID(t *testing.T) {
 	ctrl := gomock.NewController(t)
- 
+
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
- 
+
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
- 
+
 	type want struct {
 		*jobsmodel.GetJobByIDResponse
 	}
- 
+
 	var (
 		createdAt   = time.Now()
 		updatedAt   = time.Now()
@@ -539,7 +539,7 @@ func TestGetJobByID(t *testing.T) {
 			Valid: false,
 		}
 	)
- 
+
 	// Test cases
 	tests := []struct {
 		name  string
@@ -622,9 +622,9 @@ func TestGetJobByID(t *testing.T) {
 			isErr: true,
 		},
 	}
- 
+
 	defer ctrl.Finish()
- 
+
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -635,37 +635,37 @@ func TestGetJobByID(t *testing.T) {
 				}
 				return
 			}
- 
+
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
- 
+
 			assert.Equal(t, job, tt.want.GetJobByIDResponse)
 		})
 	}
 }
- 
+
 func TestGetJobLogs(t *testing.T) {
 	ctrl := gomock.NewController(t)
- 
+
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
- 
+
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
- 
+
 	type want struct {
 		*jobsmodel.GetJobLogsResponse
 	}
- 
+
 	var (
 		timestamp               = time.Now()
 		singleflightRepoCalls   int32
 		singleflightReleaseChan chan struct{}
 	)
- 
+
 	// Test cases
 	tests := []struct {
 		name    string
@@ -1003,7 +1003,7 @@ func TestGetJobLogs(t *testing.T) {
 					jobsmodel.JobLogsSortOrderDesc,
 				)
 				filters := &jobsmodel.GetJobLogsFilters{Stream: int(req.GetFilters().GetStream())}
- 
+
 				cache.EXPECT().
 					Get(gomock.Any(), cacheKey, gomock.Any()).
 					Return(nil, status.Error(codes.NotFound, "cache miss")).
@@ -1012,7 +1012,7 @@ func TestGetJobLogs(t *testing.T) {
 					Set(gomock.Any(), cacheKey, gomock.Any(), gomock.Any()).
 					Return(nil).
 					AnyTimes()
- 
+
 				singleflightRepoCalls = 0
 				singleflightReleaseChan = make(chan struct{})
 				repo.EXPECT().
@@ -1036,18 +1036,18 @@ func TestGetJobLogs(t *testing.T) {
 			},
 			execute: func(t *testing.T, req *jobspb.GetJobLogsRequest, want want) {
 				t.Helper()
- 
+
 				var wg sync.WaitGroup
 				results := make([]*jobsmodel.GetJobLogsResponse, 2)
 				errs := make([]error, 2)
- 
+
 				for i := range 2 {
 					idx := i
 					wg.Go(func() {
 						results[idx], errs[idx] = s.GetJobLogs(t.Context(), req)
 					})
 				}
- 
+
 				for range 50 {
 					if atomic.LoadInt32(&singleflightRepoCalls) == 1 {
 						break
@@ -1056,7 +1056,7 @@ func TestGetJobLogs(t *testing.T) {
 				}
 				close(singleflightReleaseChan)
 				wg.Wait()
- 
+
 				assert.Equal(t, int32(1), atomic.LoadInt32(&singleflightRepoCalls))
 				assert.NoError(t, errs[0])
 				assert.NoError(t, errs[1])
@@ -1184,9 +1184,9 @@ func TestGetJobLogs(t *testing.T) {
 			isErr: true,
 		},
 	}
- 
+
 	defer ctrl.Finish()
- 
+
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -1194,7 +1194,7 @@ func TestGetJobLogs(t *testing.T) {
 				tt.execute(t, tt.req, tt.want)
 				return
 			}
- 
+
 			jobLogs, err := s.GetJobLogs(t.Context(), tt.req)
 			if tt.isErr {
 				if err == nil {
@@ -1202,25 +1202,25 @@ func TestGetJobLogs(t *testing.T) {
 				}
 				return
 			}
- 
+
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
- 
+
 			assert.Equal(t, jobLogs, tt.want.GetJobLogsResponse)
 		})
 	}
 }
- 
+
 func TestGetJobLogsAscendingSortOrder(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
- 
+
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
 	s := jobs.New(validator.New(), repo, cache)
- 
+
 	req := &jobspb.GetJobLogsRequest{
 		Id:         "job_id",
 		WorkflowId: "workflow_id",
@@ -1239,12 +1239,12 @@ func TestGetJobLogsAscendingSortOrder(t *testing.T) {
 		req.GetFilters().GetStream(),
 		jobsmodel.JobLogsSortOrderAsc,
 	)
- 
+
 	cache.EXPECT().Get(gomock.Any(), cacheKey, gomock.Any()).Return(nil, status.Error(codes.NotFound, "cache miss")).AnyTimes()
 	repo.EXPECT().
 		GetJobLogs(gomock.Any(), req.GetId(), req.GetWorkflowId(), req.GetUserId(), req.GetCursor(), jobsmodel.JobLogsSortOrderAsc, filters).
 		Return(&jobsmodel.GetJobLogsResponse{ID: req.GetId(), WorkflowID: req.GetWorkflowId()}, jobsmodel.JobStatusRunning.ToString(), nil)
- 
+
 	res, err := s.GetJobLogs(t.Context(), req)
 	if err != nil {
 		t.Fatalf("GetJobLogs() error = %v", err)
@@ -1253,21 +1253,21 @@ func TestGetJobLogsAscendingSortOrder(t *testing.T) {
 		t.Fatalf("unexpected response ID: got %q want %q", res.ID, req.GetId())
 	}
 }
- 
+
 func TestStreamJobLogs(t *testing.T) {
 	ctrl := gomock.NewController(t)
- 
+
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
- 
+
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
- 
+
 	type want struct {
 		channelType string
 	}
- 
+
 	// Test cases
 	tests := []struct {
 		name  string
@@ -1286,14 +1286,14 @@ func TestStreamJobLogs(t *testing.T) {
 			mock: func(req *jobspb.StreamJobLogsRequest) {
 				redisMock, _ := redismock.NewClientMock()
 				sub := redisMock.Subscribe(t.Context(), "job_logs")
- 
+
 				repo.EXPECT().StreamJobLogs(
 					gomock.Any(),
 					req.GetId(),
 					req.GetWorkflowId(),
 					req.GetUserId(),
 				).Return(sub, nil)
- 
+
 				// Simulate sending logs to the channel
 				go func() {
 					redisMock.Publish(t.Context(), "job_logs", &jobsmodel.JobLog{
@@ -1358,15 +1358,15 @@ func TestStreamJobLogs(t *testing.T) {
 			isErr: true,
 		},
 	}
- 
+
 	defer ctrl.Finish()
- 
+
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 			defer cancel()
- 
+
 			stream, err := s.StreamJobLogs(ctx, tt.req)
 			if tt.isErr {
 				if err == nil {
@@ -1377,17 +1377,17 @@ func TestStreamJobLogs(t *testing.T) {
 				}
 				return
 			}
- 
+
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
- 
+
 			if stream == nil {
 				t.Errorf("expected channel, got nil")
 				return
 			}
- 
+
 			// Test that the channel is properly typed
 			select {
 			case <-stream:
@@ -1395,13 +1395,13 @@ func TestStreamJobLogs(t *testing.T) {
 			case <-time.After(100 * time.Millisecond):
 				// Channel is not immediately readable (also expected)
 			}
- 
+
 			// Verify the channel can be closed without panic
 			go func() {
 				time.Sleep(50 * time.Millisecond)
 				cancel() // This should trigger cleanup in the goroutine
 			}()
- 
+
 			// Try to read from channel with timeout to ensure cleanup works
 			select {
 			case <-stream:
@@ -1411,10 +1411,10 @@ func TestStreamJobLogs(t *testing.T) {
 		})
 	}
 }
- 
+
 func searchJobLogsCacheKeyForTest(req *jobspb.SearchJobLogsRequest) string {
 	options := searchJobLogsOptionsForTest(req)
- 
+
 	return fmt.Sprintf(
 		"job_logs:search:%s:%s:%s:%s:%s:%d:%t",
 		req.GetUserId(),
@@ -1426,35 +1426,35 @@ func searchJobLogsCacheKeyForTest(req *jobspb.SearchJobLogsRequest) string {
 		options.DisableHighlight,
 	)
 }
- 
+
 func searchJobLogsOptionsForTest(req *jobspb.SearchJobLogsRequest) jobsmodel.SearchJobLogsOptions {
 	sortOrder := jobsmodel.JobLogsSortOrderDesc
 	if req.GetSortOrder() == jobspb.LogSortOrder_LOG_SORT_ORDER_ASC {
 		sortOrder = jobsmodel.JobLogsSortOrderAsc
 	}
- 
+
 	return jobsmodel.SearchJobLogsOptions{
 		SortOrder:        sortOrder,
 		DisableHighlight: req.GetDisableHighlight(),
 	}
 }
- 
+
 func TestSearchJobLogs(t *testing.T) {
 	ctrl := gomock.NewController(t)
- 
+
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
- 
+
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
- 
+
 	type want struct {
 		*jobsmodel.GetJobLogsResponse
 	}
- 
+
 	timestamp := time.Now()
- 
+
 	// Test cases
 	tests := []struct {
 		name  string
@@ -1904,9 +1904,9 @@ func TestSearchJobLogs(t *testing.T) {
 			isErr: true,
 		},
 	}
- 
+
 	defer ctrl.Finish()
- 
+
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -1917,31 +1917,31 @@ func TestSearchJobLogs(t *testing.T) {
 				}
 				return
 			}
- 
+
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
- 
+
 			assert.Equal(t, jobLogs, tt.want.GetJobLogsResponse)
 		})
 	}
 }
- 
+
 func TestListJobs(t *testing.T) {
 	ctrl := gomock.NewController(t)
- 
+
 	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
- 
+
 	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
- 
+
 	type want struct {
 		*jobsmodel.ListJobsResponse
 	}
- 
+
 	var (
 		createdAt   = time.Now()
 		updatedAt   = time.Now()
@@ -1955,7 +1955,7 @@ func TestListJobs(t *testing.T) {
 			Valid: false,
 		}
 	)
- 
+
 	// Test cases
 	tests := []struct {
 		name  string
@@ -2118,9 +2118,9 @@ func TestListJobs(t *testing.T) {
 			isErr: true,
 		},
 	}
- 
+
 	defer ctrl.Finish()
- 
+
 	for _, tt := range tests {
 		tt.mock(tt.req)
 		t.Run(tt.name, func(t *testing.T) {
@@ -2131,12 +2131,12 @@ func TestListJobs(t *testing.T) {
 				}
 				return
 			}
- 
+
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
- 
+
 			assert.Equal(t, len(jobs.Jobs), len(tt.want.ListJobsResponse.Jobs))
 			assert.Equal(t, jobs.Jobs, tt.want.ListJobsResponse.Jobs)
 			assert.Equal(t, jobs.Cursor, tt.want.ListJobsResponse.Cursor)

--- a/internal/service/jobs/mock/jobs.go
+++ b/internal/service/jobs/mock/jobs.go
@@ -236,9 +236,9 @@ func (mr *MockRepositoryMockRecorder) ScheduleJob(ctx, workflowID, userID, sched
 }
 
 // SearchJobLogs mocks base method.
-func (m *MockRepository) SearchJobLogs(ctx context.Context, jobID, workflowID, userID, cursor string, filters *jobs.SearchJobLogsFilters) (*jobs.GetJobLogsResponse, string, error) {
+func (m *MockRepository) SearchJobLogs(ctx context.Context, jobID, workflowID, userID, cursor string, filters *jobs.SearchJobLogsFilters, options jobs.SearchJobLogsOptions) (*jobs.GetJobLogsResponse, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchJobLogs", ctx, jobID, workflowID, userID, cursor, filters)
+	ret := m.ctrl.Call(m, "SearchJobLogs", ctx, jobID, workflowID, userID, cursor, filters, options)
 	ret0, _ := ret[0].(*jobs.GetJobLogsResponse)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -246,9 +246,9 @@ func (m *MockRepository) SearchJobLogs(ctx context.Context, jobID, workflowID, u
 }
 
 // SearchJobLogs indicates an expected call of SearchJobLogs.
-func (mr *MockRepositoryMockRecorder) SearchJobLogs(ctx, jobID, workflowID, userID, cursor, filters any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) SearchJobLogs(ctx, jobID, workflowID, userID, cursor, filters, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchJobLogs", reflect.TypeOf((*MockRepository)(nil).SearchJobLogs), ctx, jobID, workflowID, userID, cursor, filters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchJobLogs", reflect.TypeOf((*MockRepository)(nil).SearchJobLogs), ctx, jobID, workflowID, userID, cursor, filters, options)
 }
 
 // StreamJobLogs mocks base method.

--- a/pkg/proto/go/jobs/jobs.pb.go
+++ b/pkg/proto/go/jobs/jobs.pb.go
@@ -1922,13 +1922,14 @@ func (x *Log) GetEventId() string {
 
 // GetJobLogsResponse contains the result of a job log retrieval attempt.
 type GetJobLogsResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                   // ID of the job
-	WorkflowId    string                 `protobuf:"bytes,2,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"` // ID of the workflow
-	Logs          []*Log                 `protobuf:"bytes,3,rep,name=logs,proto3" json:"logs,omitempty"`                               // List of log messages
-	Cursor        string                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`                           // Cursor for pagination
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Id             string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                               // ID of the job
+	WorkflowId     string                 `protobuf:"bytes,2,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`             // ID of the workflow
+	Logs           []*Log                 `protobuf:"bytes,3,rep,name=logs,proto3" json:"logs,omitempty"`                                           // List of log messages
+	Cursor         string                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`                                       // Cursor for pagination
+	HighlightToken string                 `protobuf:"bytes,5,opt,name=highlight_token,json=highlightToken,proto3" json:"highlight_token,omitempty"` // Token used for parsing highlighted log ranges
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *GetJobLogsResponse) Reset() {
@@ -1985,6 +1986,13 @@ func (x *GetJobLogsResponse) GetLogs() []*Log {
 func (x *GetJobLogsResponse) GetCursor() string {
 	if x != nil {
 		return x.Cursor
+	}
+	return ""
+}
+
+func (x *GetJobLogsResponse) GetHighlightToken() string {
+	if x != nil {
+		return x.HighlightToken
 	}
 	return ""
 }
@@ -2105,14 +2113,16 @@ func (x *SearchJobLogsFilters) GetMessage() string {
 
 // SearchJobLogsRequest contains the details needed to search the logs of a job.
 type SearchJobLogsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                   // ID of the job
-	WorkflowId    string                 `protobuf:"bytes,2,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"` // ID of the workflow
-	UserId        string                 `protobuf:"bytes,3,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`             // ID of the user
-	Cursor        string                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`                           // Cursor for pagination
-	Filters       *SearchJobLogsFilters  `protobuf:"bytes,5,opt,name=filters,proto3" json:"filters,omitempty"`                         // Filters applied to the search
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Id               string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                                        // ID of the job
+	WorkflowId       string                 `protobuf:"bytes,2,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`                      // ID of the workflow
+	UserId           string                 `protobuf:"bytes,3,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`                                  // ID of the user
+	Cursor           string                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`                                                // Cursor for pagination
+	Filters          *SearchJobLogsFilters  `protobuf:"bytes,5,opt,name=filters,proto3" json:"filters,omitempty"`                                              // Filters applied to the search
+	SortOrder        LogSortOrder           `protobuf:"varint,6,opt,name=sort_order,json=sortOrder,proto3,enum=jobs.LogSortOrder" json:"sort_order,omitempty"` // Sort order for retained log pagination
+	DisableHighlight bool                   `protobuf:"varint,7,opt,name=disable_highlight,json=disableHighlight,proto3" json:"disable_highlight,omitempty"`   // Disable search result highlighting
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *SearchJobLogsRequest) Reset() {
@@ -2178,6 +2188,20 @@ func (x *SearchJobLogsRequest) GetFilters() *SearchJobLogsFilters {
 		return x.Filters
 	}
 	return nil
+}
+
+func (x *SearchJobLogsRequest) GetSortOrder() LogSortOrder {
+	if x != nil {
+		return x.SortOrder
+	}
+	return LogSortOrder_LOG_SORT_ORDER_UNSPECIFIED
+}
+
+func (x *SearchJobLogsRequest) GetDisableHighlight() bool {
+	if x != nil {
+		return x.DisableHighlight
+	}
+	return false
 }
 
 // ListJobsFilters contains the filters for listing jobs.
@@ -2635,13 +2659,14 @@ const file_jobs_jobs_proto_rawDesc = "" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12!\n" +
 	"\fsequence_num\x18\x03 \x01(\rR\vsequenceNum\x12\x16\n" +
 	"\x06stream\x18\x04 \x01(\tR\x06stream\x12\x19\n" +
-	"\bevent_id\x18\x05 \x01(\tR\aeventId\"|\n" +
+	"\bevent_id\x18\x05 \x01(\tR\aeventId\"\xa5\x01\n" +
 	"\x12GetJobLogsResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vworkflow_id\x18\x02 \x01(\tR\n" +
 	"workflowId\x12\x1d\n" +
 	"\x04logs\x18\x03 \x03(\v2\t.jobs.LogR\x04logs\x12\x16\n" +
-	"\x06cursor\x18\x04 \x01(\tR\x06cursor\"`\n" +
+	"\x06cursor\x18\x04 \x01(\tR\x06cursor\x12'\n" +
+	"\x0fhighlight_token\x18\x05 \x01(\tR\x0ehighlightToken\"`\n" +
 	"\x14StreamJobLogsRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vworkflow_id\x18\x02 \x01(\tR\n" +
@@ -2649,14 +2674,17 @@ const file_jobs_jobs_proto_rawDesc = "" +
 	"\auser_id\x18\x03 \x01(\tR\x06userId\"Y\n" +
 	"\x14SearchJobLogsFilters\x12'\n" +
 	"\x06stream\x18\x01 \x01(\x0e2\x0f.jobs.LogStreamR\x06stream\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"\xae\x01\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\x8e\x02\n" +
 	"\x14SearchJobLogsRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vworkflow_id\x18\x02 \x01(\tR\n" +
 	"workflowId\x12\x17\n" +
 	"\auser_id\x18\x03 \x01(\tR\x06userId\x12\x16\n" +
 	"\x06cursor\x18\x04 \x01(\tR\x06cursor\x124\n" +
-	"\afilters\x18\x05 \x01(\v2\x1a.jobs.SearchJobLogsFiltersR\afilters\"C\n" +
+	"\afilters\x18\x05 \x01(\v2\x1a.jobs.SearchJobLogsFiltersR\afilters\x121\n" +
+	"\n" +
+	"sort_order\x18\x06 \x01(\x0e2\x12.jobs.LogSortOrderR\tsortOrder\x12+\n" +
+	"\x11disable_highlight\x18\a \x01(\bR\x10disableHighlight\"C\n" +
 	"\x0fListJobsFilters\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x18\n" +
 	"\atrigger\x18\x02 \x01(\tR\atrigger\"\xa5\x01\n" +
@@ -2779,45 +2807,46 @@ var file_jobs_jobs_proto_depIdxs = []int32{
 	29, // 4: jobs.GetJobLogsResponse.logs:type_name -> jobs.Log
 	0,  // 5: jobs.SearchJobLogsFilters.stream:type_name -> jobs.LogStream
 	32, // 6: jobs.SearchJobLogsRequest.filters:type_name -> jobs.SearchJobLogsFilters
-	34, // 7: jobs.ListJobsRequest.filters:type_name -> jobs.ListJobsFilters
-	36, // 8: jobs.ListJobsResponse.jobs:type_name -> jobs.JobsResponse
-	2,  // 9: jobs.JobsService.ScheduleJob:input_type -> jobs.ScheduleJobRequest
-	4,  // 10: jobs.JobsService.UpdateJobStatus:input_type -> jobs.UpdateJobStatusRequest
-	6,  // 11: jobs.JobsService.ClaimJob:input_type -> jobs.ClaimJobRequest
-	8,  // 12: jobs.JobsService.RenewJobLease:input_type -> jobs.RenewJobLeaseRequest
-	10, // 13: jobs.JobsService.AttachJobContainer:input_type -> jobs.AttachJobContainerRequest
-	12, // 14: jobs.JobsService.CompleteJob:input_type -> jobs.CompleteJobRequest
-	14, // 15: jobs.JobsService.FailJob:input_type -> jobs.FailJobRequest
-	16, // 16: jobs.JobsService.CancelClaimedJob:input_type -> jobs.CancelClaimedJobRequest
-	18, // 17: jobs.JobsService.ReleaseJobForRetry:input_type -> jobs.ReleaseJobForRetryRequest
-	21, // 18: jobs.JobsService.RecoverExpiredJobLeases:input_type -> jobs.RecoverExpiredJobLeasesRequest
-	23, // 19: jobs.JobsService.GetJob:input_type -> jobs.GetJobRequest
-	25, // 20: jobs.JobsService.GetJobByID:input_type -> jobs.GetJobByIDRequest
-	28, // 21: jobs.JobsService.GetJobLogs:input_type -> jobs.GetJobLogsRequest
-	31, // 22: jobs.JobsService.StreamJobLogs:input_type -> jobs.StreamJobLogsRequest
-	33, // 23: jobs.JobsService.SearchJobLogs:input_type -> jobs.SearchJobLogsRequest
-	35, // 24: jobs.JobsService.ListJobs:input_type -> jobs.ListJobsRequest
-	3,  // 25: jobs.JobsService.ScheduleJob:output_type -> jobs.ScheduleJobResponse
-	5,  // 26: jobs.JobsService.UpdateJobStatus:output_type -> jobs.UpdateJobStatusResponse
-	7,  // 27: jobs.JobsService.ClaimJob:output_type -> jobs.ClaimJobResponse
-	9,  // 28: jobs.JobsService.RenewJobLease:output_type -> jobs.RenewJobLeaseResponse
-	11, // 29: jobs.JobsService.AttachJobContainer:output_type -> jobs.AttachJobContainerResponse
-	13, // 30: jobs.JobsService.CompleteJob:output_type -> jobs.CompleteJobResponse
-	15, // 31: jobs.JobsService.FailJob:output_type -> jobs.FailJobResponse
-	17, // 32: jobs.JobsService.CancelClaimedJob:output_type -> jobs.CancelClaimedJobResponse
-	19, // 33: jobs.JobsService.ReleaseJobForRetry:output_type -> jobs.ReleaseJobForRetryResponse
-	22, // 34: jobs.JobsService.RecoverExpiredJobLeases:output_type -> jobs.RecoverExpiredJobLeasesResponse
-	24, // 35: jobs.JobsService.GetJob:output_type -> jobs.GetJobResponse
-	26, // 36: jobs.JobsService.GetJobByID:output_type -> jobs.GetJobByIDResponse
-	30, // 37: jobs.JobsService.GetJobLogs:output_type -> jobs.GetJobLogsResponse
-	29, // 38: jobs.JobsService.StreamJobLogs:output_type -> jobs.Log
-	30, // 39: jobs.JobsService.SearchJobLogs:output_type -> jobs.GetJobLogsResponse
-	37, // 40: jobs.JobsService.ListJobs:output_type -> jobs.ListJobsResponse
-	25, // [25:41] is the sub-list for method output_type
-	9,  // [9:25] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	1,  // 7: jobs.SearchJobLogsRequest.sort_order:type_name -> jobs.LogSortOrder
+	34, // 8: jobs.ListJobsRequest.filters:type_name -> jobs.ListJobsFilters
+	36, // 9: jobs.ListJobsResponse.jobs:type_name -> jobs.JobsResponse
+	2,  // 10: jobs.JobsService.ScheduleJob:input_type -> jobs.ScheduleJobRequest
+	4,  // 11: jobs.JobsService.UpdateJobStatus:input_type -> jobs.UpdateJobStatusRequest
+	6,  // 12: jobs.JobsService.ClaimJob:input_type -> jobs.ClaimJobRequest
+	8,  // 13: jobs.JobsService.RenewJobLease:input_type -> jobs.RenewJobLeaseRequest
+	10, // 14: jobs.JobsService.AttachJobContainer:input_type -> jobs.AttachJobContainerRequest
+	12, // 15: jobs.JobsService.CompleteJob:input_type -> jobs.CompleteJobRequest
+	14, // 16: jobs.JobsService.FailJob:input_type -> jobs.FailJobRequest
+	16, // 17: jobs.JobsService.CancelClaimedJob:input_type -> jobs.CancelClaimedJobRequest
+	18, // 18: jobs.JobsService.ReleaseJobForRetry:input_type -> jobs.ReleaseJobForRetryRequest
+	21, // 19: jobs.JobsService.RecoverExpiredJobLeases:input_type -> jobs.RecoverExpiredJobLeasesRequest
+	23, // 20: jobs.JobsService.GetJob:input_type -> jobs.GetJobRequest
+	25, // 21: jobs.JobsService.GetJobByID:input_type -> jobs.GetJobByIDRequest
+	28, // 22: jobs.JobsService.GetJobLogs:input_type -> jobs.GetJobLogsRequest
+	31, // 23: jobs.JobsService.StreamJobLogs:input_type -> jobs.StreamJobLogsRequest
+	33, // 24: jobs.JobsService.SearchJobLogs:input_type -> jobs.SearchJobLogsRequest
+	35, // 25: jobs.JobsService.ListJobs:input_type -> jobs.ListJobsRequest
+	3,  // 26: jobs.JobsService.ScheduleJob:output_type -> jobs.ScheduleJobResponse
+	5,  // 27: jobs.JobsService.UpdateJobStatus:output_type -> jobs.UpdateJobStatusResponse
+	7,  // 28: jobs.JobsService.ClaimJob:output_type -> jobs.ClaimJobResponse
+	9,  // 29: jobs.JobsService.RenewJobLease:output_type -> jobs.RenewJobLeaseResponse
+	11, // 30: jobs.JobsService.AttachJobContainer:output_type -> jobs.AttachJobContainerResponse
+	13, // 31: jobs.JobsService.CompleteJob:output_type -> jobs.CompleteJobResponse
+	15, // 32: jobs.JobsService.FailJob:output_type -> jobs.FailJobResponse
+	17, // 33: jobs.JobsService.CancelClaimedJob:output_type -> jobs.CancelClaimedJobResponse
+	19, // 34: jobs.JobsService.ReleaseJobForRetry:output_type -> jobs.ReleaseJobForRetryResponse
+	22, // 35: jobs.JobsService.RecoverExpiredJobLeases:output_type -> jobs.RecoverExpiredJobLeasesResponse
+	24, // 36: jobs.JobsService.GetJob:output_type -> jobs.GetJobResponse
+	26, // 37: jobs.JobsService.GetJobByID:output_type -> jobs.GetJobByIDResponse
+	30, // 38: jobs.JobsService.GetJobLogs:output_type -> jobs.GetJobLogsResponse
+	29, // 39: jobs.JobsService.StreamJobLogs:output_type -> jobs.Log
+	30, // 40: jobs.JobsService.SearchJobLogs:output_type -> jobs.GetJobLogsResponse
+	37, // 41: jobs.JobsService.ListJobs:output_type -> jobs.ListJobsResponse
+	26, // [26:42] is the sub-list for method output_type
+	10, // [10:26] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_jobs_jobs_proto_init() }

--- a/proto/jobs/jobs.proto
+++ b/proto/jobs/jobs.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
-
+ 
 package jobs;
-
+ 
 option go_package = "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs;jobs";
-
+ 
 // ScheduleJobRequest contains the details needed to create a new job.
 message ScheduleJobRequest {
   string workflow_id         = 1; // ID of the workflow
@@ -13,22 +13,22 @@ message ScheduleJobRequest {
   string idempotency_key     = 5; // Optional idempotency key for scheduling
   int64  workflow_generation = 6; // Optional workflow generation guard for automatic scheduling
 }
-
+ 
 // ScheduleJobResponse contains the result of a job creation attempt.
 message ScheduleJobResponse {
   string id = 1; // ID of the job
 }
-
+ 
 // UpdateJobStatusRequest contains the details needed to update the status of a job.
 message UpdateJobStatusRequest {
   string id           = 1; // ID of the job
   string container_id = 2; // ID of the container (if applicable)
   string status       = 3; // Status of the job
 }
-
+ 
 // UpdateJobStatusResponse contains the result of a job status update attempt.
 message UpdateJobStatusResponse {}
-
+ 
 // ClaimJobRequest contains the details needed to claim a queued job for execution.
 message ClaimJobRequest {
   string id                     = 1; // ID of the job
@@ -37,7 +37,7 @@ message ClaimJobRequest {
   int32  lease_duration_seconds = 4; // Lease duration in seconds
   int32  dispatch_attempt       = 5; // Dispatch attempt from the Kafka event
 }
-
+ 
 // ClaimJobResponse contains the result of a job claim attempt.
 message ClaimJobResponse {
   bool   claimed           = 1; // Whether the job was claimed
@@ -51,36 +51,36 @@ message ClaimJobResponse {
   int32  attempts          = 9; // Number of execution attempts
   string lease_token       = 10; // Lease token required for updates
 }
-
+ 
 // RenewJobLeaseRequest contains the details needed to renew a running job lease.
 message RenewJobLeaseRequest {
   string id                     = 1; // ID of the job
   string lease_token            = 2; // Current lease token
   int32  lease_duration_seconds = 3; // Lease duration in seconds
 }
-
+ 
 // RenewJobLeaseResponse contains the result of a lease renewal.
 message RenewJobLeaseResponse {}
-
+ 
 // AttachJobContainerRequest contains the details needed to attach a container ID to a running job.
 message AttachJobContainerRequest {
   string id           = 1; // ID of the job
   string lease_token  = 2; // Current lease token
   string container_id = 3; // Container ID
 }
-
+ 
 // AttachJobContainerResponse contains the result of attaching a container ID.
 message AttachJobContainerResponse {}
-
+ 
 // CompleteJobRequest contains the details needed to complete a claimed job.
 message CompleteJobRequest {
   string id          = 1; // ID of the job
   string lease_token = 2; // Current lease token
 }
-
+ 
 // CompleteJobResponse contains the result of completing a job.
 message CompleteJobResponse {}
-
+ 
 // FailJobRequest contains the details needed to fail a claimed job.
 message FailJobRequest {
   string id            = 1; // ID of the job
@@ -89,19 +89,19 @@ message FailJobRequest {
   string error_code    = 4; // Error code
   string error_message = 5; // Error message
 }
-
+ 
 // FailJobResponse contains the result of failing a job.
 message FailJobResponse {}
-
+ 
 // CancelClaimedJobRequest contains the details needed to cancel a claimed job.
 message CancelClaimedJobRequest {
   string id          = 1; // ID of the job
   string lease_token = 2; // Current lease token
 }
-
+ 
 // CancelClaimedJobResponse contains the result of canceling a claimed job.
 message CancelClaimedJobResponse {}
-
+ 
 // ReleaseJobForRetryRequest contains the details needed to release a claimed job for retry.
 message ReleaseJobForRetryRequest {
   string id              = 1; // ID of the job
@@ -110,10 +110,10 @@ message ReleaseJobForRetryRequest {
   string error_code      = 4; // Error code
   string error_message   = 5; // Error message
 }
-
+ 
 // ReleaseJobForRetryResponse contains the result of releasing a job for retry.
 message ReleaseJobForRetryResponse {}
-
+ 
 // ExpiredJobLease contains a running job whose lease has expired.
 message ExpiredJobLease {
   string id            = 1; // ID of the job
@@ -127,26 +127,26 @@ message ExpiredJobLease {
   int32  attempts      = 9; // Number of execution attempts
   bool   log_retention = 10; // Whether logs should be durably retained
 }
-
+ 
 // RecoverExpiredJobLeasesRequest contains the details needed to fetch expired leases.
 message RecoverExpiredJobLeasesRequest {
   int32  batch_size             = 1; // Maximum number of expired leases to claim
   string worker_id              = 2; // Worker claiming the expired leases for recovery
   int32  lease_duration_seconds = 3; // Lease duration in seconds for recovered claims
 }
-
+ 
 // RecoverExpiredJobLeasesResponse contains expired leases to recover.
 message RecoverExpiredJobLeasesResponse {
   repeated ExpiredJobLease jobs = 1; // Expired leased jobs
 }
-
+ 
 // GetJobRequest contains the details needed to get a job.
 message GetJobRequest {
   string id          = 1; // ID of the job
   string workflow_id = 2; // ID of the workflow
   string user_id     = 3; // ID of the user
 }
-
+ 
 // GetJobResponse contains the result of a job retrieval attempt.
 message GetJobResponse {
   string id           = 1; // ID of the job
@@ -159,12 +159,12 @@ message GetJobResponse {
   string created_at   = 8; // Time the job was created
   string updated_at   = 9; // Time the job was last updated
 }
-
+ 
 // GetJobByIDRequest contains the details needed to get a job by ID.
 message GetJobByIDRequest {
   string id = 1; // ID of the job
 }
-
+ 
 // GetJobByIDResponse contains the result of a job retrieval attempt.
 message GetJobByIDResponse {
   string id           = 1; // ID of the job
@@ -179,7 +179,7 @@ message GetJobByIDResponse {
   string created_at   = 10; // Time the job was created
   string updated_at   = 11; // Time the job was last updated
 }
-
+ 
 // LogStream represents the type of log stream.
 enum LogStream {
   LOG_STREAM_UNSPECIFIED = 0;
@@ -187,19 +187,19 @@ enum LogStream {
   LOG_STREAM_STDERR      = 2;
   LOG_STREAM_ALL         = 3;
 }
-
+ 
 // LogSortOrder represents the order used for retained log pagination.
 enum LogSortOrder {
   LOG_SORT_ORDER_UNSPECIFIED = 0;
   LOG_SORT_ORDER_DESC        = 1;
   LOG_SORT_ORDER_ASC         = 2;
 }
-
+ 
 // SearchJobLogsFilters are the filters that are to be applied on the get job logs request.
 message GetJobLogsFilters {
   LogStream stream = 1;
 }
-
+ 
 // GetJobLogsRequest contains the details needed to get the logs of a job.
 message GetJobLogsRequest {
   string            id          = 1; // ID of the job
@@ -209,7 +209,7 @@ message GetJobLogsRequest {
   GetJobLogsFilters filters     = 5; // Filters applied to the search
   LogSortOrder      sort_order  = 6; // Sort order for retained log pagination
 }
-
+ 
 // Log contains the details of a log.
 message Log {
   string timestamp    = 1; // Time the log was created
@@ -218,28 +218,29 @@ message Log {
   string stream       = 4; // Stream type (stdout or stderr)
   string event_id     = 5; // Unique retained/live log event ID
 }
-
+ 
 // GetJobLogsResponse contains the result of a job log retrieval attempt.
 message GetJobLogsResponse {
   string       id          = 1; // ID of the job
   string       workflow_id = 2; // ID of the workflow
   repeated Log logs        = 3; // List of log messages
   string       cursor      = 4; // Cursor for pagination
+  string       highlight_token = 5; // Token used for parsing highlighted log ranges
 }
-
+ 
 // StreamJobLogsRequest contains the details needed to stream the logs of a job.
 message StreamJobLogsRequest {
   string id          = 1; // ID of the job
   string workflow_id = 2; // ID of the workflow
   string user_id     = 3; // ID of the user
 }
-
+ 
 // SearchJobLogsFilters are the filters that are to be applied on the search job logs request.
 message SearchJobLogsFilters {
   LogStream stream  = 1;
   string    message = 2;
 }
-
+ 
 // SearchJobLogsRequest contains the details needed to search the logs of a job.
 message SearchJobLogsRequest {
   string               id          = 1; // ID of the job
@@ -247,14 +248,16 @@ message SearchJobLogsRequest {
   string               user_id     = 3; // ID of the user
   string               cursor      = 4; // Cursor for pagination
   SearchJobLogsFilters filters     = 5; // Filters applied to the search
+  LogSortOrder         sort_order  = 6; // Sort order for retained log pagination
+  bool                 disable_highlight = 7; // Disable search result highlighting
 }
-
+ 
 // ListJobsFilters contains the filters for listing jobs.
 message ListJobsFilters {
   string status  = 1; // Status of the job (optional)
   string trigger = 2; // Trigger type of the job (optional)
 }
-
+ 
 // ListJobsRequest contains the details needed to list all jobs for a workflow_id.
 message ListJobsRequest {
   string                   workflow_id = 1; // ID of the workflow
@@ -262,7 +265,7 @@ message ListJobsRequest {
   string                   cursor      = 3; // Cursor for pagination
   optional ListJobsFilters filters     = 4; // Filters applied to the list
 }
-
+ 
 // JobsResponse contains the result of a job listing attempt.
 message JobsResponse {
   string id           = 1; // ID of the job
@@ -277,69 +280,69 @@ message JobsResponse {
   string updated_at   = 10; // Time the job was last updated
   int32  attempts     = 11; // Number of execution attempts
 }
-
+ 
 message ListJobsResponse {
   repeated JobsResponse jobs   = 1; // List of jobs
   string                cursor = 2; // Cursor for pagination
 }
-
+ 
 // JobsService handles job related operations.
 service JobsService {
     // ScheduleJob schedules a job to run at a specific time.
   rpc ScheduleJob(ScheduleJobRequest) returns (ScheduleJobResponse) {}
-
+ 
     // UpdateJobStatus updates the status of a job.
     // This is an internal API and should not be exposed to the public.
   rpc UpdateJobStatus(UpdateJobStatusRequest) returns (UpdateJobStatusResponse) {}
-
+ 
     // ClaimJob atomically claims a queued job for execution.
     // This is an internal API and should not be exposed to the public.
   rpc ClaimJob(ClaimJobRequest) returns (ClaimJobResponse) {}
-
+ 
     // RenewJobLease renews a running job lease.
     // This is an internal API and should not be exposed to the public.
   rpc RenewJobLease(RenewJobLeaseRequest) returns (RenewJobLeaseResponse) {}
-
+ 
     // AttachJobContainer attaches a container ID to a running claimed job.
     // This is an internal API and should not be exposed to the public.
   rpc AttachJobContainer(AttachJobContainerRequest) returns (AttachJobContainerResponse) {}
-
+ 
     // CompleteJob completes a running claimed job.
     // This is an internal API and should not be exposed to the public.
   rpc CompleteJob(CompleteJobRequest) returns (CompleteJobResponse) {}
-
+ 
     // FailJob marks a running claimed job as failed.
     // This is an internal API and should not be exposed to the public.
   rpc FailJob(FailJobRequest) returns (FailJobResponse) {}
-
+ 
     // CancelClaimedJob marks a running claimed job as canceled.
     // This is an internal API and should not be exposed to the public.
   rpc CancelClaimedJob(CancelClaimedJobRequest) returns (CancelClaimedJobResponse) {}
-
+ 
     // ReleaseJobForRetry releases a running claimed job back to pending.
     // This is an internal API and should not be exposed to the public.
   rpc ReleaseJobForRetry(ReleaseJobForRetryRequest) returns (ReleaseJobForRetryResponse) {}
-
+ 
     // RecoverExpiredJobLeases returns expired running job leases for recovery.
     // This is an internal API and should not be exposed to the public.
   rpc RecoverExpiredJobLeases(RecoverExpiredJobLeasesRequest) returns (RecoverExpiredJobLeasesResponse) {}
-
+ 
     // GetJob gets a job by ID and user_id.
   rpc GetJob(GetJobRequest) returns (GetJobResponse) {}
-
+ 
     // GetJobByID gets a job by ID.
     // This is an internal API and should not be exposed to the public.
   rpc GetJobByID(GetJobByIDRequest) returns (GetJobByIDResponse) {}
-
+ 
     // GetJobLogs gets the logs of a job.
   rpc GetJobLogs(GetJobLogsRequest) returns (GetJobLogsResponse) {}
-
+ 
     // StreamJobLogs streams the logs of a job.
   rpc StreamJobLogs(StreamJobLogsRequest) returns (stream Log) {}
-
+ 
     // SearchJobLogs returns the filtered logs of a job.
   rpc SearchJobLogs(SearchJobLogsRequest) returns (GetJobLogsResponse) {}
-
+ 
     // ListJobs returns a list of all jobs for a workflow_id owned by a user.
   rpc ListJobs(ListJobsRequest) returns (ListJobsResponse) {}
 }

--- a/proto/jobs/jobs.proto
+++ b/proto/jobs/jobs.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
- 
+
 package jobs;
- 
+
 option go_package = "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs;jobs";
- 
+
 // ScheduleJobRequest contains the details needed to create a new job.
 message ScheduleJobRequest {
   string workflow_id         = 1; // ID of the workflow
@@ -13,22 +13,22 @@ message ScheduleJobRequest {
   string idempotency_key     = 5; // Optional idempotency key for scheduling
   int64  workflow_generation = 6; // Optional workflow generation guard for automatic scheduling
 }
- 
+
 // ScheduleJobResponse contains the result of a job creation attempt.
 message ScheduleJobResponse {
   string id = 1; // ID of the job
 }
- 
+
 // UpdateJobStatusRequest contains the details needed to update the status of a job.
 message UpdateJobStatusRequest {
   string id           = 1; // ID of the job
   string container_id = 2; // ID of the container (if applicable)
   string status       = 3; // Status of the job
 }
- 
+
 // UpdateJobStatusResponse contains the result of a job status update attempt.
 message UpdateJobStatusResponse {}
- 
+
 // ClaimJobRequest contains the details needed to claim a queued job for execution.
 message ClaimJobRequest {
   string id                     = 1; // ID of the job
@@ -37,7 +37,7 @@ message ClaimJobRequest {
   int32  lease_duration_seconds = 4; // Lease duration in seconds
   int32  dispatch_attempt       = 5; // Dispatch attempt from the Kafka event
 }
- 
+
 // ClaimJobResponse contains the result of a job claim attempt.
 message ClaimJobResponse {
   bool   claimed           = 1; // Whether the job was claimed
@@ -51,36 +51,36 @@ message ClaimJobResponse {
   int32  attempts          = 9; // Number of execution attempts
   string lease_token       = 10; // Lease token required for updates
 }
- 
+
 // RenewJobLeaseRequest contains the details needed to renew a running job lease.
 message RenewJobLeaseRequest {
   string id                     = 1; // ID of the job
   string lease_token            = 2; // Current lease token
   int32  lease_duration_seconds = 3; // Lease duration in seconds
 }
- 
+
 // RenewJobLeaseResponse contains the result of a lease renewal.
 message RenewJobLeaseResponse {}
- 
+
 // AttachJobContainerRequest contains the details needed to attach a container ID to a running job.
 message AttachJobContainerRequest {
   string id           = 1; // ID of the job
   string lease_token  = 2; // Current lease token
   string container_id = 3; // Container ID
 }
- 
+
 // AttachJobContainerResponse contains the result of attaching a container ID.
 message AttachJobContainerResponse {}
- 
+
 // CompleteJobRequest contains the details needed to complete a claimed job.
 message CompleteJobRequest {
   string id          = 1; // ID of the job
   string lease_token = 2; // Current lease token
 }
- 
+
 // CompleteJobResponse contains the result of completing a job.
 message CompleteJobResponse {}
- 
+
 // FailJobRequest contains the details needed to fail a claimed job.
 message FailJobRequest {
   string id            = 1; // ID of the job
@@ -89,19 +89,19 @@ message FailJobRequest {
   string error_code    = 4; // Error code
   string error_message = 5; // Error message
 }
- 
+
 // FailJobResponse contains the result of failing a job.
 message FailJobResponse {}
- 
+
 // CancelClaimedJobRequest contains the details needed to cancel a claimed job.
 message CancelClaimedJobRequest {
   string id          = 1; // ID of the job
   string lease_token = 2; // Current lease token
 }
- 
+
 // CancelClaimedJobResponse contains the result of canceling a claimed job.
 message CancelClaimedJobResponse {}
- 
+
 // ReleaseJobForRetryRequest contains the details needed to release a claimed job for retry.
 message ReleaseJobForRetryRequest {
   string id              = 1; // ID of the job
@@ -110,10 +110,10 @@ message ReleaseJobForRetryRequest {
   string error_code      = 4; // Error code
   string error_message   = 5; // Error message
 }
- 
+
 // ReleaseJobForRetryResponse contains the result of releasing a job for retry.
 message ReleaseJobForRetryResponse {}
- 
+
 // ExpiredJobLease contains a running job whose lease has expired.
 message ExpiredJobLease {
   string id            = 1; // ID of the job
@@ -127,26 +127,26 @@ message ExpiredJobLease {
   int32  attempts      = 9; // Number of execution attempts
   bool   log_retention = 10; // Whether logs should be durably retained
 }
- 
+
 // RecoverExpiredJobLeasesRequest contains the details needed to fetch expired leases.
 message RecoverExpiredJobLeasesRequest {
   int32  batch_size             = 1; // Maximum number of expired leases to claim
   string worker_id              = 2; // Worker claiming the expired leases for recovery
   int32  lease_duration_seconds = 3; // Lease duration in seconds for recovered claims
 }
- 
+
 // RecoverExpiredJobLeasesResponse contains expired leases to recover.
 message RecoverExpiredJobLeasesResponse {
   repeated ExpiredJobLease jobs = 1; // Expired leased jobs
 }
- 
+
 // GetJobRequest contains the details needed to get a job.
 message GetJobRequest {
   string id          = 1; // ID of the job
   string workflow_id = 2; // ID of the workflow
   string user_id     = 3; // ID of the user
 }
- 
+
 // GetJobResponse contains the result of a job retrieval attempt.
 message GetJobResponse {
   string id           = 1; // ID of the job
@@ -159,12 +159,12 @@ message GetJobResponse {
   string created_at   = 8; // Time the job was created
   string updated_at   = 9; // Time the job was last updated
 }
- 
+
 // GetJobByIDRequest contains the details needed to get a job by ID.
 message GetJobByIDRequest {
   string id = 1; // ID of the job
 }
- 
+
 // GetJobByIDResponse contains the result of a job retrieval attempt.
 message GetJobByIDResponse {
   string id           = 1; // ID of the job
@@ -179,7 +179,7 @@ message GetJobByIDResponse {
   string created_at   = 10; // Time the job was created
   string updated_at   = 11; // Time the job was last updated
 }
- 
+
 // LogStream represents the type of log stream.
 enum LogStream {
   LOG_STREAM_UNSPECIFIED = 0;
@@ -187,19 +187,19 @@ enum LogStream {
   LOG_STREAM_STDERR      = 2;
   LOG_STREAM_ALL         = 3;
 }
- 
+
 // LogSortOrder represents the order used for retained log pagination.
 enum LogSortOrder {
   LOG_SORT_ORDER_UNSPECIFIED = 0;
   LOG_SORT_ORDER_DESC        = 1;
   LOG_SORT_ORDER_ASC         = 2;
 }
- 
+
 // SearchJobLogsFilters are the filters that are to be applied on the get job logs request.
 message GetJobLogsFilters {
   LogStream stream = 1;
 }
- 
+
 // GetJobLogsRequest contains the details needed to get the logs of a job.
 message GetJobLogsRequest {
   string            id          = 1; // ID of the job
@@ -209,7 +209,7 @@ message GetJobLogsRequest {
   GetJobLogsFilters filters     = 5; // Filters applied to the search
   LogSortOrder      sort_order  = 6; // Sort order for retained log pagination
 }
- 
+
 // Log contains the details of a log.
 message Log {
   string timestamp    = 1; // Time the log was created
@@ -218,46 +218,46 @@ message Log {
   string stream       = 4; // Stream type (stdout or stderr)
   string event_id     = 5; // Unique retained/live log event ID
 }
- 
+
 // GetJobLogsResponse contains the result of a job log retrieval attempt.
 message GetJobLogsResponse {
-  string       id          = 1; // ID of the job
-  string       workflow_id = 2; // ID of the workflow
-  repeated Log logs        = 3; // List of log messages
-  string       cursor      = 4; // Cursor for pagination
+  string       id              = 1; // ID of the job
+  string       workflow_id     = 2; // ID of the workflow
+  repeated Log logs            = 3; // List of log messages
+  string       cursor          = 4; // Cursor for pagination
   string       highlight_token = 5; // Token used for parsing highlighted log ranges
 }
- 
+
 // StreamJobLogsRequest contains the details needed to stream the logs of a job.
 message StreamJobLogsRequest {
   string id          = 1; // ID of the job
   string workflow_id = 2; // ID of the workflow
   string user_id     = 3; // ID of the user
 }
- 
+
 // SearchJobLogsFilters are the filters that are to be applied on the search job logs request.
 message SearchJobLogsFilters {
   LogStream stream  = 1;
   string    message = 2;
 }
- 
+
 // SearchJobLogsRequest contains the details needed to search the logs of a job.
 message SearchJobLogsRequest {
-  string               id          = 1; // ID of the job
-  string               workflow_id = 2; // ID of the workflow
-  string               user_id     = 3; // ID of the user
-  string               cursor      = 4; // Cursor for pagination
-  SearchJobLogsFilters filters     = 5; // Filters applied to the search
-  LogSortOrder         sort_order  = 6; // Sort order for retained log pagination
+  string               id                = 1; // ID of the job
+  string               workflow_id       = 2; // ID of the workflow
+  string               user_id           = 3; // ID of the user
+  string               cursor            = 4; // Cursor for pagination
+  SearchJobLogsFilters filters           = 5; // Filters applied to the search
+  LogSortOrder         sort_order        = 6; // Sort order for retained log pagination
   bool                 disable_highlight = 7; // Disable search result highlighting
 }
- 
+
 // ListJobsFilters contains the filters for listing jobs.
 message ListJobsFilters {
   string status  = 1; // Status of the job (optional)
   string trigger = 2; // Trigger type of the job (optional)
 }
- 
+
 // ListJobsRequest contains the details needed to list all jobs for a workflow_id.
 message ListJobsRequest {
   string                   workflow_id = 1; // ID of the workflow
@@ -265,7 +265,7 @@ message ListJobsRequest {
   string                   cursor      = 3; // Cursor for pagination
   optional ListJobsFilters filters     = 4; // Filters applied to the list
 }
- 
+
 // JobsResponse contains the result of a job listing attempt.
 message JobsResponse {
   string id           = 1; // ID of the job
@@ -280,69 +280,69 @@ message JobsResponse {
   string updated_at   = 10; // Time the job was last updated
   int32  attempts     = 11; // Number of execution attempts
 }
- 
+
 message ListJobsResponse {
   repeated JobsResponse jobs   = 1; // List of jobs
   string                cursor = 2; // Cursor for pagination
 }
- 
+
 // JobsService handles job related operations.
 service JobsService {
     // ScheduleJob schedules a job to run at a specific time.
   rpc ScheduleJob(ScheduleJobRequest) returns (ScheduleJobResponse) {}
- 
+
     // UpdateJobStatus updates the status of a job.
     // This is an internal API and should not be exposed to the public.
   rpc UpdateJobStatus(UpdateJobStatusRequest) returns (UpdateJobStatusResponse) {}
- 
+
     // ClaimJob atomically claims a queued job for execution.
     // This is an internal API and should not be exposed to the public.
   rpc ClaimJob(ClaimJobRequest) returns (ClaimJobResponse) {}
- 
+
     // RenewJobLease renews a running job lease.
     // This is an internal API and should not be exposed to the public.
   rpc RenewJobLease(RenewJobLeaseRequest) returns (RenewJobLeaseResponse) {}
- 
+
     // AttachJobContainer attaches a container ID to a running claimed job.
     // This is an internal API and should not be exposed to the public.
   rpc AttachJobContainer(AttachJobContainerRequest) returns (AttachJobContainerResponse) {}
- 
+
     // CompleteJob completes a running claimed job.
     // This is an internal API and should not be exposed to the public.
   rpc CompleteJob(CompleteJobRequest) returns (CompleteJobResponse) {}
- 
+
     // FailJob marks a running claimed job as failed.
     // This is an internal API and should not be exposed to the public.
   rpc FailJob(FailJobRequest) returns (FailJobResponse) {}
- 
+
     // CancelClaimedJob marks a running claimed job as canceled.
     // This is an internal API and should not be exposed to the public.
   rpc CancelClaimedJob(CancelClaimedJobRequest) returns (CancelClaimedJobResponse) {}
- 
+
     // ReleaseJobForRetry releases a running claimed job back to pending.
     // This is an internal API and should not be exposed to the public.
   rpc ReleaseJobForRetry(ReleaseJobForRetryRequest) returns (ReleaseJobForRetryResponse) {}
- 
+
     // RecoverExpiredJobLeases returns expired running job leases for recovery.
     // This is an internal API and should not be exposed to the public.
   rpc RecoverExpiredJobLeases(RecoverExpiredJobLeasesRequest) returns (RecoverExpiredJobLeasesResponse) {}
- 
+
     // GetJob gets a job by ID and user_id.
   rpc GetJob(GetJobRequest) returns (GetJobResponse) {}
- 
+
     // GetJobByID gets a job by ID.
     // This is an internal API and should not be exposed to the public.
   rpc GetJobByID(GetJobByIDRequest) returns (GetJobByIDResponse) {}
- 
+
     // GetJobLogs gets the logs of a job.
   rpc GetJobLogs(GetJobLogsRequest) returns (GetJobLogsResponse) {}
- 
+
     // StreamJobLogs streams the logs of a job.
   rpc StreamJobLogs(StreamJobLogsRequest) returns (stream Log) {}
- 
+
     // SearchJobLogs returns the filtered logs of a job.
   rpc SearchJobLogs(SearchJobLogsRequest) returns (GetJobLogsResponse) {}
- 
+
     // ListJobs returns a list of all jobs for a workflow_id owned by a user.
   rpc ListJobs(ListJobsRequest) returns (ListJobsResponse) {}
 }


### PR DESCRIPTION
# Summary
- Add token-scoped Meili search highlights so dashboard rendering only trusts markers generated for the current search response.
- Add filtered log downloads with txt, json, and jsonl formats, using ASC order for download logs.
- Support stream/search filters and CANCELED terminal jobs for log downloads.
- Document the raw log download query parameters and response formats.