### PR TITLE
fix(crypto): replace fixed-nonce AES-CTR with authenticated AES-GCM

### DIFF
--- a/internal/pkg/crypto/crypto.go
+++ b/internal/pkg/crypto/crypto.go
@@ -9,9 +9,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// bytes are random bytes.
-var bytes = []byte{35, 46, 57, 24, 85, 35, 24, 74, 87, 35, 88, 98, 66, 32, 14, 0o5}
-
 // Crypto is responsible for encrypting and decrypting data.
 type Crypto struct {
 	secret string
@@ -36,7 +33,7 @@ func (c *Crypto) encode(data []byte) string {
 func (c *Crypto) decode(s string) ([]byte, error) {
 	data, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to decode data: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to decode data: %v", err)
 	}
 
 	return data, nil
@@ -49,10 +46,13 @@ func (c *Crypto) Encrypt(data string) (string, error) {
 		return "", status.Errorf(codes.Internal, "failed to create new cipher: %v", err)
 	}
 
-	plainText := []byte(data)
-	stream := cipher.NewCTR(block, bytes)
-	cipherText := make([]byte, len(plainText))
-	stream.XORKeyStream(cipherText, plainText)
+	aead, err := cipher.NewGCMWithRandomNonce(block)
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "failed to create authenticated cipher: %v", err)
+	}
+
+	// Seal authenticates the ciphertext and prepends a random nonce.
+	cipherText := aead.Seal(nil, nil, []byte(data), nil)
 	return c.encode(cipherText), nil
 }
 
@@ -63,13 +63,24 @@ func (c *Crypto) Decrypt(data string) (string, error) {
 		return "", status.Errorf(codes.Internal, "failed to create new cipher: %v", err)
 	}
 
-	cipherText, err := c.decode(data)
+	aead, err := cipher.NewGCMWithRandomNonce(block)
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "failed to create authenticated cipher: %v", err)
+	}
+
+	decodedBytes, err := c.decode(data)
 	if err != nil {
 		return "", err
 	}
 
-	plainText := make([]byte, len(cipherText))
-	cfb := cipher.NewCTR(block, bytes)
-	cfb.XORKeyStream(plainText, cipherText)
+	if len(decodedBytes) < aead.Overhead() {
+		return "", status.Error(codes.InvalidArgument, "ciphertext is too short")
+	}
+
+	plainText, err := aead.Open(nil, nil, decodedBytes, nil)
+	if err != nil {
+		return "", status.Error(codes.InvalidArgument, "failed to authenticate ciphertext")
+	}
+
 	return string(plainText), nil
 }

--- a/internal/pkg/crypto/crypto_test.go
+++ b/internal/pkg/crypto/crypto_test.go
@@ -1,12 +1,13 @@
 package crypto_test
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/hitesh22rana/chronoverse/internal/pkg/crypto"
 )
 
-func Test(t *testing.T) {
+func TestEncryptDecrypt(t *testing.T) {
 	c, err := crypto.New("01234567890123456789012345678901")
 	if err != nil {
 		t.Fatal(err)
@@ -45,5 +46,77 @@ func Test(t *testing.T) {
 				t.Fatalf("expected %s, got %s", tt.want, decrypted)
 			}
 		})
+	}
+}
+
+func TestEncryptUsesUniqueNonces(t *testing.T) {
+	c, err := crypto.New("01234567890123456789012345678901")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	enc1, err := c.Encrypt("same plaintext")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	enc2, err := c.Encrypt("same plaintext")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if enc1 == enc2 {
+		t.Fatal("expected two encryptions of the same plaintext to produce different ciphertexts due to random nonces")
+	}
+}
+
+func TestDecryptRejectsInvalidData(t *testing.T) {
+	c, err := crypto.New("01234567890123456789012345678901")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "too short",
+			data: base64.StdEncoding.EncodeToString([]byte("too_short")),
+		},
+		{
+			name: "invalid base64",
+			data: "invalid-base64!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := c.Decrypt(tt.data); err == nil {
+				t.Fatal("expected decryption to fail")
+			}
+		})
+	}
+}
+
+func TestDecryptRejectsTampering(t *testing.T) {
+	c, err := crypto.New("01234567890123456789012345678901")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encrypted, err := c.Encrypt("authenticated data")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cipherText, err := base64.StdEncoding.DecodeString(encrypted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cipherText[len(cipherText)-1] ^= 1
+
+	if _, err := c.Decrypt(base64.StdEncoding.EncodeToString(cipherText)); err == nil {
+		t.Fatal("expected decryption to reject modified ciphertext")
 	}
 }


### PR DESCRIPTION
## Summary

- replace fixed-nonce AES-CTR with AES-GCM
- use a cryptographically random nonce for every encryption
- authenticate ciphertext and reject modified session values
- validate malformed and truncated encrypted payloads
- add regression coverage for round trips, nonce uniqueness, invalid input, and tampering

## Security assessment

The previous fixed CTR nonce reused the same keystream for every value encrypted with the same key. XORing two ciphertexts therefore exposed the XOR of their plaintexts. AES-GCM removes that reuse and adds integrity protection so ciphertext changes are detected before plaintext is returned.

The issue is valid, although its application-level severity is lower than critical because session JWTs are signed and active sessions are also checked against Redis.