### PR TITLE
docs: reconcile repository, development, and Kubernetes guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ For the full event flow and replay-safety model, see the
 - Docker
 - Docker Compose
 - `kubectl` for Kubernetes deployments
+- OpenSSL for Kubernetes bootstrap; Java `keytool` when generating production Kafka TLS material
+- kind when using the repository's `--create-kind` local-cluster workflow
 
 The compose stacks build or pull all runtime services. Local Go, Node.js, Buf,
 and lint tooling are only needed when developing the codebase directly.
@@ -170,12 +172,20 @@ Important API notes:
 
 ```sh
 make tools
+make dependencies
 make generate
+make mockgen
 make test/short
 make test
 make lint
 make build/all
 ```
+
+`make dependencies` regenerates protobuf stubs and runs `go mod tidy`; use
+`make mockgen` after changing an interface with a `//go:generate` directive.
+Kubernetes changes should also pass all four `make k8s/render/*` and
+`make k8s/dry-run/*` targets plus both setup-script dry runs documented in the
+[Kubernetes guide](https://hitesh22rana.github.io/chronoverse/docs/deployment/kubernetes/#validation).
 
 Dashboard commands live in `dashboard/`:
 
@@ -185,6 +195,9 @@ npm run dev:port
 npm run build
 npm run lint
 ```
+
+Static-site commands live in `static/`; `npm run check` validates MDX and
+OpenAPI, lints, type-checks, and performs the static export.
 
 More operational commands and troubleshooting notes are in the
 [operations guide](https://hitesh22rana.github.io/chronoverse/docs/operations/monitoring/).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,20 +9,22 @@ log delivery, notifications, analytics, and replay-safe event publication.
 
 ### Entry Points
 
-- `dashboard` is the Next.js UI. In development it is exposed on host port
-  `3001`; in production it sits behind Nginx on port `80`.
+- `dashboard` is the Next.js UI. Compose development exposes it on host port
+  `3001`; Compose production puts it behind Nginx on port `80`.
 - `server` is the public HTTP API. In development it is exposed on host port
   `8080`; in production it is only reachable inside the compose network and is
   proxied by Nginx under `/api/`.
-- `nginx` exists in production only. It proxies dashboard traffic to
+- In Compose, `nginx` exists in production only. It proxies dashboard traffic to
   `dashboard:3000`, rewrites `/api/...` to `server:8080`, and disables buffering
   for job log SSE routes.
 
 In Kubernetes, `infra/k8s` provides Kustomize overlays. The local overlay
 deploys the same entry points inside a single namespace. The production overlay
 deploys the application, workers, Nginx, Docker proxy, Kafka topic initializer,
-and migration job while expecting stateful infrastructure to be managed outside
-the overlay.
+migration job, PostgreSQL, Redis, Kafka, ClickHouse, Meilisearch, LGTM, dynamic
+PVCs, and HorizontalPodAutoscalers. It is a self-hosted topology; operators own
+the StorageClass, Secret lifecycle, ingress hostnames, runtime-node preparation,
+backups, and production sizing.
 
 ### Domain Services
 
@@ -182,9 +184,11 @@ expected operating conditions.
 - Compose generates a local CA, service certificates, client certificates, and
   Ed25519 auth keys through `init-certs`.
 - The Kubernetes local overlay generates development certificates into a local
-  certificate PVC. The production overlay mounts pre-created Kubernetes Secrets
-  for auth keys, CA material, client TLS, service TLS, Kafka stores, and
-  datastore credentials.
+  certificate PVC. Production mounts Kubernetes Secrets for auth keys, CA
+  material, client TLS, service TLS, infrastructure TLS, Kafka stores, and
+  datastore credentials. The setup script preserves complete operator-provided
+  Secrets and can generate a missing fallback set; partial internal TLS trust
+  chains are rejected.
 - PostgreSQL, ClickHouse, Redis, Meilisearch, Kafka, and gRPC services run with
   TLS or mTLS in compose.
 - The HTTP server uses encrypted session cookies, CSRF cookies, and service JWT

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,6 +89,11 @@ before exposing the HTTP entrypoint.
 
 ## Core Environment Groups
 
+Every Go process accepts `ENV`; its code default is `development`. Compose and
+Kubernetes set it explicitly for the selected topology. Treat it as a runtime
+mode label rather than a substitute for configuring credentials, TLS, public
+origins, or storage.
+
 ### Server
 
 The public HTTP server reads:
@@ -232,6 +237,12 @@ The jobs service also needs workflows-service client settings so log endpoints
 can enforce workflow retention policy. Runtime heartbeat settings control which
 `runtime_nodes` are fresh enough for new container claims and when an expired
 lease should be treated as owned by an unavailable runtime.
+
+### Notifications Service
+
+- `NOTIFICATIONS_SERVICE_CONFIG_FETCH_LIMIT`
+
+This caps the fetch size used by the notification list operation.
 
 ### Runtime Agent
 
@@ -382,14 +393,20 @@ production environments should manage:
 - Database passwords and `MEILISEARCH_MASTER_KEY`.
 - Public hostnames, allowed origins, and same-site cookie policy.
 
-Kubernetes production deployments should create these Secrets before applying
-the production overlay:
+Kubernetes production deployments may pre-create these Secrets to own their
+credentials and trust material. `scripts/k8s/setup.sh` preserves complete
+operator-provided Secrets and generates missing bootstrap material; it rejects
+partial Secrets and partial internal TLS trust chains:
 
 - `postgres-secret`: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`
 - `clickhouse-secret`: `CLICKHOUSE_PASSWORD`
-- `meilisearch-secret`: `MEILISEARCH_MASTER_KEY`
+- `meilisearch-secret`: `MEILISEARCH_MASTER_KEY`, `MEILI_MASTER_KEY`
+- `kafka-tls-secret`: Kafka keystore, truststore, and key passwords
+- `chronoverse-server-security`: `CRYPTO_SECRET`, `SERVER_CSRF_HMAC_SECRET`
 - `chronoverse-auth`: `auth.ed`, `auth.ed.pub`
 - `chronoverse-ca`: `ca.crt`
+- `chronoverse-ingress-tls`: `tls.crt`, `tls.key`
 - `chronoverse-client-tls`: `tls.crt`, `tls.key`
 - `chronoverse-service-tls`: per-service gRPC certificate and key files
+- `chronoverse-infra-tls`: PostgreSQL, Redis, ClickHouse, Kafka, and Meilisearch certificate/key pairs
 - `chronoverse-kafka-tls`: Kafka keystore, truststore, and credential files

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -153,7 +153,9 @@ Repository commands:
 
 ```sh
 make tools
+make dependencies
 make generate
+make mockgen
 make test/short
 make test
 make lint
@@ -164,6 +166,9 @@ make build/all
 Important notes:
 
 - `make generate` requires `buf`.
+- `make dependencies` regenerates protobuf stubs and runs `go mod tidy -v`.
+- `make mockgen` installs the configured tools and runs every `//go:generate`
+  directive.
 - `make tools` installs Go tooling into `./.bin`.
 - `make test` runs Go tests with the race detector.
 - `make build/all` builds all Go services and workers, including `outbox-relay`.
@@ -181,6 +186,18 @@ npm run lint:fix
 
 The dashboard `dev:port` script runs on port `3001`, matching the dev compose
 dashboard port.
+
+Static documentation commands:
+
+```sh
+cd static
+npm ci
+npm run validate:docs
+npm run check
+```
+
+`npm run check` includes documentation validation, lint, type checking, and the
+static Next.js export.
 
 ## Operational Tuning
 
@@ -324,8 +341,9 @@ expected keys.
 - Run `kubectl -n chronoverse get pods,job` and find the first failing pod or
   incomplete Job.
 - Inspect `init-kafka-topics` and `database-migration` before application logs.
-- Confirm production overlay placeholder hosts were patched for real external
-  dependencies.
+- Confirm the production StorageClass, Ingress hostname/TLS certificate,
+  `SERVER_HOST_URL`, `SERVER_FRONTEND_URL`, allowed origins, credentials, and
+  generated or operator-provided Secrets match the target cluster.
 - Confirm Docker-capable nodes expose Docker Engine at `/var/run/docker.sock`
   and have the `chronoverse.io/docker-workloads=true` label.
 - Confirm workers can reach runtime node IPs on TCP `2375`; NetworkPolicy,

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -3,6 +3,19 @@
 Chronoverse Kubernetes support is packaged with Kustomize and an operator-facing
 setup script.
 
+## Prerequisites
+
+- `kubectl` configured for the intended cluster.
+- OpenSSL for generated credentials and certificates.
+- Java `keytool` when production Kafka TLS material must be generated.
+- kind only when using `--create-kind`.
+- A default dynamic StorageClass or `--storage-class <name>` for production.
+- metrics-server or an equivalent `autoscaling/v2` resource-metrics provider
+  before relying on the production HPAs.
+
+Container execution also requires labeled Docker-capable nodes as described
+under [Cluster Prerequisites](#cluster-prerequisites).
+
 ## Setup
 
 Use the setup script as the primary entrypoint:
@@ -27,12 +40,19 @@ The script is interactive by default and also supports repeatable flags:
 ```sh
 scripts/k8s/setup.sh --mode production --dry-run
 scripts/k8s/setup.sh --mode production --storage-class fast-ssd
+scripts/k8s/setup.sh --mode production --context my-cluster
+scripts/k8s/setup.sh --mode production --skip-apply
 scripts/k8s/setup.sh --mode local --create-kind
 ```
 
+`--skip-apply` bootstraps prerequisites without applying manifests. `--context`
+is passed to every kubectl operation. Run `scripts/k8s/setup.sh --help` for the
+authoritative option list.
+
 ## Render and Apply Directly
 
-Direct Kustomize usage remains available after prerequisites are prepared:
+Direct Kustomize usage remains available after required Secrets, certificates,
+node labels, storage, public URLs, and ingress values are prepared:
 
 ```sh
 kubectl kustomize infra/k8s/overlays/local
@@ -152,3 +172,7 @@ make k8s/dry-run/production
 scripts/k8s/setup.sh --mode local --dry-run
 scripts/k8s/setup.sh --mode production --dry-run
 ```
+
+The render targets work offline. The kubectl and setup-script dry runs still use
+API discovery and must point at a reachable cluster. Use a separate validator
+such as `kubeconform` when live-cluster OpenAPI validation is not available.

--- a/static/content/docs/contributing/development.mdx
+++ b/static/content/docs/contributing/development.mdx
@@ -1,13 +1,25 @@
 # Development workflow
 
-## Generate dependencies
+## Install tools and synchronize dependencies
 
 ```bash
 make tools
+make dependencies
+```
+
+`make tools` installs the repository's Go generators and linter into `.bin`; Buf itself must also be installed and available on `PATH`. `make dependencies` runs `make generate` and then `go mod tidy -v`. Generation removes and recreates `pkg/proto`, updates `buf.lock`, and compiles the protobuf contracts. Keep `proto/`, `pkg/proto/go/`, `buf.lock`, `go.mod`, and `go.sum` changes together when applicable.
+
+Run the narrower target when only protobuf output needs verification:
+
+```bash
 make generate
 ```
 
-`make generate` compiles protobuf contracts. Keep source and generated code in the same change.
+After changing a Go interface with a `//go:generate` directive, regenerate mocks:
+
+```bash
+make mockgen
+```
 
 ## Test
 
@@ -27,11 +39,27 @@ cd dashboard && npm run lint && npm run build
 cd ../static && npm run check
 ```
 
+Use `npm ci` in both frontend workspaces when reproducing CI from their committed lockfiles. `npm run check` in `static/` validates the MDX/OpenAPI registry, lints, type-checks, and performs the static Next.js export.
+
+## Kubernetes changes
+
+Render and client-dry-run both overlays after changing `infra/k8s`, `scripts/k8s`, deployment configuration, image arguments, ports, probes, or Secrets:
+
+```bash
+make k8s/render/local
+make k8s/render/production
+make k8s/dry-run/local
+make k8s/dry-run/production
+scripts/k8s/setup.sh --mode local --dry-run
+scripts/k8s/setup.sh --mode production --dry-run
+```
+
+The render targets work offline. The kubectl client dry runs still use API discovery and therefore need a reachable selected cluster; full OpenAPI schema validation likewise needs a live target cluster or a separate validator such as `kubeconform`. The setup-script dry runs additionally exercise prerequisite, existing-Secret inspection, and Secret preparation logic against the selected kubectl context.
+
 ## Documentation changes
 
-Add or edit MDX under `static/content/docs`, update `docs.config.ts`, and update `static/content/openapi.yaml` when the public HTTP contract changes. `npm run validate:docs` rejects unregistered pages, duplicate slugs, missing source references, broken docs links, and invalid OpenAPI.
+Add or edit MDX under `static/content/docs`, update `static/docs.config.ts`, and update `static/content/openapi.yaml` when the public HTTP contract changes. Keep the concise repository references under `docs/`, `README.md`, `infra/k8s/README.md`, and landing-page copy aligned when the same behavior is described there. From `static/`, `npm run validate:docs` rejects unregistered pages, duplicate slugs, missing source references, broken docs links, and invalid OpenAPI.
 
 ## Releases
 
-Git tags matching `v*` trigger service image release jobs after lint, build, and test complete. The static site deploys from `main` through GitHub Pages.
-
+Git tags matching `v*` trigger service image release jobs after lint, build, generated-protobuf verification, and tests complete. The static site validates and deploys from `main` through GitHub Pages.

--- a/static/content/docs/contributing/repository-layout.mdx
+++ b/static/content/docs/contributing/repository-layout.mdx
@@ -2,7 +2,10 @@
 
 | Path | Purpose |
 | --- | --- |
-| `cmd/` | Executable entry points for services, workers, migration, relay, and server |
+| `cmd/` | Executable entry points for five domain services, the HTTP server, workers, processors, runtime agent, relay, and migrations |
+| `internal/app/` | Interfaces between entry points and domain implementations; source for generated mocks |
+| `internal/config/` | Typed environment-variable contracts for every Go process |
+| `internal/model/` | Shared domain models and asynchronous event envelopes |
 | `internal/server/` | Public HTTP gateway and middleware |
 | `internal/service/` | Domain service logic |
 | `internal/repository/` | Persistence and worker implementations |
@@ -12,12 +15,22 @@
 | `dashboard/` | Authenticated product dashboard |
 | `static/` | Public landing page and static MDX documentation |
 | `docs/` | Concise repository-level engineering references |
+| `infra/k8s/` | Kustomize base plus local and production overlays; includes the operator runbook |
+| `scripts/k8s/` | Kubernetes prerequisite, Secret bootstrap, render, validation, and apply workflow |
+| `certs/` | Git-ignored local workspace populated and mounted by Compose certificate/bootstrap jobs |
+| `compose.dev.yaml` | Locally built, debug-friendly full-stack topology |
+| `compose.prod.yaml` | Published-image topology with Nginx, resource limits, and replicated workers |
+| `Makefile` and `tools.go` | Generation, test, lint, build, run, and Kubernetes validation entry points |
+| `.github/` | CI, release-image, and GitHub Pages deployment automation |
 
 ## Ownership pattern
 
 Entry points compose configuration, infrastructure, repositories, and services. Business state transitions remain in domain layers; reusable transport and storage behavior belongs under `internal/pkg` only when it is truly cross-domain.
 
+Deployment ownership follows the same separation. `infra/k8s/base` owns shared application resources. `infra/k8s/overlays/local` and `infra/k8s/overlays/production` own strategy-specific infrastructure, storage, replica, and patch choices. `scripts/k8s/setup.sh` owns prerequisite and Secret bootstrap before Kustomize apply. Compose remains a separate supported topology rather than generated Kubernetes input.
+
 ## Generated files
 
-Do not edit generated protobuf Go files by hand. Change `proto/*.proto` and run the generation target.
+Do not edit generated protobuf Go files by hand. Change the source files below `proto/` and run `make generate`; commit changes under `pkg/proto/go/` and `buf.lock` with the contract change.
 
+Mocks below `internal/**/mock/` come from `//go:generate` directives. After changing an interface, run `make mockgen` and commit the resulting mock changes. Build artifacts under `.bin/`, `dashboard/.next/`, `static/.next/`, and `static/out/` are local output and are not source documentation.

--- a/static/content/docs/deployment/configuration.mdx
+++ b/static/content/docs/deployment/configuration.mdx
@@ -4,6 +4,8 @@ Configuration is environment-variable driven. The Compose files provide runnable
 
 Kubernetes manifests keep the same environment-variable contract. Kustomize overlays merge the ConfigMaps and Secrets that provide those values.
 
+All Go processes accept `ENV` as the runtime mode label. It defaults to `development`, but credentials, TLS, origins, storage, and public URLs still require their own explicit production values.
+
 ## HTTP server
 
 Host and timeouts use `SERVER_HOST`, `SERVER_PORT`, request/read/header/idle timeout values, request body limit, session and CSRF expiry, host URL, allowed origins, same-site mode, `SERVER_CSRF_HMAC_SECRET`, and `CRYPTO_SECRET`.
@@ -23,6 +25,8 @@ Servers use `GRPC_HOST`, `GRPC_PORT`, request timeout, and `GRPC_TLS_*`. Clients
 ## Workers
 
 Scheduler settings control poll interval, context timeout, and batch size. Jobs service settings include runtime heartbeat windows for claim and recovery. Runtime agent settings control runtime identity, Docker endpoint, heartbeat interval, and max concurrency; `RUNTIME_AGENT_ID` must remain stable for the same runtime node across restarts. Workflow worker settings control digest resolution and image-pull locks. Execution worker settings control concurrency, runtime-local image-pull locks, per-workload Docker container memory/CPU/PID limits, leases, retries, recovery, and log publication. Processor settings control batching and cleanup. Outbox settings control enabled topic groups, claims, retries, cleanup, and retention.
+
+Domain-service-specific limits include workflow and job list fetch limits, workflow cleanup settings, and `NOTIFICATIONS_SERVICE_CONFIG_FETCH_LIMIT` for notification listing.
 
 ## Detailed source
 

--- a/static/content/docs/deployment/kubernetes.mdx
+++ b/static/content/docs/deployment/kubernetes.mdx
@@ -15,9 +15,21 @@ scripts/k8s/setup.sh --mode production
 
 The script keeps complete operator-provided Secrets and generates only missing bootstrap material. Partial Secrets fail with a clear missing-key error.
 
+Useful non-interactive options include:
+
+```bash
+scripts/k8s/setup.sh --mode local --create-kind
+scripts/k8s/setup.sh --mode production --context <context> --storage-class <name>
+scripts/k8s/setup.sh --mode production --skip-apply
+```
+
+`--skip-apply` prepares prerequisites without applying the overlay. `--context` keeps every kubectl operation on the named context. Run `scripts/k8s/setup.sh --help` for the current option list.
+
 ## Cluster prerequisites
 
 Kubernetes does not include a generic `kubectl` command to create a cluster. Create the cluster with your lifecycle tool, such as kind, minikube, kubeadm, or managed Kubernetes provisioning.
+
+The setup workflow requires `kubectl` and OpenSSL. Production Secret generation also requires Java `keytool`; `--create-kind` additionally requires kind. The production overlay needs a default dynamic StorageClass or an explicit `--storage-class`, and its HPAs need metrics-server or an equivalent `autoscaling/v2` resource-metrics provider.
 
 Container workflows require Docker-capable runtime nodes. Label every node that should own Docker containers:
 
@@ -72,7 +84,14 @@ scripts/k8s/setup.sh --mode local --dry-run
 scripts/k8s/setup.sh --mode production --dry-run
 ```
 
-Schema validation with OpenAPI requires a live cluster or an external validator such as `kubeconform`.
+The render targets work offline. Both `kubectl apply --dry-run=client` and the setup-script dry runs still use API discovery and therefore require a reachable selected cluster. Full OpenAPI schema validation requires that live cluster or an external validator such as `kubeconform`.
+
+Direct Kustomize apply remains available after required Secrets, certificates, node labels, storage, public URLs, and ingress values have been prepared:
+
+```bash
+kubectl apply -k infra/k8s/overlays/local
+kubectl apply -k infra/k8s/overlays/production
+```
 
 ## Local production smoke access
 

--- a/static/content/docs/installation.mdx
+++ b/static/content/docs/installation.mdx
@@ -4,22 +4,25 @@ Docker Compose is the quickest way to run the full platform. Kubernetes deployme
 
 ## Runtime installation
 
-Clone the repository and use either `compose.dev.yaml`, `compose.prod.yaml`, or a Kubernetes overlay. The development Compose profile builds local images and exposes debugging ports. The production Compose profile uses GHCR images, internal networking, resource constraints, worker replicas, and Nginx as the public entry point.
+Clone the repository and use either `compose.dev.yaml`, `compose.prod.yaml`, or the Kubernetes setup workflow. The development Compose profile builds local images and exposes debugging ports. The production Compose profile uses GHCR images, internal networking, resource constraints, worker replicas, and Nginx as the public entry point.
 
 ```bash
-kubectl apply -k infra/k8s/overlays/local
+scripts/k8s/setup.sh --mode local --create-kind
 ```
+
+The setup script prepares required Secrets and certificates before applying the local Kustomize overlay. Direct `kubectl apply -k` is supported only after those prerequisites exist; see [Kubernetes deployment](/docs/deployment/kubernetes).
 
 ## Development toolchain
 
 - Go `1.25.4`
-- Node.js compatible with Next.js 16
+- Node.js 24 for the static-site CI path; the dashboard container builds with Node.js 25
 - Buf for protobuf generation
 - Docker for integration tests and container execution tests
 
 ```bash
 make tools
-make generate
+make dependencies
+make mockgen # after changing generated-mock interfaces
 make test/short
 make lint
 make build/all
@@ -30,8 +33,8 @@ make build/all
 The application dashboard and public static site are separate Next.js applications:
 
 ```bash
-cd dashboard && npm install
-cd ../static && npm install
+cd dashboard && npm ci
+cd ../static && npm ci
 ```
 
 The static site exports plain HTML into `static/out` and is deployed to GitHub Pages.

--- a/static/docs.config.ts
+++ b/static/docs.config.ts
@@ -100,8 +100,8 @@ export const docsConfig: DocGroup[] = [
   {
     title: "Contributing",
     pages: [
-      { slug: "contributing/repository-layout", title: "Repository layout", description: "Where services, workers, contracts, and frontends live.", source: "contributing/repository-layout", sourceRefs: ["README.md"] },
-      { slug: "contributing/development", title: "Development workflow", description: "Generate, lint, test, build, and release changes.", source: "contributing/development", sourceRefs: ["Makefile", ".github/workflows/ci.yaml"] },
+      { slug: "contributing/repository-layout", title: "Repository layout", description: "Where runtime, deployment, contracts, frontends, and documentation live.", source: "contributing/repository-layout", sourceRefs: ["README.md", "Makefile", "infra/k8s", "scripts/k8s"] },
+      { slug: "contributing/development", title: "Development workflow", description: "Generate, lint, test, build, validate deployment, and release changes.", source: "contributing/development", sourceRefs: ["Makefile", ".github/workflows/ci.yaml", ".github/workflows/deploy-static.yml", "static/package.json"] },
     ],
   },
 ];

--- a/static/src/app/page.tsx
+++ b/static/src/app/page.tsx
@@ -27,7 +27,9 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { getOpenApiOperations } from "@/lib/openapi";
 import { REPOSITORY_URL, withBasePath } from "@/lib/site";
+import { docPages } from "../../docs.config";
 
 const capabilities = [
   { icon: Workflow, title: "Scheduled workflows", text: "Run interval-based workloads with generation guards and asynchronous build preparation." },
@@ -58,6 +60,8 @@ const timeline = [
 ];
 
 export default function Home() {
+  const operationCount = getOpenApiOperations().length;
+
   return (
     <main>
       <section className="hero section-shell">
@@ -69,7 +73,7 @@ export default function Home() {
             <Button asChild size="lg"><Link href="/docs/quickstart">Read the docs<ArrowRight data-icon="inline-end" /></Link></Button>
             <Button asChild size="lg" variant="outline"><a href={REPOSITORY_URL} target="_blank" rel="noreferrer"><GitHubMark data-icon="inline-start" />View source</a></Button>
           </div>
-          <div className="hero-command"><Terminal /><code>kubectl apply -k infra/k8s/overlays/local</code></div>
+          <div className="hero-command"><Terminal /><code>scripts/k8s/setup.sh --mode local --create-kind</code></div>
         </div>
         <div className="hero-visual" aria-label="Chronoverse engineering status panel">
           <Image src={withBasePath("/assets/chronoverse.png")} alt="Chronoverse astronaut with an hourglass visor" width={1536} height={1024} priority />
@@ -161,7 +165,7 @@ export default function Home() {
       <section className="section-shell docs-cta">
         <div>
           <Braces />
-          <span>46 authored guides · 23 generated API operations · static HTML</span>
+          <span>{docPages.length} authored guides · {operationCount} generated API operations · static HTML</span>
         </div>
         <h2>The engineering reference lives with the code.</h2>
         <p>MDX content, OpenAPI contracts, navigation, validation, and search are built in this repository and deployed with the landing page.</p>


### PR DESCRIPTION
## Summary

- reconcile `README.md`, repository-local guides, and the static MDX site with the current runtime and deployment implementation
- expand repository ownership documentation for `infra/k8s`, `scripts/k8s`, configuration/models, Compose, generated protobufs, mocks, and CI
- document the actual dependency, generation, frontend, and Kubernetes validation workflows
- correct the production Kubernetes topology, prerequisite, storage, Secret, runtime-node, and dry-run guidance
- make landing-page guide and generated API-operation counts derive from their source inventories
- complete the documented Go environment-variable and Kubernetes Secret inventories