### PR TITLE
Add OpenTelemetry endpoint metrics for REST and gRPC

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -137,6 +137,8 @@ linters:
           - ireturn
         path: _test\.go
     paths:
+      - ^dashboard/
+      - ^static/
       - third_party$
       - builtin$
       - examples$
@@ -154,6 +156,8 @@ formatters:
   exclusions:
     generated: lax
     paths:
+      - ^dashboard/
+      - ^static/
       - third_party$
       - builtin$
       - examples$

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/eapache/go-resiliency v1.7.0
 	github.com/exaring/otelpgx v0.9.3
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-playground/validator/v10 v10.28.0
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
@@ -25,11 +26,13 @@ require (
 	go.opentelemetry.io/contrib/bridges/otelzap v0.13.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0
 	go.opentelemetry.io/contrib/instrumentation/host v0.63.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.63.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0
+	go.opentelemetry.io/otel/metric v1.38.0
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/sdk/log v0.14.0
 	go.opentelemetry.io/otel/sdk/metric v1.38.0
@@ -57,7 +60,6 @@ require (
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.11 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
@@ -97,11 +99,9 @@ require (
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.14.0 // indirect
-	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/internal/app/analytics/analytics.go
+++ b/internal/app/analytics/analytics.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
@@ -28,6 +27,7 @@ import (
 	"github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	grpcmiddlewares "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/middlewares"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
+	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
 
@@ -148,7 +148,7 @@ func New(ctx context.Context, cfg *Config, auth auth.IAuth, svc Service) *grpc.S
 	}
 
 	serverOpts = append(serverOpts,
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.StatsHandler(otelpkg.GRPCServerHandler()),
 		grpc.ChainUnaryInterceptor(
 			grpcmiddlewares.UnaryLoggingInterceptor(loggerpkg.FromContext(ctx)),
 			grpcmiddlewares.UnaryAudienceInterceptor(),

--- a/internal/app/jobs/jobs.go
+++ b/internal/app/jobs/jobs.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
@@ -31,6 +30,7 @@ import (
 	authpkg "github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	grpcmiddlewares "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/middlewares"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
+	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
 
@@ -168,7 +168,7 @@ func New(ctx context.Context, cfg *Config, auth authpkg.IAuth, svc Service) *grp
 
 	var serverOpts []grpc.ServerOption
 	serverOpts = append(serverOpts,
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.StatsHandler(otelpkg.GRPCServerHandler()),
 		grpc.ChainUnaryInterceptor(
 			grpcmiddlewares.UnaryLoggingInterceptor(loggerpkg.FromContext(ctx)),
 			grpcmiddlewares.UnaryAudienceInterceptor(),

--- a/internal/app/notifications/notifications.go
+++ b/internal/app/notifications/notifications.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
@@ -29,6 +28,7 @@ import (
 	authpkg "github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	grpcmiddlewares "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/middlewares"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
+	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
 
@@ -123,7 +123,7 @@ func New(ctx context.Context, cfg *Config, auth authpkg.IAuth, svc Service) *grp
 
 	var serverOpts []grpc.ServerOption
 	serverOpts = append(serverOpts,
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.StatsHandler(otelpkg.GRPCServerHandler()),
 		grpc.ChainUnaryInterceptor(
 			grpcmiddlewares.UnaryLoggingInterceptor(loggerpkg.FromContext(ctx)),
 			grpcmiddlewares.UnaryAudienceInterceptor(),

--- a/internal/app/users/users.go
+++ b/internal/app/users/users.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
@@ -29,6 +28,7 @@ import (
 	"github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	grpcmiddlewares "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/middlewares"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
+	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
 
@@ -173,7 +173,7 @@ func New(ctx context.Context, cfg *Config, _auth auth.IAuth, svc Service) *grpc.
 	}
 
 	serverOpts = append(serverOpts,
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.StatsHandler(otelpkg.GRPCServerHandler()),
 		grpc.ChainUnaryInterceptor(
 			grpcmiddlewares.UnaryLoggingInterceptor(loggerpkg.FromContext(ctx)),
 			grpcmiddlewares.UnaryAudienceInterceptor(),

--- a/internal/app/workflows/workflows.go
+++ b/internal/app/workflows/workflows.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
@@ -29,6 +28,7 @@ import (
 	authpkg "github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	grpcmiddlewares "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/middlewares"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
+	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
 
@@ -133,7 +133,7 @@ func New(ctx context.Context, cfg *Config, auth authpkg.IAuth, svc Service) *grp
 
 	var serverOpts []grpc.ServerOption
 	serverOpts = append(serverOpts,
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.StatsHandler(otelpkg.GRPCServerHandler()),
 		grpc.ChainUnaryInterceptor(
 			grpcmiddlewares.UnaryLoggingInterceptor(loggerpkg.FromContext(ctx)),
 			grpcmiddlewares.UnaryAudienceInterceptor(),

--- a/internal/pkg/grpc/client/client.go
+++ b/internal/pkg/grpc/client/client.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/eapache/go-resiliency/breaker"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/status"
+
+	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 )
 
 // TLSConfig holds the TLS configuration for gRPC client.
@@ -147,7 +148,7 @@ func NewClient(svcCfg *ServiceConfig, cbCfg *CircuitBreakerConfig, retryCfg *Ret
 
 	opts = append(
 		opts,
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithStatsHandler(otelpkg.GRPCClientHandler()),
 		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
 		grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)),

--- a/internal/pkg/kind/heartbeat/heartbeat.go
+++ b/internal/pkg/kind/heartbeat/heartbeat.go
@@ -7,6 +7,8 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 )
 
 // HeartBeat represents the HEARTBEAT workflow.
@@ -27,7 +29,8 @@ func (h *HeartBeat) Execute(
 ) error {
 	// HTTP client with timeout
 	client := &http.Client{
-		Timeout: timeout,
+		Timeout:   timeout,
+		Transport: otelpkg.HTTPTransport(nil),
 	}
 
 	// Create request with context

--- a/internal/pkg/kind/heartbeat/heartbeat_test.go
+++ b/internal/pkg/kind/heartbeat/heartbeat_test.go
@@ -1,12 +1,18 @@
 package heartbeat_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/hitesh22rana/chronoverse/internal/pkg/kind/heartbeat"
 )
@@ -31,6 +37,54 @@ func TestNew(t *testing.T) {
 			_ = heartbeat.New()
 		})
 	}
+}
+
+func TestHeartBeatExecuteEmitsHTTPClientTelemetry(t *testing.T) {
+	oldMeterProvider := otel.GetMeterProvider()
+	oldTracerProvider := otel.GetTracerProvider()
+	oldPropagator := otel.GetTextMapPropagator()
+	t.Cleanup(func() {
+		otel.SetMeterProvider(oldMeterProvider)
+		otel.SetTracerProvider(oldTracerProvider)
+		otel.SetTextMapPropagator(oldPropagator)
+	})
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	tracerProvider := sdktrace.NewTracerProvider()
+	otel.SetMeterProvider(meterProvider)
+	otel.SetTracerProvider(tracerProvider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	traceparent := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		traceparent <- r.Header.Get("traceparent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, span := tracerProvider.Tracer("heartbeat-test").Start(context.Background(), "execute")
+	err := heartbeat.New().Execute(ctx, time.Second, server.URL, http.StatusOK, nil)
+	span.End()
+	if err != nil {
+		t.Fatalf("heartbeat execution failed: %v", err)
+	}
+	if got := <-traceparent; got == "" {
+		t.Fatal("expected heartbeat request to propagate trace context")
+	}
+
+	var metrics metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &metrics); err != nil {
+		t.Fatalf("failed to collect heartbeat metrics: %v", err)
+	}
+	for _, scope := range metrics.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == "http.client.request.duration" {
+				return
+			}
+		}
+	}
+	t.Fatal("http.client.request.duration metric not found")
 }
 
 func TestHeartBeat_Execute(t *testing.T) {

--- a/internal/pkg/otel/instrumentation.go
+++ b/internal/pkg/otel/instrumentation.go
@@ -1,0 +1,117 @@
+package otel
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/stats"
+)
+
+// HTTPHandler instruments an HTTP server handler with the configured global
+// OpenTelemetry providers. Route templates from http.ServeMux are used for
+// span names and metric attributes to avoid recording high-cardinality paths.
+func HTTPHandler(handler http.Handler, operation string, opts ...otelhttp.Option) http.Handler {
+	defaultOpts := []otelhttp.Option{
+		otelhttp.WithTracerProvider(otel.GetTracerProvider()),
+		otelhttp.WithMeterProvider(otel.GetMeterProvider()),
+		otelhttp.WithSpanNameFormatter(func(operation string, request *http.Request) string {
+			if state, ok := request.Context().Value(httpRouteStateKey{}).(*httpRouteState); ok && state.route != "" {
+				return request.Method + " " + state.route
+			}
+			if request.Pattern == "" {
+				return operation
+			}
+
+			return request.Method + " " + request.Pattern
+		}),
+	}
+
+	instrumented := otelhttp.NewHandler(withHTTPRouteAttributes(handler), operation, append(defaultOpts, opts...)...)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		state := &httpRouteState{}
+		ctx := context.WithValue(r.Context(), httpRouteStateKey{}, state)
+		instrumented.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+type httpRouteStateKey struct{}
+
+type httpRouteState struct {
+	route string
+}
+
+func withHTTPRouteAttributes(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler.ServeHTTP(w, r)
+
+		route := httpRoute(r.Pattern)
+		if route == "" {
+			return
+		}
+
+		attr := semconv.HTTPRoute(route)
+		if state, ok := r.Context().Value(httpRouteStateKey{}).(*httpRouteState); ok {
+			state.route = route
+		}
+		labeler, _ := otelhttp.LabelerFromContext(r.Context())
+		labeler.Add(attr)
+		trace.SpanFromContext(r.Context()).SetAttributes(attr)
+	})
+}
+
+func httpRoute(pattern string) string {
+	if index := strings.IndexByte(pattern, '/'); index >= 0 {
+		return pattern[index:]
+	}
+
+	return ""
+}
+
+// HTTPTransport instruments outbound HTTP requests with the configured global
+// OpenTelemetry providers.
+func HTTPTransport(transport http.RoundTripper, opts ...otelhttp.Option) http.RoundTripper {
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	defaultOpts := []otelhttp.Option{
+		otelhttp.WithTracerProvider(otel.GetTracerProvider()),
+		otelhttp.WithMeterProvider(otel.GetMeterProvider()),
+	}
+
+	return otelhttp.NewTransport(transport, append(defaultOpts, opts...)...)
+}
+
+// GRPCServerHandler instruments inbound gRPC calls with the configured global
+// OpenTelemetry providers.
+func GRPCServerHandler(opts ...otelgrpc.Option) stats.Handler {
+	defaultOpts := []otelgrpc.Option{
+		otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+		otelgrpc.WithMeterProvider(otel.GetMeterProvider()),
+	}
+
+	return otelgrpc.NewServerHandler(append(defaultOpts, opts...)...)
+}
+
+// GRPCClientHandler instruments outbound gRPC calls with the configured global
+// OpenTelemetry providers.
+func GRPCClientHandler(opts ...otelgrpc.Option) stats.Handler {
+	defaultOpts := []otelgrpc.Option{
+		otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+		otelgrpc.WithMeterProvider(otel.GetMeterProvider()),
+	}
+
+	return otelgrpc.NewClientHandler(append(defaultOpts, opts...)...)
+}
+
+// Meter returns a meter from the configured global OpenTelemetry provider.
+func Meter(scope string, opts ...metric.MeterOption) metric.Meter {
+	return otel.GetMeterProvider().Meter(scope, opts...)
+}

--- a/internal/pkg/otel/instrumentation_test.go
+++ b/internal/pkg/otel/instrumentation_test.go
@@ -1,0 +1,360 @@
+package otel_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/test/bufconn"
+
+	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
+)
+
+func TestHTTPHandlerRecordsRouteMetrics(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /workflows/{workflow_id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		if _, err := io.WriteString(w, "accepted"); err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	})
+	handler := otelpkg.HTTPHandler(
+		mux,
+		"test-server",
+		otelhttp.WithMeterProvider(meterProvider),
+		otelhttp.WithTracerProvider(tracerProvider),
+	)
+
+	request := httptest.NewRequest(http.MethodGet, "/workflows/workflow-123", http.NoBody)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %d", http.StatusAccepted, response.Code)
+	}
+
+	duration := collectFloatHistogram(t, reader, "http.server.request.duration")
+	if len(duration.DataPoints) != 1 {
+		t.Fatalf("expected one duration datapoint, got %d", len(duration.DataPoints))
+	}
+
+	attrs := duration.DataPoints[0].Attributes
+	assertStringAttribute(t, attrs, "http.request.method", http.MethodGet)
+	assertStringAttribute(t, attrs, "http.route", "/workflows/{workflow_id}")
+	assertInt64Attribute(t, attrs, "http.response.status_code", http.StatusAccepted)
+	if strings.Contains(attrs.Encoded(attribute.DefaultEncoder()), "workflow-123") {
+		t.Fatal("metric attributes contain a concrete workflow ID")
+	}
+
+	assertMetricExists(t, reader, "http.server.request.body.size")
+	assertMetricExists(t, reader, "http.server.response.body.size")
+
+	spans := spanRecorder.Ended()
+	if len(spans) != 1 || spans[0].Name() != "GET /workflows/{workflow_id}" {
+		t.Fatalf("unexpected spans: %#v", spans)
+	}
+}
+
+func TestHTTPHandlerRecordsErrorAndUnmatchedRequests(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		method     string
+		target     string
+		wantStatus int
+	}{
+		{name: "method not allowed", method: http.MethodPost, target: "/known", wantStatus: http.StatusMethodNotAllowed},
+		{name: "unmatched", method: http.MethodGet, target: "/missing", wantStatus: http.StatusNotFound},
+		{name: "server error", method: http.MethodGet, target: "/error", wantStatus: http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reader := sdkmetric.NewManualReader()
+			meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			mux := http.NewServeMux()
+			mux.HandleFunc("GET /known", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			mux.HandleFunc("GET /error", func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "failed", http.StatusInternalServerError)
+			})
+			handler := otelpkg.HTTPHandler(mux, "test-server", otelhttp.WithMeterProvider(meterProvider))
+
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(tt.method, tt.target, http.NoBody))
+			if response.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d", tt.wantStatus, response.Code)
+			}
+
+			duration := collectFloatHistogram(t, reader, "http.server.request.duration")
+			if len(duration.DataPoints) != 1 {
+				t.Fatalf("expected one duration datapoint, got %d", len(duration.DataPoints))
+			}
+			assertInt64Attribute(t, duration.DataPoints[0].Attributes, "http.response.status_code", tt.wantStatus)
+		})
+	}
+}
+
+func TestHTTPHandlerPreservesStreamingAndDownloadWriters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pattern string
+		target  string
+		route   string
+	}{
+		{name: "event stream", pattern: "GET /workflows/{workflow_id}/jobs/{job_id}/events", target: "/workflows/wf-1/jobs/job-1/events", route: "/workflows/{workflow_id}/jobs/{job_id}/events"},
+		{name: "log download", pattern: "GET /workflows/{workflow_id}/jobs/{job_id}/logs/raw", target: "/workflows/wf-1/jobs/job-1/logs/raw", route: "/workflows/{workflow_id}/jobs/{job_id}/logs/raw"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reader := sdkmetric.NewManualReader()
+			meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			mux := http.NewServeMux()
+			mux.HandleFunc(tt.pattern, func(w http.ResponseWriter, _ *http.Request) {
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					t.Fatal("instrumented response writer does not implement http.Flusher")
+				}
+				if _, err := io.WriteString(w, "chunk"); err != nil {
+					t.Fatalf("failed to write stream chunk: %v", err)
+				}
+				flusher.Flush()
+			})
+			handler := otelpkg.HTTPHandler(mux, "test-server", otelhttp.WithMeterProvider(meterProvider))
+
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, tt.target, http.NoBody))
+
+			duration := collectFloatHistogram(t, reader, "http.server.request.duration")
+			if len(duration.DataPoints) != 1 || duration.DataPoints[0].Count != 1 {
+				t.Fatalf("expected one completed request measurement, got %#v", duration.DataPoints)
+			}
+			assertStringAttribute(t, duration.DataPoints[0].Attributes, "http.route", tt.route)
+		})
+	}
+}
+
+func TestHTTPTransportPropagatesTraceAndRecordsMetrics(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	tracerProvider := sdktrace.NewTracerProvider()
+	traceparent := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		traceparent <- r.Header.Get("traceparent")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Transport: otelpkg.HTTPTransport(
+		nil,
+		otelhttp.WithMeterProvider(meterProvider),
+		otelhttp.WithTracerProvider(tracerProvider),
+		otelhttp.WithPropagators(propagation.TraceContext{}),
+	)}
+	ctx, span := tracerProvider.Tracer("test").Start(context.Background(), "parent")
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	response, err := client.Do(request)
+	span.End()
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if err := response.Body.Close(); err != nil {
+		t.Fatalf("failed to close response body: %v", err)
+	}
+
+	if got := <-traceparent; got == "" {
+		t.Fatal("expected traceparent header")
+	}
+	assertMetricExists(t, reader, "http.client.request.duration")
+}
+
+func TestGRPCHandlersRecordUnaryAndStreamingMetrics(t *testing.T) {
+	t.Parallel()
+
+	serverReader := sdkmetric.NewManualReader()
+	serverMeterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(serverReader))
+	clientReader := sdkmetric.NewManualReader()
+	clientMeterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(clientReader))
+	tracerProvider := sdktrace.NewTracerProvider()
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer(grpc.StatsHandler(otelpkg.GRPCServerHandler(
+		otelgrpc.WithMeterProvider(serverMeterProvider),
+		otelgrpc.WithTracerProvider(tracerProvider),
+	)))
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("test", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(server, healthServer)
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.Serve(listener)
+	}()
+	defer func() {
+		server.Stop()
+		if err := <-serveErr; err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Errorf("gRPC server failed: %v", err)
+		}
+	}()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///test",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithStatsHandler(otelpkg.GRPCClientHandler(
+			otelgrpc.WithMeterProvider(clientMeterProvider),
+			otelgrpc.WithTracerProvider(tracerProvider),
+		)),
+	)
+	if err != nil {
+		t.Fatalf("failed to create gRPC client: %v", err)
+	}
+	defer conn.Close()
+	client := grpc_health_v1.NewHealthClient(conn)
+
+	if _, checkErr := client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: "test"}); checkErr != nil {
+		t.Fatalf("unary health check failed: %v", checkErr)
+	}
+	streamCtx, cancel := context.WithCancel(t.Context())
+	stream, err := client.Watch(streamCtx, &grpc_health_v1.HealthCheckRequest{Service: "test"})
+	if err != nil {
+		cancel()
+		t.Fatalf("streaming health check failed: %v", err)
+	}
+	if _, err := stream.Recv(); err != nil {
+		cancel()
+		t.Fatalf("failed to receive streaming health response: %v", err)
+	}
+	cancel()
+	if _, recvErr := stream.Recv(); recvErr == nil {
+		t.Fatal("expected canceled stream to return an error")
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	serverDuration := collectFloatHistogram(t, serverReader, "rpc.server.duration")
+	clientDuration := collectFloatHistogram(t, clientReader, "rpc.client.duration")
+	assertRPCMethods(t, serverDuration.DataPoints, "Check", "Watch")
+	assertRPCMethods(t, clientDuration.DataPoints, "Check", "Watch")
+}
+
+func collectFloatHistogram(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Histogram[float64] {
+	t.Helper()
+
+	metrics := collectMetrics(t, reader)
+	for _, scope := range metrics.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == name {
+				histogram, ok := metric.Data.(metricdata.Histogram[float64])
+				if !ok {
+					t.Fatalf("metric %s has type %T", name, metric.Data)
+				}
+				return histogram
+			}
+		}
+	}
+
+	t.Fatalf("metric %s not found", name)
+	return metricdata.Histogram[float64]{}
+}
+
+func assertMetricExists(t *testing.T, reader *sdkmetric.ManualReader, name string) {
+	t.Helper()
+
+	metrics := collectMetrics(t, reader)
+	for _, scope := range metrics.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == name {
+				return
+			}
+		}
+	}
+
+	t.Fatalf("metric %s not found", name)
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+
+	var metrics metricdata.ResourceMetrics
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	if err := reader.Collect(ctx, &metrics); err != nil {
+		t.Fatalf("failed to collect metrics: %v", err)
+	}
+	return metrics
+}
+
+func assertStringAttribute(t *testing.T, attrs attribute.Set, key, want string) {
+	t.Helper()
+
+	value, ok := attrs.Value(attribute.Key(key))
+	if !ok || value.AsString() != want {
+		t.Fatalf("expected attribute %s=%q, got %v", key, want, value)
+	}
+}
+
+func assertInt64Attribute(t *testing.T, attrs attribute.Set, key string, want int) {
+	t.Helper()
+
+	value, ok := attrs.Value(attribute.Key(key))
+	if !ok || value.AsInt64() != int64(want) {
+		t.Fatalf("expected attribute %s=%d, got %v", key, want, value)
+	}
+}
+
+func assertRPCMethods(t *testing.T, points []metricdata.HistogramDataPoint[float64], methods ...string) {
+	t.Helper()
+
+	found := make(map[string]bool, len(methods))
+	for _, point := range points {
+		value, ok := point.Attributes.Value(attribute.Key("rpc.method"))
+		if ok {
+			found[value.AsString()] = true
+		}
+	}
+	for _, method := range methods {
+		if !found[method] {
+			t.Fatalf("RPC method %s not found in metric datapoints", method)
+		}
+	}
+}

--- a/internal/pkg/otel/otel.go
+++ b/internal/pkg/otel/otel.go
@@ -52,11 +52,9 @@ func InitTracerProvider(ctx context.Context, res *resource.Resource) (*sdktrace.
 		return nil, status.Errorf(codes.Internal, "failed to create OTLP trace exporter: %v", err)
 	}
 
-	bsp := sdktrace.NewBatchSpanProcessor(exporter)
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),
-		sdktrace.WithSpanProcessor(bsp),
 	)
 	otel.SetTracerProvider(tp)
 

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -139,21 +139,6 @@ func handleError(w http.ResponseWriter, err error, message ...string) {
 	}
 }
 
-// customResponseWriter wraps http.ResponseWriter to capture status code.
-type customResponseWriter struct {
-	http.ResponseWriter
-	status int
-}
-
-func (w *customResponseWriter) WriteHeader(statusCode int) {
-	w.status = statusCode
-	w.ResponseWriter.WriteHeader(statusCode)
-}
-
-func (w *customResponseWriter) Write(b []byte) (int, error) {
-	return w.ResponseWriter.Write(b)
-}
-
 // gzipResponseWriter combines gzip compression with status code capture.
 type gzipResponseWriter struct {
 	http.ResponseWriter

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
-	"go.opentelemetry.io/otel/attribute"
+	"github.com/felixge/httpsnoop"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -18,36 +17,15 @@ import (
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
 
-// withOtelMiddleware adds OpenTelemetry tracing to the HTTP handler.
-func (s *Server) withOtelMiddleware(next http.Handler) http.Handler {
+// withRequestLoggingMiddleware logs completed HTTP requests. OpenTelemetry
+// tracing and metrics are provided by the shared OTEL HTTP handler wrapper.
+func (s *Server) withRequestLoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Skip tracing for streaming endpoints
-		if strings.Contains(r.URL.Path, "/logs/raw") || strings.Contains(r.URL.Path, "/events") {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		startTime := time.Now()
-
-		// Start a new span for the request
-		ctx, span := s.tp.Start(
-			r.Context(),
-			fmt.Sprintf("%s %s", r.Method, r.URL.Path),
-			trace.WithAttributes(
-				attribute.String("http.method", r.Method),
-				attribute.String("http.url", r.URL.String()),
-				attribute.String("http.host", r.Host),
-				attribute.String("http.remote_addr", r.RemoteAddr),
-				attribute.String("http.user_agent", r.UserAgent()),
-			),
-		)
-		defer span.End()
-
-		spanCtx := span.SpanContext()
+		spanCtx := trace.SpanContextFromContext(r.Context())
 		requestLogFields := []zap.Field{
-			zap.Any("ctx", ctx),
+			zap.Any("ctx", r.Context()),
 			zap.String("method", r.Method),
-			zap.String("path", r.URL.Path),
+			zap.String("path", requestLogPath(r)),
 			zap.String("host", r.Host),
 			zap.String("remote_addr", r.RemoteAddr),
 			zap.String("user_agent", r.UserAgent()),
@@ -60,41 +38,32 @@ func (s *Server) withOtelMiddleware(next http.Handler) http.Handler {
 		}
 		log := s.logger.With(requestLogFields...)
 
-		// Wrapped response writer to capture the status code
-		wrw := &customResponseWriter{
-			ResponseWriter: w,
-			status:         http.StatusOK,
-		}
-
-		// Continue the request with the new context
-		next.ServeHTTP(wrw, r.WithContext(ctx))
-
-		duration := time.Since(startTime)
-
-		// Set the status code in the span
-		span.SetAttributes(attribute.Int("http.status_code", wrw.status))
+		metrics := httpsnoop.CaptureMetrics(next, w, r)
 
 		logFields := []zap.Field{
-			zap.Int("status", wrw.status),
-			zap.Duration("duration_ms", duration),
-			zap.String("duration", duration.String()),
+			zap.Int("status", metrics.Code),
+			zap.Duration("duration_ms", metrics.Duration),
+			zap.String("duration", metrics.Duration.String()),
 		}
 
-		msg := fmt.Sprintf("%s %s", r.Method, r.URL.Path)
+		msg := fmt.Sprintf("%s %s", r.Method, requestLogPath(r))
 		//nolint:gocritic // This if-else chain is better than a switch statement
-		if wrw.status >= 500 {
+		if metrics.Code >= 500 {
 			log.Error(msg, logFields...)
-			span.SetAttributes(attribute.String("http.error", http.StatusText(wrw.status)))
-			span.RecordError(fmt.Errorf("server error: %s", http.StatusText(wrw.status)))
-		} else if wrw.status >= 400 {
+		} else if metrics.Code >= 400 {
 			log.Warn(msg, logFields...)
-			span.SetAttributes(attribute.String("http.error", http.StatusText(wrw.status)))
-			span.RecordError(fmt.Errorf("client error: %s", http.StatusText(wrw.status)))
 		} else {
 			log.Info(msg, logFields...)
-			span.SetAttributes(attribute.String("http.success", http.StatusText(wrw.status)))
 		}
 	})
+}
+
+func requestLogPath(r *http.Request) string {
+	if r.Pattern != "" {
+		return r.Pattern
+	}
+
+	return r.URL.Path
 }
 
 // withCORSMiddleware adds CORS headers to all responses.

--- a/internal/server/middlewares_test.go
+++ b/internal/server/middlewares_test.go
@@ -7,12 +7,15 @@ import (
 	"strings"
 	"testing"
 
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 )
 
 func TestCORSMiddlewareAllowsIdempotencyKeyHeader(t *testing.T) {
@@ -50,17 +53,20 @@ func TestOtelMiddlewareLogsTraceIdentifiers(t *testing.T) {
 		sdktrace.WithSpanProcessor(tracetest.NewSpanRecorder()),
 	)
 	s := &Server{
-		tp:     tracerProvider.Tracer("server-test"),
 		logger: zap.New(core),
 	}
 
-	handler := s.withOtelMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		spanCtx := oteltrace.SpanContextFromContext(r.Context())
-		if !spanCtx.IsValid() {
-			t.Fatal("expected traced request context")
-		}
-		w.WriteHeader(http.StatusAccepted)
-	}))
+	handler := otelpkg.HTTPHandler(
+		s.withRequestLoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			spanCtx := oteltrace.SpanContextFromContext(r.Context())
+			if !spanCtx.IsValid() {
+				t.Fatal("expected traced request context")
+			}
+			w.WriteHeader(http.StatusAccepted)
+		})),
+		"server-test",
+		otelhttp.WithTracerProvider(tracerProvider),
+	)
 
 	req := httptest.NewRequest(http.MethodGet, "/notifications", http.NoBody)
 	res := httptest.NewRecorder()
@@ -78,6 +84,21 @@ func TestOtelMiddlewareLogsTraceIdentifiers(t *testing.T) {
 	fields := entries[0].ContextMap()
 	assertNonEmptyStringField(t, fields, "trace_id")
 	assertNonEmptyStringField(t, fields, "span_id")
+}
+
+func TestRequestLoggingMiddlewarePreservesFlusher(t *testing.T) {
+	s := &Server{logger: zap.NewNop()}
+	flusherAvailable := false
+	handler := s.withRequestLoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, flusherAvailable = w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/events", http.NoBody))
+
+	if !flusherAvailable {
+		t.Fatal("expected request logging middleware to preserve http.Flusher")
+	}
 }
 
 func assertNonEmptyStringField(t *testing.T, fields map[string]any, key string) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,8 +10,6 @@ import (
 	"syscall"
 	"time"
 
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	analyticspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/analytics"
@@ -23,13 +21,13 @@ import (
 	"github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/crypto"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
+	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/redis"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
 
 // Server implements the HTTP server.
 type Server struct {
-	tp                  trace.Tracer
 	logger              *zap.Logger
 	auth                auth.IAuth
 	crypto              *crypto.Crypto
@@ -111,7 +109,6 @@ func New(
 	}
 
 	srv := &Server{
-		tp:                  otel.Tracer(svcpkg.Info().GetName()),
 		logger:              logger,
 		auth:                auth,
 		crypto:              crypto,
@@ -141,10 +138,13 @@ func New(
 	srv.registerRoutes(router)
 
 	// Common middlewares
-	srv.httpServer.Handler = srv.withOtelMiddleware(
-		srv.withCORSMiddleware(
-			srv.withCompressionMiddleware(router),
+	srv.httpServer.Handler = otelpkg.HTTPHandler(
+		srv.withRequestLoggingMiddleware(
+			srv.withCORSMiddleware(
+				srv.withCompressionMiddleware(router),
+			),
 		),
+		svcpkg.Info().GetName(),
 	)
 	return srv
 }

--- a/static/content/docs/operations/monitoring.mdx
+++ b/static/content/docs/operations/monitoring.mdx
@@ -12,6 +12,8 @@ Compose checks PostgreSQL with TLS `psql`, ClickHouse with the secure client, Re
 
 Monitor request and RPC latency, Kafka consumer progress, outbox pending and dead rows, expired job leases, execution retries, log processor batch failures, ClickHouse insert latency, Meilisearch health, and database pool saturation.
 
+For endpoint traffic, use histogram counts for request rate, status-code attributes for error ratios, and histogram buckets for latency percentiles. Group REST traffic by `http.route` rather than raw URL paths, and group gRPC traffic by `rpc.service` and `rpc.method`.
+
 ## User-visible checks
 
 Track scheduling delay, workflow build failures, jobs stuck outside terminal states, SSE connection failures, missing retained logs, and analytics lag.
@@ -24,4 +26,3 @@ docker compose -f compose.prod.yaml logs --since=15m server
 docker compose -f compose.prod.yaml logs --since=15m outbox-relay
 docker compose -f compose.prod.yaml logs --since=15m execution-worker
 ```
-

--- a/static/content/docs/operations/observability.mdx
+++ b/static/content/docs/operations/observability.mdx
@@ -12,7 +12,53 @@ Trace context crosses HTTP, gRPC, and Kafka. Use a single trace to follow an API
 
 ## Metrics
 
-Runtime and host metrics complement application spans. Watch latency distributions and saturation rather than relying only on process uptime.
+Runtime and host metrics complement application spans. HTTP, gRPC, and Redis instrumentation uses the same global OpenTelemetry meter provider and exports through the configured OTLP endpoint.
+
+### Endpoint metrics
+
+The HTTP server emits the standard OpenTelemetry histograms:
+
+- `http.server.request.duration`
+- `http.server.request.body.size`
+- `http.server.response.body.size`
+
+Outbound heartbeat requests emit the corresponding `http.client.*` metrics. HTTP server metrics use route templates such as `/workflows/{workflow_id}`; workflow IDs, job IDs, users, URLs, and authentication data are not metric attributes.
+
+All gRPC servers and clients emit:
+
+- `rpc.server.duration` and `rpc.client.duration`
+- `rpc.server.request.size` and `rpc.client.request.size`
+- `rpc.server.response.size` and `rpc.client.response.size`
+- per-RPC request and response message counts
+
+Useful dimensions include HTTP method, route, and response status, plus gRPC service, method, and status code. Unary and streaming RPCs are both recorded.
+
+Request volume is derived from histogram sample counts rather than a separate request counter. In Grafana's Prometheus data source, the OTEL metrics are normalized to Prometheus names. Example queries include:
+
+```promql
+# REST requests per second by route and method
+sum by (http_route, http_request_method) (
+  rate(http_server_request_duration_seconds_count[5m])
+)
+
+# REST 5xx ratio
+sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))
+/
+sum(rate(http_server_request_duration_seconds_count[5m]))
+
+# REST p95 latency by route
+histogram_quantile(
+  0.95,
+  sum by (le, http_route) (rate(http_server_request_duration_seconds_bucket[5m]))
+)
+
+# gRPC requests per second by service and method
+sum by (rpc_service, rpc_method) (
+  rate(rpc_server_duration_milliseconds_count[5m])
+)
+```
+
+Watch latency distributions, error ratios, and saturation rather than relying only on process uptime.
 
 ## Logs
 
@@ -21,4 +67,3 @@ Structured application logs include service context and trace correlation where 
 ## Investigation order
 
 Start from the user-visible request or job ID, locate its trace, inspect failed spans and correlated logs, then confirm durable state in PostgreSQL and transport progress in Kafka.
-


### PR DESCRIPTION
## Summary

- Add shared OpenTelemetry wrappers for HTTP and gRPC server/client instrumentation.
- Emit normalized REST endpoint metrics, preserve streaming support, and instrument heartbeat HTTP calls.
- Centralize existing gRPC telemetry and remove duplicate trace processor registration.
- Document endpoint metric names and Grafana PromQL queries.
- Restrict Go linting to backend code by excluding frontend workspaces.