### PR TITLE
Fix distributed trace propagation

### DIFF
--- a/internal/pkg/grpc/client/client.go
+++ b/internal/pkg/grpc/client/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/eapache/go-resiliency/breaker"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -146,6 +147,7 @@ func NewClient(svcCfg *ServiceConfig, cbCfg *CircuitBreakerConfig, retryCfg *Ret
 
 	opts = append(
 		opts,
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
 		grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)),

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -29,15 +29,6 @@ func (s *Server) withOtelMiddleware(next http.Handler) http.Handler {
 
 		startTime := time.Now()
 
-		log := s.logger.With(
-			zap.Any("ctx", r.Context()),
-			zap.String("method", r.Method),
-			zap.String("path", r.URL.Path),
-			zap.String("host", r.Host),
-			zap.String("remote_addr", r.RemoteAddr),
-			zap.String("user_agent", r.UserAgent()),
-		)
-
 		// Start a new span for the request
 		ctx, span := s.tp.Start(
 			r.Context(),
@@ -51,6 +42,23 @@ func (s *Server) withOtelMiddleware(next http.Handler) http.Handler {
 			),
 		)
 		defer span.End()
+
+		spanCtx := span.SpanContext()
+		requestLogFields := []zap.Field{
+			zap.Any("ctx", ctx),
+			zap.String("method", r.Method),
+			zap.String("path", r.URL.Path),
+			zap.String("host", r.Host),
+			zap.String("remote_addr", r.RemoteAddr),
+			zap.String("user_agent", r.UserAgent()),
+		}
+		if spanCtx.IsValid() {
+			requestLogFields = append(requestLogFields,
+				zap.String("trace_id", spanCtx.TraceID().String()),
+				zap.String("span_id", spanCtx.SpanID().String()),
+			)
+		}
+		log := s.logger.With(requestLogFields...)
 
 		// Wrapped response writer to capture the status code
 		wrw := &customResponseWriter{

--- a/internal/server/middlewares_test.go
+++ b/internal/server/middlewares_test.go
@@ -76,10 +76,23 @@ func TestOtelMiddlewareLogsTraceIdentifiers(t *testing.T) {
 	}
 
 	fields := entries[0].ContextMap()
-	if fields["trace_id"] == "" {
-		t.Fatalf("expected trace_id field, got %#v", fields)
+	assertNonEmptyStringField(t, fields, "trace_id")
+	assertNonEmptyStringField(t, fields, "span_id")
+}
+
+func assertNonEmptyStringField(t *testing.T, fields map[string]any, key string) {
+	t.Helper()
+
+	value, ok := fields[key]
+	if !ok {
+		t.Fatalf("expected %s field, got %#v", key, fields)
 	}
-	if fields["span_id"] == "" {
-		t.Fatalf("expected span_id field, got %#v", fields)
+
+	text, ok := value.(string)
+	if !ok {
+		t.Fatalf("expected %s field to be a string, got %T", key, value)
+	}
+	if text == "" {
+		t.Fatalf("expected %s field to be non-empty, got %#v", key, fields)
 	}
 }

--- a/internal/server/middlewares_test.go
+++ b/internal/server/middlewares_test.go
@@ -6,6 +6,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestCORSMiddlewareAllowsIdempotencyKeyHeader(t *testing.T) {
@@ -34,5 +41,45 @@ func TestCORSMiddlewareAllowsIdempotencyKeyHeader(t *testing.T) {
 	allowedHeaders := strings.ToLower(res.Header().Get("Access-Control-Allow-Headers"))
 	if !strings.Contains(allowedHeaders, "idempotency-key") {
 		t.Fatalf("expected idempotency-key in CORS allowed headers, got %q", allowedHeaders)
+	}
+}
+
+func TestOtelMiddlewareLogsTraceIdentifiers(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	tracerProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(tracetest.NewSpanRecorder()),
+	)
+	s := &Server{
+		tp:     tracerProvider.Tracer("server-test"),
+		logger: zap.New(core),
+	}
+
+	handler := s.withOtelMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		spanCtx := oteltrace.SpanContextFromContext(r.Context())
+		if !spanCtx.IsValid() {
+			t.Fatal("expected traced request context")
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/notifications", http.NoBody)
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %d", http.StatusAccepted, res.Code)
+	}
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+
+	fields := entries[0].ContextMap()
+	if fields["trace_id"] == "" {
+		t.Fatalf("expected trace_id field, got %#v", fields)
+	}
+	if fields["span_id"] == "" {
+		t.Fatalf("expected span_id field, got %#v", fields)
 	}
 }


### PR DESCRIPTION
## Summary

- Propagate OpenTelemetry context through shared gRPC clients so service-to-service calls stay in one distributed trace.
- Correlate HTTP server access logs with the traced request context and explicit trace/span identifiers.
- Add coverage for HTTP middleware trace identifiers.