### PR TITLE
feat(dashboard): add shareable job log line selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ analytics into one self-hosted stack.
 - **Replay-safe execution**: idempotency keys, workflow generations, deterministic event keys, transactional outbox delivery, durable job leases, Redis-coordinated Docker image pulls, worker retries, and stale-event guards.
 - **Runtime-aware Docker execution**: `runtime-agent` registers each Docker-capable node, `jobs-service` assigns runtime ownership during claim, and workers talk directly to the selected Docker endpoint for execution, logs, and cleanup.
 - **Job execution lifecycle**: queued, running, completed, failed, and canceled jobs with automatic retry handling for system failures.
-- **Retained job logs**: ClickHouse-backed logs, Meilisearch-backed search, raw log download, stream filtering, and Server-Sent Events for live output.
+- **Retained job logs**: ClickHouse-backed logs, Meilisearch-backed search, raw log download, stream filtering, shareable line selections, and Server-Sent Events for live output.
 - **Retention controls**: per-workflow log retention with explicit behavior for non-log-producing or retention-disabled workflows.
 - **Notifications and analytics**: user notifications, workflow/job analytics, retained log counts, and execution duration summaries.
 - **Security by default in compose**: generated certificates, TLS/mTLS across infrastructure and gRPC services, CSRF-protected session cookies, and Ed25519 JWTs for service authorization.

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -58,7 +58,8 @@
         "eslint-config-next": "16.0.4",
         "globals": "^16.5.0",
         "tailwindcss": "^4.1.17",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -363,32 +364,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.6.0.tgz",
-      "integrity": "sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1350,6 +1329,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -2557,10 +2546,300 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2907,15 +3186,33 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
-      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.7",
@@ -2951,6 +3248,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3535,6 +3833,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3781,6 +4192,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4000,6 +4421,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4421,6 +4852,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4941,6 +5379,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4956,6 +5404,16 @@
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
       "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5123,6 +5581,21 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6490,9 +6963,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -6750,6 +7223,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6858,6 +7345,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6888,9 +7382,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6907,7 +7401,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7188,6 +7682,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/run-parallel": {
@@ -7479,6 +8007,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -7502,6 +8037,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7735,15 +8284,32 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7771,9 +8337,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7782,6 +8348,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8135,6 +8711,461 @@
         "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8238,6 +9269,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "start:port": "next start --port 3001",
+    "test": "vitest run",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix"
   },
@@ -62,6 +63,7 @@
     "eslint-config-next": "16.0.4",
     "globals": "^16.5.0",
     "tailwindcss": "^4.1.17",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -61,6 +61,7 @@ import type { DownloadLogsFormat } from "@/hooks/use-job-logs"
 
 import { cn, jsonRegex } from "@/lib/utils"
 import {
+    buildLogViewerUrl,
     formatLogLineSelection,
     getSelectedLogText,
     isLogLineSelected,
@@ -239,6 +240,7 @@ export function LogsViewer({
     const [downloadPopoverOpen, setDownloadPopoverOpen] = useState(false)
     const [isSearchFocused, setIsSearchFocused] = useState(false)
     const searchInputRef = useRef<HTMLInputElement>(null)
+    const pendingSearchQueryRef = useRef<string | null>(null)
     const virtuosoRef = useRef<VirtuosoHandle>(null)
     const deepLinkFetchInFlightRef = useRef(false)
     const lastScrolledSelectionRef = useRef("")
@@ -287,7 +289,7 @@ export function LogsViewer({
 
         const query = params.toString()
         const hash = window.location.hash
-        router.replace(`${pathname}${query ? `?${query}` : ""}${hash}`, { scroll: false })
+        router.replace(buildLogViewerUrl(pathname, query, hash), { scroll: false })
     }, [pathname, router, searchParams])
 
     const updateLineSelection = useCallback((selection: LogLineSelection) => {
@@ -351,6 +353,14 @@ export function LogsViewer({
     }, [jobId])
 
     useEffect(() => {
+        const pendingSearchQuery = pendingSearchQueryRef.current
+        if (pendingSearchQuery !== null) {
+            if (searchQuery === pendingSearchQuery) {
+                pendingSearchQueryRef.current = null
+            }
+            return
+        }
+
         setSearchInput(searchQuery)
     }, [searchQuery])
 
@@ -445,6 +455,7 @@ export function LogsViewer({
     useEffect(() => {
         const timer = setTimeout(() => {
             if (searchInput !== searchQuery) {
+                pendingSearchQueryRef.current = searchInput
                 startSearchTransition(() => {
                     updateSearchQuery(searchInput)
                 })
@@ -560,7 +571,7 @@ export function LogsViewer({
                                         onSelect={() => void copyLogLines(actionSelection)}
                                     >
                                         <Copy />
-                                        Copy line
+                                        {actionSelection.start === actionSelection.end ? "Copy line" : "Copy lines"}
                                     </DropdownMenuItem>
                                     <DropdownMenuItem
                                         disabled={!canCopyPermalink}

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -306,6 +306,20 @@ export function LogsViewer({
         window.history.replaceState(window.history.state, "", url)
     }, [])
 
+    const clearLineSelection = useCallback(() => {
+        if (!lineSelection && !window.location.hash) {
+            return
+        }
+
+        setLineSelection(null)
+        setSelectionAnchor(null)
+        setIsSelectionUnavailable(false)
+
+        const url = new URL(window.location.href)
+        url.hash = ""
+        window.history.replaceState(window.history.state, "", url)
+    }, [lineSelection])
+
     const handleLineClick = useCallback((
         lineNumber: number,
         event: ReactMouseEvent<HTMLAnchorElement>
@@ -633,7 +647,10 @@ export function LogsViewer({
                             ref={searchInputRef}
                             placeholder="Search logs... (Ctrl+F)"
                             value={searchInput}
-                            onChange={(e) => setSearchInput(e.target.value)}
+                            onChange={(e) => {
+                                setSearchInput(e.target.value)
+                                clearLineSelection()
+                            }}
                             onFocus={() => setIsSearchFocused(true)}
                             onBlur={() => setIsSearchFocused(false)}
                             className="pl-10 pr-8 w-full"
@@ -660,6 +677,7 @@ export function LogsViewer({
                                             setStream(value)
                                             setPopoverOpen(false)
                                             if (value !== (streamFilter || "all")) {
+                                                clearLineSelection()
                                                 startSearchTransition(() => {
                                                     applyStreamFilter(value === "all" ? "" : value)
                                                 })

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -369,6 +369,11 @@ export function LogsViewer({
             return
         }
 
+        if (event.shiftKey && event.button === 0) {
+            event.preventDefault()
+            window.getSelection()?.removeAllRanges()
+        }
+
         rowPointerGestureRef.current = {
             startX: event.clientX,
             startY: event.clientY,

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -64,6 +64,7 @@ import {
     buildLogViewerUrl,
     formatLogLineSelection,
     getSelectedLogText,
+    getUnavailableSelectionMessage,
     isLogLineSelected,
     normalizeLogLineSelection,
     parseLogLineSelection,
@@ -462,7 +463,7 @@ export function LogsViewer({
         }
 
         lastUnavailableSelectionRef.current = selectionKey
-        toast.warning(`Log line ${lineSelection.end} is unavailable`)
+        toast.warning(getUnavailableSelectionMessage(lineSelection))
     }, [isSelectionUnavailable, lineSelection, selectionKey])
 
     // Debounced search update

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -7,18 +7,22 @@ import {
     useState,
     useTransition,
 } from "react"
+import type { MouseEvent as ReactMouseEvent } from "react"
 import {
     usePathname,
     useRouter,
     useSearchParams,
 } from "next/navigation"
 import {
+    Copy,
     Download,
     Filter,
     Loader2,
     Search,
 } from "lucide-react"
+import { toast } from "sonner"
 import { Virtuoso } from "react-virtuoso"
+import type { VirtuosoHandle } from "react-virtuoso"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -37,11 +41,24 @@ import {
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip"
 
 import { useJobLogs } from "@/hooks/use-job-logs"
 import type { DownloadLogsFormat } from "@/hooks/use-job-logs"
 
 import { cn, jsonRegex } from "@/lib/utils"
+import {
+    formatLogLineSelection,
+    isLogLineSelected,
+    normalizeLogLineSelection,
+    parseLogLineSelection,
+    shouldFetchMoreLogsForSelection,
+} from "@/lib/log-line-selection"
+import type { LogLineSelection } from "@/lib/log-line-selection"
 
 interface LogViewerProps {
     workflowId: string
@@ -75,6 +92,7 @@ const highlightTokenPattern = /^[a-f0-9]{32}$/
 const highlightStartPrefix = "__CV_HL_START_"
 const highlightEndPrefix = "__CV_HL_END_"
 const highlightSuffix = "__"
+const shareableJobStatuses = new Set(["COMPLETED", "FAILED", "CANCELED"])
 
 const escapeHtml = (value: string) => {
     return value.replace(/[&<>"']/g, (char) => {
@@ -211,6 +229,13 @@ export function LogsViewer({
     const [downloadPopoverOpen, setDownloadPopoverOpen] = useState(false)
     const [isSearchFocused, setIsSearchFocused] = useState(false)
     const searchInputRef = useRef<HTMLInputElement>(null)
+    const virtuosoRef = useRef<VirtuosoHandle>(null)
+    const deepLinkFetchInFlightRef = useRef(false)
+    const lastScrolledSelectionRef = useRef("")
+    const lastUnavailableSelectionRef = useRef("")
+    const [lineSelection, setLineSelection] = useState<LogLineSelection | null>(null)
+    const [selectionAnchor, setSelectionAnchor] = useState<number | null>(null)
+    const [isSelectionUnavailable, setIsSelectionUnavailable] = useState(false)
 
     const {
         logs,
@@ -237,6 +262,25 @@ export function LogsViewer({
     const [downloadFormat, setDownloadFormat] = useState<DownloadLogsFormat>("txt")
     const disableLogInteractions = isRetentionDisabled || isLogsUnsupportedForKind
     const parseJson = searchParams.get("json") === "true"
+    const datasetKey = `${pathname}?${searchParams.toString()}`
+    const selectionFragment = lineSelection ? formatLogLineSelection(lineSelection) : ""
+    const selectionKey = `${datasetKey}${selectionFragment}`
+    const canCopySelection = Boolean(
+        lineSelection &&
+        shareableJobStatuses.has(jobStatus) &&
+        !disableLogInteractions &&
+        !isSelectionUnavailable &&
+        logs.length >= lineSelection.end
+    )
+    const copyLinkTooltip = !lineSelection
+        ? "Select a log line first"
+        : jobStatus === "RUNNING"
+            ? "Links can be copied after the job finishes"
+            : isSelectionUnavailable
+                ? "The selected log line is unavailable"
+                : canCopySelection
+                    ? "Copy a link to the selected logs"
+                    : "Log links are unavailable"
 
     const updateJsonRendering = useCallback((enabled: boolean) => {
         const params = new URLSearchParams(searchParams.toString())
@@ -248,12 +292,133 @@ export function LogsViewer({
         }
 
         const query = params.toString()
-        router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+        const hash = window.location.hash
+        router.replace(`${pathname}${query ? `?${query}` : ""}${hash}`, { scroll: false })
     }, [pathname, router, searchParams])
+
+    const updateLineSelection = useCallback((selection: LogLineSelection) => {
+        const normalized = normalizeLogLineSelection(selection.start, selection.end)
+        if (!normalized) {
+            return
+        }
+
+        setLineSelection(normalized)
+        setIsSelectionUnavailable(false)
+
+        const url = new URL(window.location.href)
+        url.hash = formatLogLineSelection(normalized)
+        window.history.replaceState(window.history.state, "", url)
+    }, [])
+
+    const handleLineClick = useCallback((
+        lineNumber: number,
+        event: ReactMouseEvent<HTMLAnchorElement>
+    ) => {
+        event.preventDefault()
+
+        if (event.shiftKey) {
+            const anchor = selectionAnchor ?? lineSelection?.start ?? lineNumber
+            const range = normalizeLogLineSelection(anchor, lineNumber)
+            if (range) {
+                updateLineSelection(range)
+            }
+            return
+        }
+
+        setSelectionAnchor(lineNumber)
+        updateLineSelection({ start: lineNumber, end: lineNumber })
+    }, [lineSelection?.start, selectionAnchor, updateLineSelection])
+
+    const copySelectionLink = useCallback(async () => {
+        try {
+            await navigator.clipboard.writeText(window.location.href)
+            toast.success("Log link copied")
+        } catch {
+            toast.error("Failed to copy log link")
+        }
+    }, [])
 
     useEffect(() => {
         setDownloadFilename(`${jobId}-logs`)
     }, [jobId])
+
+    useEffect(() => {
+        const syncSelectionFromFragment = () => {
+            const selection = parseLogLineSelection(window.location.hash)
+            setLineSelection(selection)
+            setSelectionAnchor(selection?.start ?? null)
+            setIsSelectionUnavailable(false)
+        }
+
+        syncSelectionFromFragment()
+        window.addEventListener("hashchange", syncSelectionFromFragment)
+        window.addEventListener("popstate", syncSelectionFromFragment)
+
+        return () => {
+            window.removeEventListener("hashchange", syncSelectionFromFragment)
+            window.removeEventListener("popstate", syncSelectionFromFragment)
+        }
+    }, [workflowId, jobId])
+
+    useEffect(() => {
+        if (!lineSelection || isLogsLoading || isWorkflowLoading || logsError) {
+            return
+        }
+
+        if (logs.length >= lineSelection.end) {
+            setIsSelectionUnavailable(false)
+
+            if (lastScrolledSelectionRef.current !== selectionKey) {
+                lastScrolledSelectionRef.current = selectionKey
+                requestAnimationFrame(() => {
+                    virtuosoRef.current?.scrollToIndex({
+                        index: lineSelection.start - 1,
+                        align: "start",
+                    })
+                })
+            }
+            return
+        }
+
+        if (shouldFetchMoreLogsForSelection(lineSelection, logs.length, Boolean(hasNextPage))) {
+            if (isFetchingNextPage || deepLinkFetchInFlightRef.current) {
+                return
+            }
+
+            deepLinkFetchInFlightRef.current = true
+            void fetchNextPage().finally(() => {
+                deepLinkFetchInFlightRef.current = false
+            })
+            return
+        }
+
+        if (!isFetchingNextPage && hasNextPage === false) {
+            setIsSelectionUnavailable(true)
+        }
+    }, [
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+        isLogsLoading,
+        isWorkflowLoading,
+        lineSelection,
+        logs.length,
+        logsError,
+        selectionKey,
+    ])
+
+    useEffect(() => {
+        if (!isSelectionUnavailable || !lineSelection) {
+            return
+        }
+
+        if (lastUnavailableSelectionRef.current === selectionKey) {
+            return
+        }
+
+        lastUnavailableSelectionRef.current = selectionKey
+        toast.warning(`Log line ${lineSelection.end} is unavailable`)
+    }, [isSelectionUnavailable, lineSelection, selectionKey])
 
     // Debounced search update
     useEffect(() => {
@@ -319,14 +484,32 @@ export function LogsViewer({
     const LogRow = (index: number) => {
         const log = logs[index]
         if (!log) return null
+        const lineNumber = index + 1
+        const isSelected = isLogLineSelected(lineNumber, lineSelection)
         const formattedMessage = parseLog(log.message, log.highlightToken)
         return (
             <div
+                id={`L${lineNumber}`}
                 className={cn(
                     "flex min-h-6 hover:bg-muted/50 group",
-                    getLogStreamStyles(log.stream)
+                    getLogStreamStyles(log.stream),
+                    { "bg-accent hover:bg-accent": isSelected }
                 )}
+                data-line-number={lineNumber}
+                data-selected={isSelected || undefined}
             >
+                <a
+                    href={`#L${lineNumber}`}
+                    onClick={(event) => handleLineClick(lineNumber, event)}
+                    className={cn(
+                        "flex w-14 shrink-0 items-start justify-end border-r px-2 py-1 text-xs tabular-nums text-muted-foreground select-none",
+                        { "text-foreground": isSelected }
+                    )}
+                    aria-label={`Select log line ${lineNumber}`}
+                    aria-current={isSelected ? "location" : undefined}
+                >
+                    {lineNumber}
+                </a>
                 <span
                     className={cn("my-1 w-1 flex-none rounded-sm", getLogStreamStripStyles(log.stream))}
                     title={log.stream}
@@ -433,6 +616,22 @@ export function LogsViewer({
                                 disabled={(jobStatus === "CANCELED" && logs.length === 0) || (logs.length === 0 && !!completedAt)}
                             />
                         </div>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <span>
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        disabled={!canCopySelection}
+                                        onClick={copySelectionLink}
+                                    >
+                                        <Copy data-icon="inline-start" />
+                                        Copy link
+                                    </Button>
+                                </span>
+                            </TooltipTrigger>
+                            <TooltipContent>{copyLinkTooltip}</TooltipContent>
+                        </Tooltip>
                         <Popover open={downloadPopoverOpen} onOpenChange={setDownloadPopoverOpen}>
                             <PopoverTrigger asChild>
                                 <Button
@@ -527,6 +726,7 @@ export function LogsViewer({
                     </div>
                 ) : logs.length > 0 ? (
                     <Virtuoso
+                        ref={virtuosoRef}
                         totalCount={logs.length}
                         itemContent={LogRow}
                         endReached={handleEndReached}

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -16,7 +16,9 @@ import {
 import {
     Copy,
     Download,
+    Ellipsis,
     Filter,
+    Link,
     Loader2,
     Search,
 } from "lucide-react"
@@ -42,6 +44,13 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
     Tooltip,
     TooltipContent,
     TooltipTrigger,
@@ -53,6 +62,7 @@ import type { DownloadLogsFormat } from "@/hooks/use-job-logs"
 import { cn, jsonRegex } from "@/lib/utils"
 import {
     formatLogLineSelection,
+    getSelectedLogText,
     isLogLineSelected,
     normalizeLogLineSelection,
     parseLogLineSelection,
@@ -262,25 +272,9 @@ export function LogsViewer({
     const [downloadFormat, setDownloadFormat] = useState<DownloadLogsFormat>("txt")
     const disableLogInteractions = isRetentionDisabled || isLogsUnsupportedForKind
     const parseJson = searchParams.get("json") === "true"
-    const datasetKey = `${pathname}?${searchParams.toString()}`
+    const datasetKey = `${pathname}?q=${searchQuery}&stream=${streamFilter}`
     const selectionFragment = lineSelection ? formatLogLineSelection(lineSelection) : ""
     const selectionKey = `${datasetKey}${selectionFragment}`
-    const canCopySelection = Boolean(
-        lineSelection &&
-        shareableJobStatuses.has(jobStatus) &&
-        !disableLogInteractions &&
-        !isSelectionUnavailable &&
-        logs.length >= lineSelection.end
-    )
-    const copyLinkTooltip = !lineSelection
-        ? "Select a log line first"
-        : jobStatus === "RUNNING"
-            ? "Links can be copied after the job finishes"
-            : isSelectionUnavailable
-                ? "The selected log line is unavailable"
-                : canCopySelection
-                    ? "Copy a link to the selected logs"
-                    : "Log links are unavailable"
 
     const updateJsonRendering = useCallback((enabled: boolean) => {
         const params = new URLSearchParams(searchParams.toString())
@@ -329,18 +323,45 @@ export function LogsViewer({
         updateLineSelection({ start: lineNumber, end: lineNumber })
     }, [lineSelection?.start, selectionAnchor, updateLineSelection])
 
-    const copySelectionLink = useCallback(async () => {
+    const copyLogLines = useCallback(async (selection: LogLineSelection) => {
         try {
-            await navigator.clipboard.writeText(window.location.href)
-            toast.success("Log link copied")
+            const text = getSelectedLogText(logs.map((log) => log.message), selection)
+            await navigator.clipboard.writeText(text)
+            toast.success(selection.start === selection.end ? "Log line copied" : "Log lines copied")
         } catch {
-            toast.error("Failed to copy log link")
+            toast.error("Failed to copy log lines")
         }
-    }, [])
+    }, [logs])
+
+    const copyPermalink = useCallback(async (selection: LogLineSelection) => {
+        try {
+            updateLineSelection(selection)
+
+            const url = new URL(window.location.href)
+            url.hash = formatLogLineSelection(selection)
+            await navigator.clipboard.writeText(url.toString())
+            toast.success("Log permalink copied")
+        } catch {
+            toast.error("Failed to copy log permalink")
+        }
+    }, [updateLineSelection])
 
     useEffect(() => {
         setDownloadFilename(`${jobId}-logs`)
     }, [jobId])
+
+    useEffect(() => {
+        setSearchInput(searchQuery)
+    }, [searchQuery])
+
+    useEffect(() => {
+        setStream(streamFilter || "all")
+    }, [streamFilter])
+
+    useEffect(() => {
+        deepLinkFetchInFlightRef.current = false
+        setIsSelectionUnavailable(false)
+    }, [datasetKey])
 
     useEffect(() => {
         const syncSelectionFromFragment = () => {
@@ -486,6 +507,17 @@ export function LogsViewer({
         if (!log) return null
         const lineNumber = index + 1
         const isSelected = isLogLineSelected(lineNumber, lineSelection)
+        const isTopSelectedLine = isSelected && lineSelection?.start === lineNumber
+        const showLineOptions = !isSelected || isTopSelectedLine
+        const actionSelection = isTopSelectedLine && lineSelection
+            ? lineSelection
+            : { start: lineNumber, end: lineNumber }
+        const canCopyLines = actionSelection.end <= logs.length
+        const canCopyPermalink = Boolean(
+            shareableJobStatuses.has(jobStatus) &&
+            !disableLogInteractions &&
+            canCopyLines
+        )
         const formattedMessage = parseLog(log.message, log.highlightToken)
         return (
             <div
@@ -498,11 +530,55 @@ export function LogsViewer({
                 data-line-number={lineNumber}
                 data-selected={isSelected || undefined}
             >
+                <div className="flex w-9 shrink-0 items-center justify-center">
+                    {showLineOptions && (
+                        <DropdownMenu>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <DropdownMenuTrigger asChild>
+                                        <Button
+                                            variant="outline"
+                                            size="icon"
+                                            className={cn(
+                                                "size-7 opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100 focus-visible:opacity-100",
+                                                { "opacity-100": isTopSelectedLine }
+                                            )}
+                                            aria-label={`Line ${lineNumber} options`}
+                                        >
+                                            <Ellipsis />
+                                        </Button>
+                                    </DropdownMenuTrigger>
+                                </TooltipTrigger>
+                                <TooltipContent side="left">
+                                    Line {lineNumber} options
+                                </TooltipContent>
+                            </Tooltip>
+                            <DropdownMenuContent align="start" className="min-w-40">
+                                <DropdownMenuGroup>
+                                    <DropdownMenuItem
+                                        disabled={!canCopyLines}
+                                        onSelect={() => void copyLogLines(actionSelection)}
+                                    >
+                                        <Copy />
+                                        Copy line
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        disabled={!canCopyPermalink}
+                                        onSelect={() => void copyPermalink(actionSelection)}
+                                    >
+                                        <Link />
+                                        Copy permalink
+                                    </DropdownMenuItem>
+                                </DropdownMenuGroup>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    )}
+                </div>
                 <a
                     href={`#L${lineNumber}`}
                     onClick={(event) => handleLineClick(lineNumber, event)}
                     className={cn(
-                        "flex w-14 shrink-0 items-start justify-end border-r px-2 py-1 text-xs tabular-nums text-muted-foreground select-none",
+                        "flex w-11 shrink-0 items-start justify-end border-r px-2 py-1 text-xs tabular-nums text-muted-foreground select-none",
                         { "text-foreground": isSelected }
                     )}
                     aria-label={`Select log line ${lineNumber}`}
@@ -616,22 +692,6 @@ export function LogsViewer({
                                 disabled={(jobStatus === "CANCELED" && logs.length === 0) || (logs.length === 0 && !!completedAt)}
                             />
                         </div>
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <span>
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        disabled={!canCopySelection}
-                                        onClick={copySelectionLink}
-                                    >
-                                        <Copy data-icon="inline-start" />
-                                        Copy link
-                                    </Button>
-                                </span>
-                            </TooltipTrigger>
-                            <TooltipContent>{copyLinkTooltip}</TooltipContent>
-                        </Tooltip>
                         <Popover open={downloadPopoverOpen} onOpenChange={setDownloadPopoverOpen}>
                             <PopoverTrigger asChild>
                                 <Button

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -28,7 +28,7 @@ import {
 } from "lucide-react"
 import { toast } from "sonner"
 import { Virtuoso } from "react-virtuoso"
-import type { VirtuosoHandle } from "react-virtuoso"
+import type { ListRange, VirtuosoHandle } from "react-virtuoso"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -256,6 +256,7 @@ export function LogsViewer({
     const virtuosoRef = useRef<VirtuosoHandle>(null)
     const deepLinkFetchInFlightRef = useRef(false)
     const lastScrolledSelectionRef = useRef("")
+    const pendingScrollSelectionRef = useRef<{ key: string; index: number; correcting: boolean } | null>(null)
     const lastUnavailableSelectionRef = useRef("")
     const [lineSelection, setLineSelection] = useState<LogLineSelection | null>(null)
     const [selectionAnchor, setSelectionAnchor] = useState<number | null>(null)
@@ -445,8 +446,41 @@ export function LogsViewer({
 
     useEffect(() => {
         deepLinkFetchInFlightRef.current = false
+        pendingScrollSelectionRef.current = null
+        lastScrolledSelectionRef.current = ""
         setIsSelectionUnavailable(false)
     }, [datasetKey])
+
+    const handleRenderedRangeChanged = useCallback((range: ListRange) => {
+        const pendingScroll = pendingScrollSelectionRef.current
+        if (!pendingScroll || pendingScroll.correcting || pendingScroll.index < range.startIndex || pendingScroll.index > range.endIndex) {
+            return
+        }
+
+        pendingScroll.correcting = true
+        requestAnimationFrame(() => {
+            if (pendingScrollSelectionRef.current !== pendingScroll) {
+                return
+            }
+
+            virtuosoRef.current?.scrollIntoView({
+                index: pendingScroll.index,
+                align: "start",
+                calculateViewLocation: ({ locationParams }) => ({
+                    ...locationParams,
+                    align: "start",
+                }),
+                done: () => {
+                    if (pendingScrollSelectionRef.current !== pendingScroll) {
+                        return
+                    }
+
+                    pendingScrollSelectionRef.current = null
+                    lastScrolledSelectionRef.current = pendingScroll.key
+                },
+            })
+        })
+    }, [])
 
     useEffect(() => {
         const syncSelectionFromFragment = () => {
@@ -475,10 +509,11 @@ export function LogsViewer({
             setIsSelectionUnavailable(false)
 
             if (lastScrolledSelectionRef.current !== selectionKey) {
-                lastScrolledSelectionRef.current = selectionKey
+                const targetIndex = lineSelection.start - 1
+                pendingScrollSelectionRef.current = { key: selectionKey, index: targetIndex, correcting: false }
                 requestAnimationFrame(() => {
                     virtuosoRef.current?.scrollToIndex({
-                        index: lineSelection.start - 1,
+                        index: targetIndex,
                         align: "start",
                     })
                 })
@@ -879,6 +914,7 @@ export function LogsViewer({
                         totalCount={logs.length}
                         itemContent={LogRow}
                         endReached={handleEndReached}
+                        rangeChanged={handleRenderedRangeChanged}
                         overscan={200}
                         className="flex flex-1 w-full h-full"
                     />

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -7,7 +7,10 @@ import {
     useState,
     useTransition,
 } from "react"
-import type { MouseEvent as ReactMouseEvent } from "react"
+import type {
+    KeyboardEvent as ReactKeyboardEvent,
+    MouseEvent as ReactMouseEvent,
+} from "react"
 import {
     usePathname,
     useRouter,
@@ -63,12 +66,14 @@ import { cn, jsonRegex } from "@/lib/utils"
 import {
     buildLogViewerUrl,
     formatLogLineSelection,
+    getNextLogLineSelection,
     getSelectedLogText,
     getUnavailableSelectionMessage,
     isLogLineSelected,
     normalizeLogLineSelection,
     parseLogLineSelection,
     shouldFetchMoreLogsForSelection,
+    shouldIgnoreLogRowSelection,
 } from "@/lib/log-line-selection"
 import type { LogLineSelection } from "@/lib/log-line-selection"
 
@@ -321,24 +326,46 @@ export function LogsViewer({
         window.history.replaceState(window.history.state, "", url)
     }, [lineSelection])
 
-    const handleLineClick = useCallback((
-        lineNumber: number,
-        event: ReactMouseEvent<HTMLAnchorElement>
-    ) => {
-        event.preventDefault()
-
-        if (event.shiftKey) {
-            const anchor = selectionAnchor ?? lineSelection?.start ?? lineNumber
-            const range = normalizeLogLineSelection(anchor, lineNumber)
-            if (range) {
-                updateLineSelection(range)
-            }
+    const selectLogLine = useCallback((lineNumber: number, extendSelection: boolean) => {
+        const anchor = selectionAnchor ?? lineSelection?.start ?? null
+        const selection = getNextLogLineSelection(lineNumber, anchor, extendSelection)
+        if (!selection) {
             return
         }
 
-        setSelectionAnchor(lineNumber)
-        updateLineSelection({ start: lineNumber, end: lineNumber })
+        if (!extendSelection) {
+            setSelectionAnchor(lineNumber)
+        }
+        updateLineSelection(selection)
     }, [lineSelection?.start, selectionAnchor, updateLineSelection])
+
+    const handleLogRowClick = useCallback((
+        lineNumber: number,
+        event: ReactMouseEvent<HTMLDivElement>
+    ) => {
+        const target = event.target
+        const isLineOptionsInteraction = target instanceof Element && Boolean(target.closest("[data-line-options]"))
+        const textSelection = window.getSelection()
+        const hasTextSelection = Boolean(textSelection && !textSelection.isCollapsed)
+
+        if (shouldIgnoreLogRowSelection(hasTextSelection, isLineOptionsInteraction)) {
+            return
+        }
+
+        selectLogLine(lineNumber, event.shiftKey)
+    }, [selectLogLine])
+
+    const handleLogRowKeyDown = useCallback((
+        lineNumber: number,
+        event: ReactKeyboardEvent<HTMLSpanElement>
+    ) => {
+        if (event.key !== "Enter" && event.key !== " ") {
+            return
+        }
+
+        event.preventDefault()
+        selectLogLine(lineNumber, event.shiftKey)
+    }, [selectLogLine])
 
     const copyLogLines = useCallback(async (selection: LogLineSelection) => {
         try {
@@ -555,8 +582,9 @@ export function LogsViewer({
                 )}
                 data-line-number={lineNumber}
                 data-selected={isSelected || undefined}
+                onClick={(event) => handleLogRowClick(lineNumber, event)}
             >
-                <div className="flex w-9 shrink-0 items-center justify-center">
+                <div className="flex w-9 shrink-0 items-center justify-center" data-line-options>
                     {showLineOptions && (
                         <DropdownMenu>
                             <Tooltip>
@@ -569,17 +597,17 @@ export function LogsViewer({
                                                 "size-7 opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100 focus-visible:opacity-100",
                                                 { "opacity-100": isTopSelectedLine }
                                             )}
-                                            aria-label={`Line ${lineNumber} options`}
+                                            aria-label="Line options"
                                         >
                                             <Ellipsis />
                                         </Button>
                                     </DropdownMenuTrigger>
                                 </TooltipTrigger>
                                 <TooltipContent side="left">
-                                    Line {lineNumber} options
+                                    Line options
                                 </TooltipContent>
                             </Tooltip>
-                            <DropdownMenuContent align="start" className="min-w-40">
+                            <DropdownMenuContent align="start" className="min-w-40" data-line-options>
                                 <DropdownMenuGroup>
                                     <DropdownMenuItem
                                         disabled={!canCopyLines}
@@ -600,18 +628,6 @@ export function LogsViewer({
                         </DropdownMenu>
                     )}
                 </div>
-                <a
-                    href={`#L${lineNumber}`}
-                    onClick={(event) => handleLineClick(lineNumber, event)}
-                    className={cn(
-                        "flex w-11 shrink-0 items-start justify-end border-r px-2 py-1 text-xs tabular-nums text-muted-foreground select-none",
-                        { "text-foreground": isSelected }
-                    )}
-                    aria-label={`Select log line ${lineNumber}`}
-                    aria-current={isSelected ? "location" : undefined}
-                >
-                    {lineNumber}
-                </a>
                 <span
                     className={cn("my-1 w-1 flex-none rounded-sm", getLogStreamStripStyles(log.stream))}
                     title={log.stream}
@@ -619,6 +635,11 @@ export function LogsViewer({
                 />
                 <span
                     className="flex-1 whitespace-pre-wrap break-all px-3 py-1"
+                    role="button"
+                    tabIndex={0}
+                    aria-label="Select log entry"
+                    aria-pressed={isSelected}
+                    onKeyDown={(event) => handleLogRowKeyDown(lineNumber, event)}
                     dangerouslySetInnerHTML={{
                         __html: formattedMessage,
                     }}

--- a/dashboard/src/components/dashboard/logs-viewer.tsx
+++ b/dashboard/src/components/dashboard/logs-viewer.tsx
@@ -10,6 +10,7 @@ import {
 import type {
     KeyboardEvent as ReactKeyboardEvent,
     MouseEvent as ReactMouseEvent,
+    PointerEvent as ReactPointerEvent,
 } from "react"
 import {
     usePathname,
@@ -246,6 +247,11 @@ export function LogsViewer({
     const [downloadPopoverOpen, setDownloadPopoverOpen] = useState(false)
     const [isSearchFocused, setIsSearchFocused] = useState(false)
     const searchInputRef = useRef<HTMLInputElement>(null)
+    const rowPointerGestureRef = useRef<{
+        startX: number
+        startY: number
+        didDrag: boolean
+    } | null>(null)
     const pendingSearchQueryRef = useRef<string | null>(null)
     const virtuosoRef = useRef<VirtuosoHandle>(null)
     const deepLinkFetchInFlightRef = useRef(false)
@@ -345,15 +351,42 @@ export function LogsViewer({
     ) => {
         const target = event.target
         const isLineOptionsInteraction = target instanceof Element && Boolean(target.closest("[data-line-options]"))
-        const textSelection = window.getSelection()
-        const hasTextSelection = Boolean(textSelection && !textSelection.isCollapsed)
+        const wasPointerDrag = Boolean(rowPointerGestureRef.current?.didDrag)
+        rowPointerGestureRef.current = null
 
-        if (shouldIgnoreLogRowSelection(hasTextSelection, isLineOptionsInteraction)) {
+        if (shouldIgnoreLogRowSelection(wasPointerDrag, isLineOptionsInteraction)) {
             return
         }
 
         selectLogLine(lineNumber, event.shiftKey)
     }, [selectLogLine])
+
+    const handleLogRowPointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+        const target = event.target
+        if (target instanceof Element && target.closest("[data-line-options]")) {
+            rowPointerGestureRef.current = null
+            return
+        }
+
+        rowPointerGestureRef.current = {
+            startX: event.clientX,
+            startY: event.clientY,
+            didDrag: false,
+        }
+    }, [])
+
+    const handleLogRowPointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+        const gesture = rowPointerGestureRef.current
+        if (!gesture || gesture.didDrag) {
+            return
+        }
+
+        const deltaX = event.clientX - gesture.startX
+        const deltaY = event.clientY - gesture.startY
+        if (Math.hypot(deltaX, deltaY) >= 4) {
+            gesture.didDrag = true
+        }
+    }, [])
 
     const handleLogRowKeyDown = useCallback((
         lineNumber: number,
@@ -582,6 +615,11 @@ export function LogsViewer({
                 )}
                 data-line-number={lineNumber}
                 data-selected={isSelected || undefined}
+                onPointerDown={handleLogRowPointerDown}
+                onPointerMove={handleLogRowPointerMove}
+                onPointerCancel={() => {
+                    rowPointerGestureRef.current = null
+                }}
                 onClick={(event) => handleLogRowClick(lineNumber, event)}
             >
                 <div className="flex w-9 shrink-0 items-center justify-center" data-line-options>

--- a/dashboard/src/hooks/use-job-logs.ts
+++ b/dashboard/src/hooks/use-job-logs.ts
@@ -8,6 +8,7 @@ import {
     useState,
 } from "react"
 import {
+    usePathname,
     useRouter,
     useSearchParams,
 } from "next/navigation"
@@ -21,6 +22,7 @@ import { toast } from "sonner"
 import { useWorkflowDetails } from "@/hooks/use-workflow-details"
 
 import { fetchWithAuth } from "@/lib/api-client"
+import { buildLogViewerUrl } from "@/lib/log-line-selection"
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL
 
@@ -142,6 +144,7 @@ const downloadFilename = (filename: string, format: DownloadLogsFormat) => {
 
 export function useJobLogs(workflowId: string, jobId: string, jobStatus: string) {
     const { workflow, isLoading: isWorkflowLoading } = useWorkflowDetails(workflowId)
+    const pathname = usePathname()
     const router = useRouter()
     const searchParams = useSearchParams()
 
@@ -184,8 +187,8 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
 
         const query = params.toString()
         const hash = window.location.hash
-        router.push(`${query ? `?${query}` : ""}${hash}`)
-    }, [router, searchParams])
+        router.push(buildLogViewerUrl(pathname, query, hash))
+    }, [pathname, router, searchParams])
 
     // Apply stream filter in URL params
     const applyStreamFilter = useCallback((newStreamFilter: string) => {
@@ -199,8 +202,8 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
 
         const query = params.toString()
         const hash = window.location.hash
-        router.push(`${query ? `?${query}` : ""}${hash}`)
-    }, [router, searchParams])
+        router.push(buildLogViewerUrl(pathname, query, hash))
+    }, [pathname, router, searchParams])
 
     // Build query parameters for the search job logs request
     const getSearchQueryParams = useMemo(() => {

--- a/dashboard/src/hooks/use-job-logs.ts
+++ b/dashboard/src/hooks/use-job-logs.ts
@@ -182,7 +182,9 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
             params.delete("q")
         }
 
-        router.push(`?${params.toString()}`)
+        const query = params.toString()
+        const hash = window.location.hash
+        router.push(`${query ? `?${query}` : ""}${hash}`)
     }, [router, searchParams])
 
     // Apply stream filter in URL params
@@ -195,7 +197,9 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
             params.delete("stream")
         }
 
-        router.push(`?${params.toString()}`)
+        const query = params.toString()
+        const hash = window.location.hash
+        router.push(`${query ? `?${query}` : ""}${hash}`)
     }, [router, searchParams])
 
     // Build query parameters for the search job logs request

--- a/dashboard/src/hooks/use-job-logs.ts
+++ b/dashboard/src/hooks/use-job-logs.ts
@@ -186,8 +186,7 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         }
 
         const query = params.toString()
-        const hash = window.location.hash
-        router.push(buildLogViewerUrl(pathname, query, hash))
+        router.push(buildLogViewerUrl(pathname, query, ""))
     }, [pathname, router, searchParams])
 
     // Apply stream filter in URL params
@@ -201,8 +200,7 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         }
 
         const query = params.toString()
-        const hash = window.location.hash
-        router.push(buildLogViewerUrl(pathname, query, hash))
+        router.push(buildLogViewerUrl(pathname, query, ""))
     }, [pathname, router, searchParams])
 
     // Build query parameters for the search job logs request

--- a/dashboard/src/lib/log-line-selection.test.ts
+++ b/dashboard/src/lib/log-line-selection.test.ts
@@ -82,7 +82,7 @@ describe("log line selection", () => {
         expect(getNextLogLineSelection(2, 7, true)).toEqual({ start: 2, end: 7 })
     })
 
-    it("ignores text selection and line-option interactions", () => {
+    it("ignores pointer drags and line-option interactions", () => {
         expect(shouldIgnoreLogRowSelection(true, false)).toBe(true)
         expect(shouldIgnoreLogRowSelection(false, true)).toBe(true)
         expect(shouldIgnoreLogRowSelection(false, false)).toBe(false)

--- a/dashboard/src/lib/log-line-selection.test.ts
+++ b/dashboard/src/lib/log-line-selection.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import {
+    formatLogLineSelection,
+    isLogLineSelected,
+    normalizeLogLineSelection,
+    parseLogLineSelection,
+    shouldFetchMoreLogsForSelection,
+} from "./log-line-selection"
+
+describe("log line fragments", () => {
+    it("parses single lines and ranges", () => {
+        expect(parseLogLineSelection("#L6")).toEqual({ start: 6, end: 6 })
+        expect(parseLogLineSelection("#L6-L19")).toEqual({ start: 6, end: 19 })
+    })
+
+    it("normalizes reversed ranges", () => {
+        expect(parseLogLineSelection("#L19-L6")).toEqual({ start: 6, end: 19 })
+        expect(normalizeLogLineSelection(19, 6)).toEqual({ start: 6, end: 19 })
+        expect(formatLogLineSelection({ start: 19, end: 6 })).toBe("#L6-L19")
+    })
+
+    it("rejects invalid fragments and unsafe line numbers", () => {
+        for (const fragment of ["", "#", "#L0", "#L-1", "#l6", "#L6-19", "#L6-L0", "#L1.5"]) {
+            expect(parseLogLineSelection(fragment)).toBeNull()
+        }
+
+        expect(parseLogLineSelection(`#L${Number.MAX_SAFE_INTEGER + 1}`)).toBeNull()
+    })
+
+    it("formats canonical fragments", () => {
+        expect(formatLogLineSelection({ start: 6, end: 6 })).toBe("#L6")
+        expect(formatLogLineSelection({ start: 6, end: 19 })).toBe("#L6-L19")
+    })
+})
+
+describe("log line selection", () => {
+    it("checks whether a line is within the selected range", () => {
+        const selection = { start: 6, end: 19 }
+
+        expect(isLogLineSelected(5, selection)).toBe(false)
+        expect(isLogLineSelected(6, selection)).toBe(true)
+        expect(isLogLineSelected(19, selection)).toBe(true)
+        expect(isLogLineSelected(20, selection)).toBe(false)
+    })
+
+    it("requests cursor pages until the maximum selected line is loaded", () => {
+        const selection = { start: 6, end: 119 }
+
+        expect(shouldFetchMoreLogsForSelection(selection, 100, true)).toBe(true)
+        expect(shouldFetchMoreLogsForSelection(selection, 119, true)).toBe(false)
+        expect(shouldFetchMoreLogsForSelection(selection, 100, false)).toBe(false)
+        expect(shouldFetchMoreLogsForSelection(null, 0, true)).toBe(false)
+    })
+})

--- a/dashboard/src/lib/log-line-selection.test.ts
+++ b/dashboard/src/lib/log-line-selection.test.ts
@@ -38,6 +38,7 @@ describe("log line fragments", () => {
     it("builds a pathname-based URL when filters are cleared", () => {
         expect(buildLogViewerUrl("/jobs/1", "", "#L1-L7")).toBe("/jobs/1#L1-L7")
         expect(buildLogViewerUrl("/jobs/1", "q=level", "#L1-L7")).toBe("/jobs/1?q=level#L1-L7")
+        expect(buildLogViewerUrl("/jobs/1", "q=level", "")).toBe("/jobs/1?q=level")
     })
 })
 

--- a/dashboard/src/lib/log-line-selection.test.ts
+++ b/dashboard/src/lib/log-line-selection.test.ts
@@ -4,11 +4,13 @@ import {
     buildLogViewerUrl,
     formatLogLineSelection,
     getSelectedLogText,
+    getNextLogLineSelection,
     getUnavailableSelectionMessage,
     isLogLineSelected,
     normalizeLogLineSelection,
     parseLogLineSelection,
     shouldFetchMoreLogsForSelection,
+    shouldIgnoreLogRowSelection,
 } from "./log-line-selection"
 
 describe("log line fragments", () => {
@@ -72,5 +74,17 @@ describe("log line selection", () => {
     it("describes unavailable single lines and ranges", () => {
         expect(getUnavailableSelectionMessage({ start: 10, end: 10 })).toBe("Log line 10 is unavailable")
         expect(getUnavailableSelectionMessage({ start: 1, end: 10 })).toBe("Some selected log lines are unavailable")
+    })
+
+    it("creates single and extended row selections", () => {
+        expect(getNextLogLineSelection(4, 2, false)).toEqual({ start: 4, end: 4 })
+        expect(getNextLogLineSelection(7, 2, true)).toEqual({ start: 2, end: 7 })
+        expect(getNextLogLineSelection(2, 7, true)).toEqual({ start: 2, end: 7 })
+    })
+
+    it("ignores text selection and line-option interactions", () => {
+        expect(shouldIgnoreLogRowSelection(true, false)).toBe(true)
+        expect(shouldIgnoreLogRowSelection(false, true)).toBe(true)
+        expect(shouldIgnoreLogRowSelection(false, false)).toBe(false)
     })
 })

--- a/dashboard/src/lib/log-line-selection.test.ts
+++ b/dashboard/src/lib/log-line-selection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+    buildLogViewerUrl,
     formatLogLineSelection,
     getSelectedLogText,
     isLogLineSelected,
@@ -32,6 +33,11 @@ describe("log line fragments", () => {
     it("formats canonical fragments", () => {
         expect(formatLogLineSelection({ start: 6, end: 6 })).toBe("#L6")
         expect(formatLogLineSelection({ start: 6, end: 19 })).toBe("#L6-L19")
+    })
+
+    it("builds a pathname-based URL when filters are cleared", () => {
+        expect(buildLogViewerUrl("/jobs/1", "", "#L1-L7")).toBe("/jobs/1#L1-L7")
+        expect(buildLogViewerUrl("/jobs/1", "q=level", "#L1-L7")).toBe("/jobs/1?q=level#L1-L7")
     })
 })
 

--- a/dashboard/src/lib/log-line-selection.test.ts
+++ b/dashboard/src/lib/log-line-selection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
     formatLogLineSelection,
+    getSelectedLogText,
     isLogLineSelected,
     normalizeLogLineSelection,
     parseLogLineSelection,
@@ -51,5 +52,12 @@ describe("log line selection", () => {
         expect(shouldFetchMoreLogsForSelection(selection, 119, true)).toBe(false)
         expect(shouldFetchMoreLogsForSelection(selection, 100, false)).toBe(false)
         expect(shouldFetchMoreLogsForSelection(null, 0, true)).toBe(false)
+    })
+
+    it("copies selected log messages in displayed order", () => {
+        const messages = ["newest", "middle", "oldest"]
+
+        expect(getSelectedLogText(messages, { start: 2, end: 2 })).toBe("middle")
+        expect(getSelectedLogText(messages, { start: 1, end: 3 })).toBe("newest\nmiddle\noldest")
     })
 })

--- a/dashboard/src/lib/log-line-selection.test.ts
+++ b/dashboard/src/lib/log-line-selection.test.ts
@@ -4,6 +4,7 @@ import {
     buildLogViewerUrl,
     formatLogLineSelection,
     getSelectedLogText,
+    getUnavailableSelectionMessage,
     isLogLineSelected,
     normalizeLogLineSelection,
     parseLogLineSelection,
@@ -66,5 +67,10 @@ describe("log line selection", () => {
 
         expect(getSelectedLogText(messages, { start: 2, end: 2 })).toBe("middle")
         expect(getSelectedLogText(messages, { start: 1, end: 3 })).toBe("newest\nmiddle\noldest")
+    })
+
+    it("describes unavailable single lines and ranges", () => {
+        expect(getUnavailableSelectionMessage({ start: 10, end: 10 })).toBe("Log line 10 is unavailable")
+        expect(getUnavailableSelectionMessage({ start: 1, end: 10 })).toBe("Some selected log lines are unavailable")
     })
 })

--- a/dashboard/src/lib/log-line-selection.ts
+++ b/dashboard/src/lib/log-line-selection.ts
@@ -62,3 +62,10 @@ export const shouldFetchMoreLogsForSelection = (
 ) => {
     return Boolean(selection && hasNextPage && loadedLogCount < selection.end)
 }
+
+export const getSelectedLogText = (
+    messages: readonly string[],
+    selection: LogLineSelection
+) => {
+    return messages.slice(selection.start - 1, selection.end).join("\n")
+}

--- a/dashboard/src/lib/log-line-selection.ts
+++ b/dashboard/src/lib/log-line-selection.ts
@@ -69,3 +69,11 @@ export const getSelectedLogText = (
 ) => {
     return messages.slice(selection.start - 1, selection.end).join("\n")
 }
+
+export const buildLogViewerUrl = (
+    pathname: string,
+    query: string,
+    fragment: string
+) => {
+    return `${pathname}${query ? `?${query}` : ""}${fragment}`
+}

--- a/dashboard/src/lib/log-line-selection.ts
+++ b/dashboard/src/lib/log-line-selection.ts
@@ -85,3 +85,22 @@ export const getUnavailableSelectionMessage = (selection: LogLineSelection) => {
 
     return "Some selected log lines are unavailable"
 }
+
+export const getNextLogLineSelection = (
+    lineNumber: number,
+    anchor: number | null,
+    extendSelection: boolean
+) => {
+    if (!extendSelection || anchor === null) {
+        return normalizeLogLineSelection(lineNumber)
+    }
+
+    return normalizeLogLineSelection(anchor, lineNumber)
+}
+
+export const shouldIgnoreLogRowSelection = (
+    hasTextSelection: boolean,
+    isLineOptionsInteraction: boolean
+) => {
+    return hasTextSelection || isLineOptionsInteraction
+}

--- a/dashboard/src/lib/log-line-selection.ts
+++ b/dashboard/src/lib/log-line-selection.ts
@@ -1,0 +1,64 @@
+export type LogLineSelection = {
+    start: number
+    end: number
+}
+
+const logLineFragmentPattern = /^#L([1-9]\d*)(?:-L([1-9]\d*))?$/
+
+const isValidLineNumber = (value: number) => {
+    return Number.isSafeInteger(value) && value > 0
+}
+
+export const normalizeLogLineSelection = (
+    start: number,
+    end: number = start
+): LogLineSelection | null => {
+    if (!isValidLineNumber(start) || !isValidLineNumber(end)) {
+        return null
+    }
+
+    return {
+        start: Math.min(start, end),
+        end: Math.max(start, end),
+    }
+}
+
+export const parseLogLineSelection = (fragment: string): LogLineSelection | null => {
+    const match = logLineFragmentPattern.exec(fragment)
+    if (!match) {
+        return null
+    }
+
+    const start = Number(match[1])
+    const end = match[2] ? Number(match[2]) : start
+    return normalizeLogLineSelection(start, end)
+}
+
+export const formatLogLineSelection = (selection: LogLineSelection): string => {
+    const normalized = normalizeLogLineSelection(selection.start, selection.end)
+    if (!normalized) {
+        return ""
+    }
+
+    if (normalized.start === normalized.end) {
+        return `#L${normalized.start}`
+    }
+
+    return `#L${normalized.start}-L${normalized.end}`
+}
+
+export const isLogLineSelected = (lineNumber: number, selection: LogLineSelection | null) => {
+    return Boolean(
+        selection &&
+        lineNumber >= selection.start &&
+        lineNumber <= selection.end
+    )
+}
+
+export const shouldFetchMoreLogsForSelection = (
+    selection: LogLineSelection | null,
+    loadedLogCount: number,
+    hasNextPage: boolean
+) => {
+    return Boolean(selection && hasNextPage && loadedLogCount < selection.end)
+}

--- a/dashboard/src/lib/log-line-selection.ts
+++ b/dashboard/src/lib/log-line-selection.ts
@@ -99,8 +99,8 @@ export const getNextLogLineSelection = (
 }
 
 export const shouldIgnoreLogRowSelection = (
-    hasTextSelection: boolean,
+    wasPointerDrag: boolean,
     isLineOptionsInteraction: boolean
 ) => {
-    return hasTextSelection || isLineOptionsInteraction
+    return wasPointerDrag || isLineOptionsInteraction
 }

--- a/dashboard/src/lib/log-line-selection.ts
+++ b/dashboard/src/lib/log-line-selection.ts
@@ -77,3 +77,11 @@ export const buildLogViewerUrl = (
 ) => {
     return `${pathname}${query ? `?${query}` : ""}${fragment}`
 }
+
+export const getUnavailableSelectionMessage = (selection: LogLineSelection) => {
+    if (selection.start === selection.end) {
+        return `Log line ${selection.end} is unavailable`
+    }
+
+    return "Some selected log lines are unavailable"
+}

--- a/static/content/docs/features/log-streaming.mdx
+++ b/static/content/docs/features/log-streaming.mdx
@@ -18,6 +18,12 @@ Running container jobs expose `GET /workflows/{workflow_id}/jobs/{job_id}/events
 
 When `q` is absent, the route performs retained stream filtering. When present, Meilisearch supplies matches and highlight ranges.
 
+## Shareable line selections
+
+The dashboard numbers logs within the current descending result set. Select a line to store it in the URL as `#L6`, or Shift-select another line to create a range such as `#L6-L19`. Search and stream filters remain part of the shared URL, so line numbers resolve against the same filtered or unfiltered result set.
+
+Opening a line link loads older cursor pages until the selected range is available, then scrolls to and highlights it. Running jobs support line selection, but the dashboard enables copying a share link only after the job reaches `COMPLETED`, `FAILED`, or `CANCELED`, because new live logs can change result positions.
+
 ## Raw downloads
 
 `GET .../logs/raw` downloads plain text. Stream and text filters are applied consistently, and search highlights are not rendered into the download.
@@ -29,4 +35,3 @@ Search highlights are handled as structured data rather than trusted HTML. Clien
 ## Error behavior
 
 Retained routes return `412` for unsupported or disabled retention. An already-open SSE response reports equivalent failures through `event: error` frames.
-

--- a/static/content/docs/features/log-streaming.mdx
+++ b/static/content/docs/features/log-streaming.mdx
@@ -20,7 +20,7 @@ When `q` is absent, the route performs retained stream filtering. When present, 
 
 ## Shareable line selections
 
-The dashboard numbers logs within the current descending result set. Select a line to store it in the URL as `#L6`, or Shift-select another line to create a range such as `#L6-L19`. The first selected line exposes actions to copy the selected log text or its permalink. Search and stream filters remain part of a shared URL, so line numbers resolve against the same filtered or unfiltered result set. Changing either filter clears the current line selection because it changes the numbered result set.
+The dashboard tracks each log's position within the current descending result set without displaying line numbers. Click a log to store its position in the URL as `#L6`, or Shift-click another log to create a range such as `#L6-L19`. The first selected log exposes actions to copy the selected log text or its permalink. Search and stream filters remain part of a shared URL, so positions resolve against the same filtered or unfiltered result set. Changing either filter clears the current selection because it changes the positioned result set.
 
 Opening a line link loads older cursor pages until the selected range is available, then scrolls to and highlights it. If a requested range extends beyond the available results, the dashboard reports that some selected log lines are unavailable. Running jobs support line selection, but the dashboard enables copying a share link only after the job reaches `COMPLETED`, `FAILED`, or `CANCELED`, because new live logs can change result positions.
 

--- a/static/content/docs/features/log-streaming.mdx
+++ b/static/content/docs/features/log-streaming.mdx
@@ -22,7 +22,7 @@ When `q` is absent, the route performs retained stream filtering. When present, 
 
 The dashboard numbers logs within the current descending result set. Select a line to store it in the URL as `#L6`, or Shift-select another line to create a range such as `#L6-L19`. The first selected line exposes actions to copy the selected log text or its permalink. Search and stream filters remain part of a shared URL, so line numbers resolve against the same filtered or unfiltered result set. Changing either filter clears the current line selection because it changes the numbered result set.
 
-Opening a line link loads older cursor pages until the selected range is available, then scrolls to and highlights it. Running jobs support line selection, but the dashboard enables copying a share link only after the job reaches `COMPLETED`, `FAILED`, or `CANCELED`, because new live logs can change result positions.
+Opening a line link loads older cursor pages until the selected range is available, then scrolls to and highlights it. If a requested range extends beyond the available results, the dashboard reports that some selected log lines are unavailable. Running jobs support line selection, but the dashboard enables copying a share link only after the job reaches `COMPLETED`, `FAILED`, or `CANCELED`, because new live logs can change result positions.
 
 ## Raw downloads
 

--- a/static/content/docs/features/log-streaming.mdx
+++ b/static/content/docs/features/log-streaming.mdx
@@ -20,7 +20,7 @@ When `q` is absent, the route performs retained stream filtering. When present, 
 
 ## Shareable line selections
 
-The dashboard numbers logs within the current descending result set. Select a line to store it in the URL as `#L6`, or Shift-select another line to create a range such as `#L6-L19`. Search and stream filters remain part of the shared URL, so line numbers resolve against the same filtered or unfiltered result set.
+The dashboard numbers logs within the current descending result set. Select a line to store it in the URL as `#L6`, or Shift-select another line to create a range such as `#L6-L19`. The first selected line exposes actions to copy the selected log text or its permalink. Search and stream filters remain part of the shared URL, so line numbers resolve against the same filtered or unfiltered result set.
 
 Opening a line link loads older cursor pages until the selected range is available, then scrolls to and highlights it. Running jobs support line selection, but the dashboard enables copying a share link only after the job reaches `COMPLETED`, `FAILED`, or `CANCELED`, because new live logs can change result positions.
 

--- a/static/content/docs/features/log-streaming.mdx
+++ b/static/content/docs/features/log-streaming.mdx
@@ -20,7 +20,7 @@ When `q` is absent, the route performs retained stream filtering. When present, 
 
 ## Shareable line selections
 
-The dashboard numbers logs within the current descending result set. Select a line to store it in the URL as `#L6`, or Shift-select another line to create a range such as `#L6-L19`. The first selected line exposes actions to copy the selected log text or its permalink. Search and stream filters remain part of the shared URL, so line numbers resolve against the same filtered or unfiltered result set.
+The dashboard numbers logs within the current descending result set. Select a line to store it in the URL as `#L6`, or Shift-select another line to create a range such as `#L6-L19`. The first selected line exposes actions to copy the selected log text or its permalink. Search and stream filters remain part of a shared URL, so line numbers resolve against the same filtered or unfiltered result set. Changing either filter clears the current line selection because it changes the numbered result set.
 
 Opening a line link loads older cursor pages until the selected range is available, then scrolls to and highlights it. Running jobs support line selection, but the dashboard enables copying a share link only after the job reaches `COMPLETED`, `FAILED`, or `CANCELED`, because new live logs can change result positions.
 


### PR DESCRIPTION
## Summary

- add GitHub-style single-line and range selection to job logs using hidden positional URL fragments
- select logs directly by click or Shift-click without displaying positional line numbers
- add per-line actions for copying selected log text or a permalink, with range actions anchored to the first selected log
- keep selection and log-text copying available for running jobs while enabling permalink copying only for completed, failed, and canceled jobs
- resolve shared deep links across cursor pages for filtered and unfiltered descending log results, then scroll to and highlight the selected rows
- clear active selections when search or stream filters change, while preserving filtered permalinks opened directly
- provide selection-aware unavailable feedback and align the README/static documentation with the final behavior
