### PR TITLE
docs: surface runtime agent architecture

### DIFF
--- a/static/content/docs/deployment/overview.mdx
+++ b/static/content/docs/deployment/overview.mdx
@@ -16,7 +16,7 @@ Chronoverse ships Docker Compose topologies and Kubernetes Kustomize overlays.
 
 <Steps>
   <Step title="Bootstrap trust">Generate the local CA, service certificates, client certificates, Kafka stores, and Ed25519 keys.</Step>
-  <Step title="Start infrastructure">Bring PostgreSQL, ClickHouse, Redis, Meilisearch, Kafka, LGTM, and the Docker proxy to healthy state.</Step>
+  <Step title="Start infrastructure">Bring PostgreSQL, ClickHouse, Redis, Meilisearch, Kafka, LGTM, Docker proxy, and runtime-agent to healthy state.</Step>
   <Step title="Prepare schemas">Create Kafka topics and run PostgreSQL, ClickHouse, and Meilisearch migrations.</Step>
   <Step title="Start application">Bring up gRPC services, workers, the HTTP server, dashboard, and production Nginx.</Step>
 </Steps>

--- a/static/content/docs/engineering/event-flows.mdx
+++ b/static/content/docs/engineering/event-flows.mdx
@@ -15,7 +15,7 @@ The scheduling worker scans due workflows, validates generation and build state,
 
 ## Job execution
 
-The execution worker consumes the job event, claims a lease, ensures the resolved image on the assigned runtime, starts the container through the Docker proxy, attaches its container ID, renews ownership, and publishes output. Terminal state changes require the lease token.
+The execution worker consumes the job event, claims a lease, receives the runtime endpoint registered by `runtime-agent`, ensures the resolved image on that runtime, starts the container through the Docker proxy, attaches its container ID, renews ownership, and publishes output. Terminal state changes require the lease token.
 
 ## Logs and analytics
 

--- a/static/content/docs/features/workflow-types.mdx
+++ b/static/content/docs/features/workflow-types.mdx
@@ -8,7 +8,7 @@ Use heartbeat workflows for endpoint availability and infrastructure checks wher
 
 ## Container
 
-`CONTAINER` workflows describe a Docker image and command in the payload. The workflow worker prepares execution metadata and the execution worker runs the workload through the Docker socket proxy.
+`CONTAINER` workflows describe a Docker image and command in the payload. The workflow worker resolves execution metadata, `jobs-service` assigns a fresh runtime node during claim, and the execution worker runs the workload through the runtime endpoint registered by `runtime-agent`.
 
 Container workflows can retain stdout and stderr, stream output while running, and participate in text search and raw downloads after completion.
 
@@ -19,4 +19,3 @@ Both kinds support interval scheduling, manual runs, failure thresholds, termina
 ## Choosing a kind
 
 Prefer heartbeat when the result is a health signal. Prefer container when the workload needs an image, command, environment, or output capture.
-

--- a/static/content/docs/internal/data-stores.mdx
+++ b/static/content/docs/internal/data-stores.mdx
@@ -20,11 +20,9 @@ Indexes retained log messages for text search and highlights. ClickHouse remains
 
 Carries durable asynchronous events. It is a transport log, not the only record of command completion or job ownership.
 
-## Docker proxy
+## Runtime registry and Docker proxy
 
-Exposes a narrow subset of Docker APIs to workers instead of mounting the daemon socket directly into every process.
-
-## Runtime nodes
+`runtime-agent` registers Docker-capable nodes in PostgreSQL and heartbeats Docker endpoint health, capacity, and status. The Docker proxy exposes a narrow subset of Docker APIs to workers instead of mounting the daemon socket directly into every process.
 
 `runtime-agent` owns rows in `runtime_nodes`. Jobs store `runtime_node_id` and an endpoint snapshot while they are running so execution, logs, termination, deletion, and expired-lease recovery use the Docker daemon that owns the container.
 

--- a/static/src/app/globals.css
+++ b/static/src/app/globals.css
@@ -145,7 +145,7 @@ svg { flex: none; }
 
 .engineering-section { border-block: 1px solid var(--border); background: color-mix(in oklab, var(--card) 52%, transparent); }
 .architecture-map { container: architecture-map / inline-size; max-width: 100%; margin: 0 0 6rem; padding: 1.25rem; border: 1px solid var(--border); border-radius: 1rem; background: var(--background); overflow: hidden; }
-.architecture-flow { min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1.15fr) auto minmax(0, 1.15fr) auto minmax(0, 1.15fr); align-items: center; gap: 1rem; }
+.architecture-flow { min-width: 0; display: grid; grid-template-columns: minmax(0, .95fr) auto minmax(0, 1.08fr) auto minmax(0, 1.08fr) auto minmax(0, 1.08fr) auto minmax(0, 1.08fr); align-items: center; gap: .85rem; }
 .architecture-lane, .architecture-column { min-height: 190px; display: flex; flex-direction: column; justify-content: center; gap: 1rem; border: 1px solid var(--border); border-radius: .75rem; padding: 1rem; background: var(--card); }
 .architecture-lane, .architecture-column, .architecture-entry > div { min-width: 0; }
 .architecture-entry { flex-direction: row; align-items: center; }

--- a/static/src/app/page.tsx
+++ b/static/src/app/page.tsx
@@ -32,7 +32,7 @@ import { REPOSITORY_URL, withBasePath } from "@/lib/site";
 const capabilities = [
   { icon: Workflow, title: "Scheduled workflows", text: "Run interval-based workloads with generation guards and asynchronous build preparation." },
   { icon: TimerReset, title: "Manual runs", text: "Dispatch immediate jobs through the same replay-safe lifecycle as automatic scheduling." },
-  { icon: Container, title: "Container execution", text: "Execute Docker-backed commands through a constrained socket proxy and durable job ownership." },
+  { icon: Container, title: "Container execution", text: "Execute Docker-backed commands through runtime ownership, node health, and constrained socket proxies." },
   { icon: Activity, title: "Heartbeat checks", text: "Model lightweight service checks separately from log-producing container workloads." },
   { icon: ScrollText, title: "Live logs", text: "Stream running stdout and stderr to the dashboard over Server-Sent Events." },
   { icon: FileSearch, title: "Retained search", text: "Store logs in ClickHouse, search with Meilisearch, and download safely filtered output." },
@@ -53,7 +53,7 @@ const timeline = [
   ["01", "Command", "The gateway validates session, CSRF state, input, and idempotency."],
   ["02", "Commit", "The domain service writes state and an outbox event atomically."],
   ["03", "Dispatch", "The relay publishes to Kafka and partition workers take ownership."],
-  ["04", "Execute", "A worker claims a lease, runs the container, and renews ownership."],
+  ["04", "Execute", "An execution worker claims a lease, receives a runtime endpoint, runs the container, and renews ownership."],
   ["05", "Observe", "Logs, notifications, analytics, traces, and terminal state converge."],
 ];
 
@@ -84,9 +84,9 @@ export default function Home() {
 
       <section className="signal-strip" aria-label="Platform summary">
         <div><strong>5</strong><span>gRPC domains</span></div>
-        <div><strong>7</strong><span>worker roles</span></div>
+        <div><strong>6</strong><span>worker roles</span></div>
         <div><strong>4</strong><span>Kafka topics</span></div>
-        <div><strong>6</strong><span>infrastructure systems</span></div>
+        <div><strong>1+</strong><span>runtime nodes</span></div>
       </section>
 
       <section className="section-shell landing-section" id="product">
@@ -103,7 +103,7 @@ export default function Home() {
 
       <section className="engineering-section" id="engineering">
         <div className="section-shell landing-section">
-          <div className="section-heading section-heading-wide"><Badge variant="secondary">Engineering</Badge><h2>Synchronous ownership. Asynchronous progress.</h2><p>The public API stays responsive through gRPC domain boundaries while Kafka workers absorb delayed, distributed, and failure-prone execution.</p></div>
+          <div className="section-heading section-heading-wide"><Badge variant="secondary">Engineering</Badge><h2>Synchronous ownership. Asynchronous progress.</h2><p>The public API stays responsive through gRPC domain boundaries while Kafka workers route delayed, distributed, and failure-prone execution through runtime-owned Docker nodes.</p></div>
           <ArchitectureMap />
 
           <div className="engineering-split">
@@ -133,7 +133,7 @@ export default function Home() {
           <div className="infra-grid">
             <Card><CardHeader><Database /><CardTitle>PostgreSQL</CardTitle></CardHeader><CardContent><CardDescription>Transactional state, idempotency, outbox rows, leases, retries, and analytics.</CardDescription></CardContent></Card>
             <Card><CardHeader><Boxes /><CardTitle>ClickHouse + Meilisearch</CardTitle></CardHeader><CardContent><CardDescription>Ordered retained output with low-latency text search and safe highlights.</CardDescription></CardContent></Card>
-            <Card><CardHeader><KeyRound /><CardTitle>Redis</CardTitle></CardHeader><CardContent><CardDescription>Sessions, cached reads, live log delivery, and shared-host image-pull coordination.</CardDescription></CardContent></Card>
+            <Card><CardHeader><KeyRound /><CardTitle>Redis</CardTitle></CardHeader><CardContent><CardDescription>Sessions, cached reads, live log delivery, and runtime-node-scoped image-pull coordination.</CardDescription></CardContent></Card>
             <Card><CardHeader><ShieldCheck /><CardTitle>TLS + OpenTelemetry</CardTitle></CardHeader><CardContent><CardDescription>mTLS service communication and trace propagation across HTTP, gRPC, and Kafka.</CardDescription></CardContent></Card>
           </div>
         </div>
@@ -143,9 +143,10 @@ export default function Home() {
         <div className="section-heading"><Badge variant="secondary">Operations</Badge><h2>Built to be inspected while it runs.</h2><p>Health checks establish startup order. LGTM receives traces, metrics, and logs. Recovery loops make abandoned work visible and bounded.</p></div>
         <div className="operations-panel">
           <div className="operations-code">
-            <span>$ kubectl -n chronoverse get deploy</span>
+            <span>$ kubectl -n chronoverse get deploy,ds</span>
             <code>outbox-relay       2/2 available</code>
             <code>execution-worker   2/2 available</code>
+            <code>docker-proxy ds    runtime-agent sidecars ready</code>
             <code>joblogs-processor  2/2 available</code>
             <code>server             2/2 available</code>
           </div>

--- a/static/src/components/architecture-map.tsx
+++ b/static/src/components/architecture-map.tsx
@@ -1,8 +1,9 @@
-import { ArrowRight, Database, RadioTower, Server, Workflow } from "lucide-react";
+import { ArrowRight, Container, Database, RadioTower, Server, Workflow } from "lucide-react";
 
 const services = ["users", "workflows", "jobs", "notifications", "analytics"];
 const workers = ["scheduler", "workflow", "execution", "job logs", "analytics", "outbox"];
-const stores = ["PostgreSQL", "ClickHouse", "Redis", "Meilisearch", "Docker proxy", "LGTM"];
+const runtime = ["runtime-agent", "Docker proxy", "runtime_nodes"];
+const stores = ["PostgreSQL", "ClickHouse", "Redis", "Kafka", "Meilisearch", "LGTM"];
 
 export function ArchitectureMap() {
   return (
@@ -21,6 +22,11 @@ export function ArchitectureMap() {
         <div className="architecture-column architecture-bus">
           <div className="architecture-label"><RadioTower /> Kafka workers</div>
           <div className="architecture-chips">{workers.map((worker) => <span key={worker}>{worker}</span>)}</div>
+        </div>
+        <ArrowRight className="architecture-arrow" aria-hidden="true" />
+        <div className="architecture-column">
+          <div className="architecture-label"><Container /> Runtime data plane</div>
+          <div className="architecture-chips">{runtime.map((item) => <span key={item}>{item}</span>)}</div>
         </div>
         <ArrowRight className="architecture-arrow" aria-hidden="true" />
         <div className="architecture-column">


### PR DESCRIPTION
## Summary
- add runtime-agent to the static architecture map as part of the runtime data plane
- update landing-page copy for runtime-owned Docker execution and runtime-node-scoped image pulls
- refresh static docs that still described container execution as Docker-proxy-only