### PR TITLE
Fix login enumeration and cache stampedes

### DIFF
--- a/internal/pkg/cache/ttl.go
+++ b/internal/pkg/cache/ttl.go
@@ -1,0 +1,21 @@
+package cache
+
+import (
+	"crypto/rand"
+	"math/big"
+	"time"
+)
+
+// AddJitter spreads cache expirations across the interval [ttl, ttl+maxJitter].
+func AddJitter(ttl, maxJitter time.Duration) time.Duration {
+	if ttl <= 0 || maxJitter <= 0 {
+		return ttl
+	}
+
+	jitter, err := rand.Int(rand.Reader, big.NewInt(int64(maxJitter)+1))
+	if err != nil {
+		return ttl
+	}
+
+	return ttl + time.Duration(jitter.Int64())
+}

--- a/internal/pkg/cache/ttl_test.go
+++ b/internal/pkg/cache/ttl_test.go
@@ -1,0 +1,41 @@
+package cache_test
+
+import (
+	"testing"
+	"time"
+
+	cachepkg "github.com/hitesh22rana/chronoverse/internal/pkg/cache"
+)
+
+func TestAddJitter(t *testing.T) {
+	ttl := 30 * time.Minute
+	maxJitter := 3 * time.Minute
+
+	for range 100 {
+		got := cachepkg.AddJitter(ttl, maxJitter)
+		if got < ttl || got > ttl+maxJitter {
+			t.Fatalf("AddJitter() = %s, want value between %s and %s", got, ttl, ttl+maxJitter)
+		}
+	}
+}
+
+func TestAddJitterDisabled(t *testing.T) {
+	tests := []struct {
+		name      string
+		ttl       time.Duration
+		maxJitter time.Duration
+	}{
+		{name: "no expiration", ttl: 0, maxJitter: time.Minute},
+		{name: "negative expiration", ttl: -time.Second, maxJitter: time.Minute},
+		{name: "no jitter", ttl: time.Minute, maxJitter: 0},
+		{name: "negative jitter", ttl: time.Minute, maxJitter: -time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cachepkg.AddJitter(tt.ttl, tt.maxJitter); got != tt.ttl {
+				t.Fatalf("AddJitter() = %s, want %s", got, tt.ttl)
+			}
+		})
+	}
+}

--- a/internal/repository/users/credentials_test.go
+++ b/internal/repository/users/credentials_test.go
@@ -1,0 +1,26 @@
+//nolint:testpackage // Tests the private timing hash and normalized credential error.
+package users
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestDummyPasswordHash(t *testing.T) {
+	if err := bcrypt.CompareHashAndPassword([]byte(dummyPasswordHash), []byte("chronoverse-dummy-password")); err != nil {
+		t.Fatalf("dummy password hash is invalid: %v", err)
+	}
+}
+
+func TestInvalidCredentialsError(t *testing.T) {
+	err := invalidCredentialsError()
+	if got := status.Code(err); got != codes.Unauthenticated {
+		t.Fatalf("invalidCredentialsError() code = %s, want %s", got, codes.Unauthenticated)
+	}
+	if got, want := status.Convert(err).Message(), "invalid email or password"; got != want {
+		t.Fatalf("invalidCredentialsError() message = %q, want %q", got, want)
+	}
+}

--- a/internal/repository/users/users.go
+++ b/internal/repository/users/users.go
@@ -20,6 +20,9 @@ import (
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
 
+// #nosec G101 -- This public bcrypt hash is only used to equalize login timing.
+const dummyPasswordHash = "$2a$10$jKOlozu2Vfz.vNPHnOvOKuKh5B2gNH4aLNs4SGYZy5KoWvjxOstCq"
+
 // Repository provides users repository.
 type Repository struct {
 	tp   trace.Tracer
@@ -136,7 +139,12 @@ func (r *Repository) LoginUser(ctx context.Context, email, pass string) (res *us
 	loginUserResponse, err := pgx.CollectExactlyOneRow(rows, pgx.RowToAddrOfStructByName[usersmodel.LoginUserData])
 	if err != nil {
 		if r.pg.IsNoRows(err) {
-			err = status.Errorf(codes.NotFound, "user not found: %v", err)
+			// Keep missing-user attempts on the same expensive path as invalid passwords.
+			compareErr := bcrypt.CompareHashAndPassword([]byte(dummyPasswordHash), []byte(pass))
+			if compareErr != nil && !errors.Is(compareErr, bcrypt.ErrMismatchedHashAndPassword) {
+				return nil, "", status.Errorf(codes.Internal, "failed to verify password: %v", compareErr)
+			}
+			err = invalidCredentialsError()
 			return nil, "", err
 		} else if r.pg.IsInvalidTextRepresentation(err) {
 			err = status.Errorf(codes.InvalidArgument, "invalid user ID: %v", err)
@@ -149,7 +157,11 @@ func (r *Repository) LoginUser(ctx context.Context, email, pass string) (res *us
 
 	// Validate password
 	if err = bcrypt.CompareHashAndPassword([]byte(loginUserResponse.Password), []byte(pass)); err != nil {
-		err = status.Errorf(codes.InvalidArgument, "invalid password: %v", err)
+		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+			return nil, "", invalidCredentialsError()
+		}
+
+		err = status.Errorf(codes.Internal, "failed to verify password: %v", err)
 		return nil, "", err
 	}
 
@@ -168,6 +180,10 @@ func (r *Repository) LoginUser(ctx context.Context, email, pass string) (res *us
 	}
 
 	return res, authToken, nil
+}
+
+func invalidCredentialsError() error {
+	return status.Error(codes.Unauthenticated, "invalid email or password")
 }
 
 // GetUser fetches user by ID.

--- a/internal/service/jobs/jobs.go
+++ b/internal/service/jobs/jobs.go
@@ -23,6 +23,7 @@ import (
 	jobspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
 
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
+	cachepkg "github.com/hitesh22rana/chronoverse/internal/pkg/cache"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/redis"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
@@ -30,7 +31,9 @@ import (
 
 const (
 	defaultExpirationTTL      = time.Minute * 30
+	cacheExpirationJitter     = defaultExpirationTTL / 10
 	jobLogSearchExpirationTTL = time.Minute * 15
+	jobLogSearchTTLJitter     = jobLogSearchExpirationTTL / 10
 	cacheTimeout              = time.Second * 5
 )
 
@@ -630,7 +633,7 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 				defer cancel()
 
-				if setErr := s.cache.Set(bgCtx, cacheKey, _res, defaultExpirationTTL); setErr != nil {
+				if setErr := s.cache.Set(bgCtx, cacheKey, _res, cachepkg.AddJitter(defaultExpirationTTL, cacheExpirationJitter)); setErr != nil {
 					logger.Warn("failed to cache job logs",
 						zap.String("user_id", req.GetUserId()),
 						zap.String("job_id", req.GetId()),
@@ -838,7 +841,7 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 				bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 				defer cancel()
 
-				if setErr := s.cache.Set(bgCtx, cacheKey, _res, jobLogSearchExpirationTTL); setErr != nil {
+				if setErr := s.cache.Set(bgCtx, cacheKey, _res, cachepkg.AddJitter(jobLogSearchExpirationTTL, jobLogSearchTTLJitter)); setErr != nil {
 					logger.Warn("failed to cache job logs",
 						zap.String("user_id", req.GetUserId()),
 						zap.String("job_id", req.GetId()),

--- a/internal/service/users/users.go
+++ b/internal/service/users/users.go
@@ -70,8 +70,6 @@ type RegisterUserRequest struct {
 }
 
 // RegisterUser a new user.
-//
-//nolint:dupl // It's ok to have duplicate code here as the logic is similar to other methods.
 func (s *Service) RegisterUser(ctx context.Context, req *userpb.RegisterUserRequest) (userID, authToken string, err error) {
 	logger := loggerpkg.FromContext(ctx).With(
 		zap.String("method", "Service.RegisterUser"),
@@ -133,8 +131,6 @@ type LoginUserRequest struct {
 }
 
 // LoginUser user.
-//
-//nolint:dupl // It's ok to have duplicate code here as the logic is similar to other methods.
 func (s *Service) LoginUser(ctx context.Context, req *userpb.LoginUserRequest) (userID, authToken string, err error) {
 	logger := loggerpkg.FromContext(ctx).With(
 		zap.String("method", "Service.LoginUser"),
@@ -160,7 +156,7 @@ func (s *Service) LoginUser(ctx context.Context, req *userpb.LoginUserRequest) (
 
 	res, authToken, err := s.repo.LoginUser(ctx, req.GetEmail(), req.GetPassword())
 	if err != nil {
-		return "", "", err
+		return "", "", normalizeLoginError(err)
 	}
 
 	// Cache the response in the background
@@ -322,6 +318,15 @@ func (s *Service) UpdateUser(ctx context.Context, req *userpb.UpdateUserRequest)
 			zap.String("user_id", req.GetId()),
 			zap.String("cache_key", cacheKey),
 		)
+	}
+
+	return err
+}
+
+func normalizeLoginError(err error) error {
+	code := status.Code(err)
+	if code == codes.NotFound || code == codes.InvalidArgument {
+		return status.Error(codes.Unauthenticated, "invalid email or password")
 	}
 
 	return err

--- a/internal/service/users/users.go
+++ b/internal/service/users/users.go
@@ -20,13 +20,15 @@ import (
 	userpb "github.com/hitesh22rana/chronoverse/pkg/proto/go/users"
 
 	usersmodel "github.com/hitesh22rana/chronoverse/internal/model/users"
+	cachepkg "github.com/hitesh22rana/chronoverse/internal/pkg/cache"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
 
 const (
-	defaultExpirationTTL = time.Minute * 30
-	cacheTimeout         = time.Second * 2
+	defaultExpirationTTL  = time.Minute * 30
+	cacheExpirationJitter = defaultExpirationTTL / 10
+	cacheTimeout          = time.Second * 2
 )
 
 // Repository provides user related operations.
@@ -107,7 +109,7 @@ func (s *Service) RegisterUser(ctx context.Context, req *userpb.RegisterUserRequ
 		// Cache the LoginUser response
 		// The key is in the format "user:{user_id}"
 		cacheKey := fmt.Sprintf("user:%s", res.ID)
-		if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
+		if setErr := s.cache.Set(bgCtx, cacheKey, res, cachepkg.AddJitter(defaultExpirationTTL, cacheExpirationJitter)); setErr != nil {
 			logger.Warn("failed to cache user",
 				zap.String("user_id", res.ID),
 				zap.String("cache_key", cacheKey),
@@ -168,7 +170,7 @@ func (s *Service) LoginUser(ctx context.Context, req *userpb.LoginUserRequest) (
 		// Cache the LoginUser response
 		// The key is in the format "user:{user_id}"
 		cacheKey := fmt.Sprintf("user:%s", res.ID)
-		if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
+		if setErr := s.cache.Set(bgCtx, cacheKey, res, cachepkg.AddJitter(defaultExpirationTTL, cacheExpirationJitter)); setErr != nil {
 			logger.Warn("failed to cache user",
 				zap.String("user_id", res.ID),
 				zap.String("cache_key", cacheKey),
@@ -238,7 +240,7 @@ func (s *Service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (res 
 			bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 			defer cancel()
 
-			if setErr := s.cache.Set(bgCtx, cacheKey, _res, defaultExpirationTTL); setErr != nil {
+			if setErr := s.cache.Set(bgCtx, cacheKey, _res, cachepkg.AddJitter(defaultExpirationTTL, cacheExpirationJitter)); setErr != nil {
 				logger.Warn("failed to cache user",
 					zap.String("user_id", _res.ID),
 					zap.String("cache_key", cacheKey),

--- a/internal/service/users/users_test.go
+++ b/internal/service/users/users_test.go
@@ -157,6 +157,7 @@ func TestLoginUser(t *testing.T) {
 	type want struct {
 		userID string
 		pat    string
+		code   codes.Code
 	}
 
 	// Test cases
@@ -197,6 +198,7 @@ func TestLoginUser(t *testing.T) {
 			want: want{
 				userID: "userID",
 				pat:    "token",
+				code:   codes.OK,
 			},
 			isErr: false,
 		},
@@ -207,7 +209,7 @@ func TestLoginUser(t *testing.T) {
 				Password: "password12345",
 			},
 			mock:  func(_ *userspb.LoginUserRequest) {},
-			want:  want{},
+			want:  want{code: codes.InvalidArgument},
 			isErr: true,
 		},
 		{
@@ -217,7 +219,7 @@ func TestLoginUser(t *testing.T) {
 				Password: "pass",
 			},
 			mock:  func(_ *userspb.LoginUserRequest) {},
-			want:  want{},
+			want:  want{code: codes.InvalidArgument},
 			isErr: true,
 		},
 		{
@@ -227,7 +229,7 @@ func TestLoginUser(t *testing.T) {
 				Password: "password1234567890123456789012345678901234567890123456789012345678901234567890",
 			},
 			mock:  func(_ *userspb.LoginUserRequest) {},
-			want:  want{},
+			want:  want{code: codes.InvalidArgument},
 			isErr: true,
 		},
 		{
@@ -243,7 +245,23 @@ func TestLoginUser(t *testing.T) {
 					req.GetPassword(),
 				).Return(nil, "", status.Errorf(codes.NotFound, "user not found"))
 			},
-			want:  want{},
+			want:  want{code: codes.Unauthenticated},
+			isErr: true,
+		},
+		{
+			name: "error: invalid password",
+			req: &userspb.LoginUserRequest{
+				Email:    "test@gmail.com",
+				Password: "password12345",
+			},
+			mock: func(req *userspb.LoginUserRequest) {
+				repo.EXPECT().LoginUser(
+					gomock.Any(),
+					req.GetEmail(),
+					req.GetPassword(),
+				).Return(nil, "", status.Errorf(codes.InvalidArgument, "invalid password"))
+			},
+			want:  want{code: codes.Unauthenticated},
 			isErr: true,
 		},
 	}
@@ -265,6 +283,9 @@ func TestLoginUser(t *testing.T) {
 			}
 			if pat != tt.want.pat {
 				t.Errorf("LoginUser() pat = %v, want %v", pat, tt.want.pat)
+			}
+			if got := status.Code(err); got != tt.want.code {
+				t.Errorf("LoginUser() code = %v, want %v", got, tt.want.code)
 			}
 		})
 	}

--- a/internal/service/workflows/workflows.go
+++ b/internal/service/workflows/workflows.go
@@ -22,6 +22,7 @@ import (
 	workflowspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/workflows"
 
 	workflowsmodel "github.com/hitesh22rana/chronoverse/internal/model/workflows"
+	cachepkg "github.com/hitesh22rana/chronoverse/internal/pkg/cache"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/kind/container"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/kind/heartbeat"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
@@ -29,8 +30,9 @@ import (
 )
 
 const (
-	defaultExpirationTTL = time.Minute * 30
-	cacheTimeout         = time.Second * 5
+	defaultExpirationTTL  = time.Minute * 30
+	cacheExpirationJitter = defaultExpirationTTL / 10
+	cacheTimeout          = time.Second * 5
 )
 
 // Repository provides job related operations.
@@ -184,7 +186,7 @@ func (s *Service) CreateWorkflow(ctx context.Context, req *workflowspb.CreateWor
 		// The key is in the format "workflow:{user_id}:{job_id}".
 		cacheKey := fmt.Sprintf("workflow:%s:%s", req.GetUserId(), res.ID)
 
-		if setErr := s.cache.Set(bgCtx, cacheKey, res, defaultExpirationTTL); setErr != nil {
+		if setErr := s.cache.Set(bgCtx, cacheKey, res, cachepkg.AddJitter(defaultExpirationTTL, cacheExpirationJitter)); setErr != nil {
 			logger.Warn("failed to cache workflow",
 				zap.String("user_id", req.GetUserId()),
 				zap.String("cache_key", cacheKey),
@@ -407,7 +409,7 @@ func (s *Service) GetWorkflow(ctx context.Context, req *workflowspb.GetWorkflowR
 
 			s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
 
-			if setErr := s.cache.Set(bgCtx, cachedKey, _res, defaultExpirationTTL); setErr != nil {
+			if setErr := s.cache.Set(bgCtx, cachedKey, _res, cachepkg.AddJitter(defaultExpirationTTL, cacheExpirationJitter)); setErr != nil {
 				logger.Warn("failed to cache workflow",
 					zap.String("user_id", req.GetUserId()),
 					zap.String("cache_key", cachedKey),
@@ -780,7 +782,7 @@ func (s *Service) ListWorkflows(ctx context.Context, req *workflowspb.ListWorkfl
 			bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 			defer cancel()
 
-			if setErr := s.cache.Set(bgCtx, cacheKey, _res, defaultExpirationTTL); setErr != nil {
+			if setErr := s.cache.Set(bgCtx, cacheKey, _res, cachepkg.AddJitter(defaultExpirationTTL, cacheExpirationJitter)); setErr != nil {
 				logger.Warn("failed to cache workflows list",
 					zap.String("user_id", req.GetUserId()),
 					zap.String("cache_key", cacheKey),

--- a/static/content/docs/api/authentication.mdx
+++ b/static/content/docs/api/authentication.mdx
@@ -10,6 +10,8 @@ Chronoverse uses browser-oriented session authentication rather than exposing se
 
 `POST /auth/login` validates credentials and issues fresh cookies.
 
+Invalid credentials return the same `401 Unauthorized` response whether or not the email is registered.
+
 ## Validate
 
 `POST /auth/validate` verifies the current session and CSRF state. It is useful for dashboard session bootstrap.

--- a/static/content/openapi.yaml
+++ b/static/content/openapi.yaml
@@ -44,7 +44,8 @@ paths:
             schema: {$ref: '#/components/schemas/AuthRequest'}
       responses:
         '201': {description: Session created}
-        '401': {$ref: '#/components/responses/Unauthorized'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {description: Invalid email or password}
   /auth/logout:
     post:
       operationId: logoutUser


### PR DESCRIPTION
## Summary

- Normalize unknown-user and incorrect-password login failures to the same `401 Unauthorized` response while equalizing bcrypt work.
- Add bounded random jitter to Redis cache TTLs for user, workflow, and job-log cache entries to spread expirations.
- Document the generic login failure contract in the API specification and authentication guide.