### PR TITLE
Clean React findings and preserve docs navigation state

### DIFF
--- a/static/docs.config.ts
+++ b/static/docs.config.ts
@@ -111,7 +111,3 @@ export const docPages = docsConfig.flatMap((group) => group.pages);
 export function getDocPage(slug: string) {
   return docPages.find((page) => page.slug === slug);
 }
-
-export function getDocHref(slug: string) {
-  return `/docs/${slug}`;
-}

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -27,6 +27,7 @@
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^3.17.0",
+        "swr": "^2.4.2",
         "tailwind-merge": "^3.3.1",
         "tw-animate-css": "^1.3.4",
         "yaml": "^2.9.0"
@@ -9384,6 +9385,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
@@ -9919,6 +9933,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vfile": {

--- a/static/package.json
+++ b/static/package.json
@@ -35,6 +35,7 @@
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^3.17.0",
+    "swr": "^2.4.2",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.3.4",
     "yaml": "^2.9.0"

--- a/static/src/app/docs/[...slug]/page.tsx
+++ b/static/src/app/docs/[...slug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import type { ComponentType } from "react";
 
 import { ApiOperation } from "@/components/docs/api-operation";
 import { DocShell } from "@/components/docs/doc-shell";
@@ -9,6 +10,57 @@ import { getOpenApiOperation, getOpenApiOperations } from "@/lib/openapi";
 import { SITE_URL } from "@/lib/site";
 
 type PageProps = { params: Promise<{ slug: string[] }> };
+type DocModule = { default: ComponentType };
+
+const docLoaders: Record<string, () => Promise<DocModule>> = {
+  introduction: () => import("@docs/introduction.mdx"),
+  quickstart: () => import("@docs/quickstart.mdx"),
+  installation: () => import("@docs/installation.mdx"),
+  "getting-started/first-workflow": () => import("@docs/getting-started/first-workflow.mdx"),
+  "concepts/workflows": () => import("@docs/concepts/workflows.mdx"),
+  "concepts/jobs": () => import("@docs/concepts/jobs.mdx"),
+  "concepts/scheduling": () => import("@docs/concepts/scheduling.mdx"),
+  "concepts/workers": () => import("@docs/concepts/workers.mdx"),
+  "concepts/lifecycle-states": () => import("@docs/concepts/lifecycle-states.mdx"),
+  "concepts/log-retention": () => import("@docs/concepts/log-retention.mdx"),
+  "engineering/architecture": () => import("@docs/engineering/architecture.mdx"),
+  "engineering/service-boundaries": () => import("@docs/engineering/service-boundaries.mdx"),
+  "engineering/event-flows": () => import("@docs/engineering/event-flows.mdx"),
+  "engineering/replay-safety": () => import("@docs/engineering/replay-safety.mdx"),
+  "engineering/transactional-outbox": () => import("@docs/engineering/transactional-outbox.mdx"),
+  "engineering/job-leases": () => import("@docs/engineering/job-leases.mdx"),
+  "engineering/kafka-processing": () => import("@docs/engineering/kafka-processing.mdx"),
+  "engineering/image-pull-coordination": () => import("@docs/engineering/image-pull-coordination.mdx"),
+  "engineering/logging-search-pipeline": () => import("@docs/engineering/logging-search-pipeline.mdx"),
+  "engineering/trace-propagation": () => import("@docs/engineering/trace-propagation.mdx"),
+  "features/workflow-types": () => import("@docs/features/workflow-types.mdx"),
+  "features/job-scheduling": () => import("@docs/features/job-scheduling.mdx"),
+  "features/log-streaming": () => import("@docs/features/log-streaming.mdx"),
+  "features/notifications": () => import("@docs/features/notifications.mdx"),
+  "features/analytics": () => import("@docs/features/analytics.mdx"),
+  "api/overview": () => import("@docs/api/overview.mdx"),
+  "api/authentication": () => import("@docs/api/authentication.mdx"),
+  "api/request-safety": () => import("@docs/api/request-safety.mdx"),
+  "api/pagination-errors": () => import("@docs/api/pagination-errors.mdx"),
+  "api/server-sent-events": () => import("@docs/api/server-sent-events.mdx"),
+  "api/reference": () => import("@docs/api/reference.mdx"),
+  "internal/grpc-services": () => import("@docs/internal/grpc-services.mdx"),
+  "internal/kafka-events": () => import("@docs/internal/kafka-events.mdx"),
+  "internal/data-stores": () => import("@docs/internal/data-stores.mdx"),
+  "deployment/overview": () => import("@docs/deployment/overview.mdx"),
+  "deployment/development": () => import("@docs/deployment/development.mdx"),
+  "deployment/production": () => import("@docs/deployment/production.mdx"),
+  "deployment/kubernetes": () => import("@docs/deployment/kubernetes.mdx"),
+  "deployment/configuration": () => import("@docs/deployment/configuration.mdx"),
+  "deployment/security": () => import("@docs/deployment/security.mdx"),
+  "operations/monitoring": () => import("@docs/operations/monitoring.mdx"),
+  "operations/observability": () => import("@docs/operations/observability.mdx"),
+  "operations/scaling": () => import("@docs/operations/scaling.mdx"),
+  "operations/recovery": () => import("@docs/operations/recovery.mdx"),
+  "operations/troubleshooting": () => import("@docs/operations/troubleshooting.mdx"),
+  "contributing/repository-layout": () => import("@docs/contributing/repository-layout.mdx"),
+  "contributing/development": () => import("@docs/contributing/development.mdx"),
+};
 
 export const dynamicParams = false;
 
@@ -51,7 +103,9 @@ export default async function DocumentationPage({ params }: PageProps) {
 
   const page = getDocPage(slug);
   if (!page) notFound();
-  const Content = (await import(`@docs/${page.source}.mdx`)).default;
+  const loadContent = docLoaders[page.source];
+  if (!loadContent) notFound();
+  const Content = (await loadContent()).default;
 
   return (
     <DocShell activeSlug={slug} description={page.description} headings={getDocHeadings(page.source)} next={navigation.next} previous={navigation.previous} title={page.title}>

--- a/static/src/app/docs/openapi.yaml/route.ts
+++ b/static/src/app/docs/openapi.yaml/route.ts
@@ -4,6 +4,8 @@ import { getOpenApiPath } from "@/lib/openapi";
 
 export const dynamic = "force-static";
 
+const openApiYaml = fs.readFileSync(getOpenApiPath(), "utf8");
+
 export function GET() {
-  return new Response(fs.readFileSync(getOpenApiPath(), "utf8"), { headers: { "Content-Type": "application/yaml; charset=utf-8" } });
+  return new Response(openApiYaml, { headers: { "Content-Type": "application/yaml; charset=utf-8" } });
 }

--- a/static/src/app/layout.tsx
+++ b/static/src/app/layout.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html data-scroll-behavior="smooth" lang="en" suppressHydrationWarning>
       <body>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
           <SearchProvider>

--- a/static/src/components/docs/api-operation.tsx
+++ b/static/src/components/docs/api-operation.tsx
@@ -72,7 +72,13 @@ function Authentication({ operation }: { operation: OpenApiOperation }) {
   return (
     <div className="security-requirements">
       {operation.security.map((requirement, index) => (
-        <section className="security-alternative" key={`${index}-${Object.keys(requirement).join("-")}`}>
+        <section
+          className="security-alternative"
+          key={Object.entries(requirement)
+            .map(([name, scopes]) => `${name}:${scopes.join(",")}`)
+            .sort()
+            .join("|")}
+        >
           {operation.security.length > 1 && <p>Authentication option {index + 1}</p>}
           {Object.entries(requirement).map(([name, scopes]) => {
             const scheme = operation.securitySchemes[name];

--- a/static/src/components/docs/docs-navigation.tsx
+++ b/static/src/components/docs/docs-navigation.tsx
@@ -2,6 +2,7 @@ import { Braces, Menu } from "lucide-react";
 import Link from "next/link";
 
 import { docsConfig } from "../../../docs.config";
+import { DocsSidebarScrollArea } from "@/components/docs/docs-sidebar-scroll-area";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
@@ -17,14 +18,24 @@ function NavigationContent({ activeSlug }: { activeSlug: string }) {
           <ul>
             {group.pages.map((page) => (
               <li key={page.slug}>
-                <Link className={cn(activeSlug === page.slug && "active")} href={`/docs/${page.slug}`}>{page.title}</Link>
+                <Link
+                  aria-current={activeSlug === page.slug ? "page" : undefined}
+                  className={cn(activeSlug === page.slug && "active")}
+                  href={`/docs/${page.slug}`}
+                >
+                  {page.title}
+                </Link>
                 {page.slug === "api/reference" && (
                   <ul className="docs-api-nav">
                     {operations.map((operation) => {
                       const slug = `api/reference/${operation.operationId}`;
                       return (
                         <li key={operation.operationId}>
-                          <Link className={cn(activeSlug === slug && "active")} href={`/docs/${slug}`}>
+                          <Link
+                            aria-current={activeSlug === slug ? "page" : undefined}
+                            className={cn(activeSlug === slug && "active")}
+                            href={`/docs/${slug}`}
+                          >
                             <Braces />
                             <span>{operation.summary}</span>
                           </Link>
@@ -43,7 +54,7 @@ function NavigationContent({ activeSlug }: { activeSlug: string }) {
 }
 
 export function DocsSidebar({ activeSlug }: { activeSlug: string }) {
-  return <aside className="docs-sidebar"><NavigationContent activeSlug={activeSlug} /></aside>;
+  return <DocsSidebarScrollArea activeSlug={activeSlug}><NavigationContent activeSlug={activeSlug} /></DocsSidebarScrollArea>;
 }
 
 export function DocsMobileNavigation({ activeSlug }: { activeSlug: string }) {

--- a/static/src/components/docs/docs-sidebar-scroll-area.tsx
+++ b/static/src/components/docs/docs-sidebar-scroll-area.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import type { ReactNode, UIEvent } from "react";
+import { useLayoutEffect, useRef } from "react";
+
+const SCROLL_POSITION_KEY = "chronoverse:docs-sidebar-scroll";
+
+function rememberScrollPosition(event: UIEvent<HTMLElement>) {
+  sessionStorage.setItem(SCROLL_POSITION_KEY, String(event.currentTarget.scrollTop));
+}
+
+export function DocsSidebarScrollArea({ activeSlug, children }: { activeSlug: string; children: ReactNode }) {
+  const sidebarRef = useRef<HTMLElement>(null);
+
+  useLayoutEffect(() => {
+    const sidebar = sidebarRef.current;
+    if (!sidebar) return;
+
+    const savedScrollTop = Number(sessionStorage.getItem(SCROLL_POSITION_KEY));
+    if (Number.isFinite(savedScrollTop)) sidebar.scrollTop = savedScrollTop;
+
+    const activeLink = sidebar.querySelector<HTMLElement>('[aria-current="page"]');
+    if (!activeLink) return;
+
+    const sidebarBounds = sidebar.getBoundingClientRect();
+    const activeLinkBounds = activeLink.getBoundingClientRect();
+    const activeLinkIsVisible = activeLinkBounds.top >= sidebarBounds.top && activeLinkBounds.bottom <= sidebarBounds.bottom;
+    if (activeLinkIsVisible) return;
+
+    const centeredScrollTop = sidebar.scrollTop
+      + activeLinkBounds.top
+      - sidebarBounds.top
+      - (sidebar.clientHeight - activeLinkBounds.height) / 2;
+    const behavior = window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
+    sidebar.scrollTo({ top: centeredScrollTop, behavior });
+  }, [activeSlug]);
+
+  return <aside className="docs-sidebar" onScroll={rememberScrollPosition} ref={sidebarRef}>{children}</aside>;
+}

--- a/static/src/components/docs/search-dialog.tsx
+++ b/static/src/components/docs/search-dialog.tsx
@@ -4,6 +4,7 @@ import Fuse from "fuse.js";
 import { FileText, Search } from "lucide-react";
 import Link from "next/link";
 import { createContext, type ReactNode, useContext, useDeferredValue, useEffect, useMemo, useState } from "react";
+import useSWR from "swr";
 
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -14,11 +15,21 @@ type SearchDocument = { title: string; description: string; headings: string; hr
 
 const SearchContext = createContext<((open: boolean) => void) | null>(null);
 
+async function fetchSearchDocuments(url: string): Promise<SearchDocument[]> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Search index request failed: ${response.status}`);
+  return response.json() as Promise<SearchDocument[]>;
+}
+
 export function SearchProvider({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [documents, setDocuments] = useState<SearchDocument[]>([]);
   const deferredQuery = useDeferredValue(query.trim());
+  const { data: documents = [] } = useSWR<SearchDocument[]>(
+    open ? `${BASE_PATH}/docs/search-index.json` : null,
+    fetchSearchDocuments,
+    { revalidateOnFocus: false, shouldRetryOnError: false },
+  );
 
   useEffect(() => {
     function keydown(event: KeyboardEvent) {
@@ -30,14 +41,6 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     window.addEventListener("keydown", keydown);
     return () => window.removeEventListener("keydown", keydown);
   }, []);
-
-  useEffect(() => {
-    if (!open || documents.length > 0) return;
-    fetch(`${BASE_PATH}/docs/search-index.json`)
-      .then((response) => response.json())
-      .then((value: SearchDocument[]) => setDocuments(value))
-      .catch(() => setDocuments([]));
-  }, [documents.length, open]);
 
   const fuse = useMemo(() => new Fuse(documents, {
     keys: [
@@ -84,17 +87,19 @@ export function SearchProvider({ children }: { children: ReactNode }) {
           <label className="search-input-wrap">
             <Search aria-hidden="true" />
             <span className="sr-only">Search query</span>
-            <input autoFocus onChange={(event) => setQuery(event.target.value)} placeholder="Search Chronoverse..." value={query} />
+            <input onChange={(event) => setQuery(event.target.value)} placeholder="Search Chronoverse..." value={query} />
           </label>
-          <div className="search-results" role="list">
+          <ul className="search-results">
             {results.map((result) => (
-              <Link href={result.href} key={result.href} onClick={() => setOpen(false)} role="listitem">
-                <FileText />
-                <span><strong>{result.title}</strong><small>{result.section} · {result.description}</small></span>
-              </Link>
+              <li key={result.href}>
+                <Link href={result.href} onClick={() => setOpen(false)}>
+                  <FileText />
+                  <span><strong>{result.title}</strong><small>{result.section} · {result.description}</small></span>
+                </Link>
+              </li>
             ))}
-            {query && results.length === 0 && <p>No documentation matched “{query}”.</p>}
-          </div>
+          </ul>
+          {query && results.length === 0 && <p>No documentation matched “{query}”.</p>}
         </DialogContent>
       </Dialog>
     </SearchContext.Provider>

--- a/static/src/components/ui/badge.tsx
+++ b/static/src/components/ui/badge.tsx
@@ -33,4 +33,4 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   )
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/static/src/components/ui/button.tsx
+++ b/static/src/components/ui/button.tsx
@@ -56,4 +56,4 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/static/src/lib/openapi.ts
+++ b/static/src/lib/openapi.ts
@@ -143,22 +143,22 @@ export function getOpenApiOperations(): OpenApiOperation[] {
   const document = getOpenApiDocument();
 
   return Object.entries(document.paths).flatMap(([route, pathItem]) =>
-    Object.entries(pathItem)
-      .filter(([method]) => HTTP_METHODS.has(method))
-      .map(([method, value]) => {
-        const operation = value as Record<string, unknown>;
-        const pathParameters = (pathItem.parameters as unknown as Array<OpenApiParameter | { $ref: string }> | undefined) ?? [];
-        const operationParameters = (operation.parameters as Array<OpenApiParameter | { $ref: string }> | undefined) ?? [];
-        const security = (operation.security as OpenApiSecurityRequirement[] | undefined) ?? document.security ?? [];
-        const securitySchemeNames = new Set(security.flatMap((requirement) => Object.keys(requirement)));
-        const securitySchemes = Object.fromEntries(
-          [...securitySchemeNames].map((name) => {
-            const scheme = document.components?.securitySchemes?.[name];
-            if (!scheme) throw new Error(`Unresolved OpenAPI security scheme: ${name}`);
-            return [name, dereferenceValue(scheme, document) as OpenApiSecurityScheme];
-          }),
-        );
-        return {
+    Object.entries(pathItem).flatMap(([method, value]) => {
+      if (!HTTP_METHODS.has(method)) return [];
+      const operation = value as Record<string, unknown>;
+      const pathParameters = (pathItem.parameters as unknown as Array<OpenApiParameter | { $ref: string }> | undefined) ?? [];
+      const operationParameters = (operation.parameters as Array<OpenApiParameter | { $ref: string }> | undefined) ?? [];
+      const security = (operation.security as OpenApiSecurityRequirement[] | undefined) ?? document.security ?? [];
+      const securitySchemeNames = new Set(security.flatMap((requirement) => Object.keys(requirement)));
+      const securitySchemes = Object.fromEntries(
+        [...securitySchemeNames].map((name) => {
+          const scheme = document.components?.securitySchemes?.[name];
+          if (!scheme) throw new Error(`Unresolved OpenAPI security scheme: ${name}`);
+          return [name, dereferenceValue(scheme, document) as OpenApiSecurityScheme];
+        }),
+      );
+      return [
+        {
           operationId: String(operation.operationId),
           method: method.toUpperCase(),
           path: route,
@@ -178,8 +178,9 @@ export function getOpenApiOperations(): OpenApiOperation[] {
               (operation.responses as Record<string, OpenApiResponse | { $ref: string }> | undefined) ?? {},
             ).map(([status, response]) => [status, dereferenceValue(response, document) as OpenApiResponse]),
           ),
-        };
-      }),
+        },
+      ];
+    }),
   );
 }
 


### PR DESCRIPTION
**Brings the Chronoverse docs frontend to a clean React Doctor 100/100 while improving navigation continuity.**

## What changed

- replace the computed MDX import with literal loaders so Next.js can split documentation pages reliably
- hoist the static OpenAPI YAML read out of the request handler and remove the unused docs helper
- load the search index lazily through SWR for request caching, deduplication, and race handling
- use stable authentication keys and native list markup, and remove redundant forced focus
- keep shadcn Button and Badge modules component-only by making unused variant helpers private
- combine OpenAPI filtering and mapping into one traversal
- preserve the desktop docs sidebar scroll position across route changes and reveal active deep links when needed
- mark active navigation links with `aria-current="page"`
- add the Next.js smooth-scroll opt-in so route scrolling is handled without the framework warning

## Navigation behavior

The main document still starts at the top for each new docs page. The sidebar now retains its independent scroll position, so navigating between API operations no longer loses the active area. Direct deep links smoothly reveal the active sidebar item and respect reduced-motion preferences.