### PR TITLE
fix: harden CSRF, HTTP headers, and production secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ docker compose -f compose.prod.yaml up -d
 ```
 
 Persist these two distinct values in your secret manager and reuse them across
-server restarts. Production startup rejects the known development placeholder
-and rejects reuse of one value for both purposes.
+server restarts. Production startup rejects empty values, the known development
+placeholder, and reuse of one value for both purposes.
 
 Production uses published images, internal service networking, resource limits,
 replicated workers, and a single Nginx entry point:

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Development defaults expose internal ports for debugging:
 ### Production Stack
 
 ```sh
+export CRYPTO_SECRET="$(openssl rand -hex 16)"
+export SERVER_CSRF_HMAC_SECRET="$(openssl rand -hex 32)"
 docker compose -f compose.prod.yaml up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ export SERVER_CSRF_HMAC_SECRET="$(openssl rand -hex 32)"
 docker compose -f compose.prod.yaml up -d
 ```
 
+Persist these two distinct values in your secret manager and reuse them across
+server restarts. Production startup rejects the known development placeholder
+and rejects reuse of one value for both purposes.
+
 Production uses published images, internal service networking, resource limits,
 replicated workers, and a single Nginx entry point:
 
@@ -150,9 +154,9 @@ The local strategy is a single-node, self-contained Kubernetes setup for
 validation with kind/minikube-style clusters. The production strategy is the
 self-hosted Chronoverse stack on your Kubernetes infrastructure: services,
 workers, PostgreSQL, Redis, Kafka, ClickHouse, Meilisearch, runtime-agent, and
-storage all run under your cluster. The setup script preserves complete
-operator-provided Secrets, rejects partial production TLS trust chains, and
-generates missing bootstrap material. See
+storage all run under your cluster. The setup script preserves valid, complete
+operator-provided Secrets, rejects partial production TLS trust chains and
+insecure or reused server secrets, and generates missing bootstrap material. See
 [infra/k8s/README.md](./infra/k8s/README.md), [configuration](./docs/configuration.md),
 and [operations](./docs/operations.md).
 

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1480,6 +1480,8 @@ services:
     image: ghcr.io/hitesh22rana/chronoverse/server:latest
     container_name: server
     environment:
+      CRYPTO_SECRET: "${CRYPTO_SECRET:?set CRYPTO_SECRET to a persistent random 32-byte value}"
+      SERVER_CSRF_HMAC_SECRET: "${SERVER_CSRF_HMAC_SECRET:?set SERVER_CSRF_HMAC_SECRET to a different persistent random value}"
       SERVER_HOST: 0.0.0.0
       SERVER_ALLOWED_ORIGINS: "http://0.0.0.0:80,"
       REDIS_HOST: redis

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -186,11 +186,14 @@ expected operating conditions.
 - The Kubernetes local overlay generates development certificates into a local
   certificate PVC. Production mounts Kubernetes Secrets for auth keys, CA
   material, client TLS, service TLS, infrastructure TLS, Kafka stores, and
-  datastore credentials. The setup script preserves complete operator-provided
+  datastore credentials. The setup script preserves valid, complete operator-provided
   Secrets and can generate a missing fallback set; partial internal TLS trust
   chains are rejected.
 - PostgreSQL, ClickHouse, Redis, Meilisearch, Kafka, and gRPC services run with
   TLS or mTLS in compose.
-- The HTTP server uses encrypted session cookies, CSRF cookies, and service JWT
-  metadata for downstream gRPC calls.
+- The HTTP server uses encrypted session cookies, constant-time CSRF HMAC
+  verification, browser security response headers, and service JWT metadata for
+  downstream gRPC calls.
+- Production startup rejects the known development secret placeholder and
+  rejects reuse of one value for encryption and CSRF signing.
 - Services and workers export OpenTelemetry data to `lgtm:4317`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -393,8 +393,8 @@ production environments should manage:
 - Database passwords and `MEILISEARCH_MASTER_KEY`.
 - Public hostnames, allowed origins, and same-site cookie policy.
 
-Production startup rejects the known development placeholder and also rejects
-deployments that reuse one value for `CRYPTO_SECRET` and
+Production startup rejects an empty CSRF HMAC secret, the known development
+placeholder, and deployments that reuse one value for `CRYPTO_SECRET` and
 `SERVER_CSRF_HMAC_SECRET`. Persist distinct random values in your secret
 manager. The production Compose profile requires both variables explicitly.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -393,10 +393,16 @@ production environments should manage:
 - Database passwords and `MEILISEARCH_MASTER_KEY`.
 - Public hostnames, allowed origins, and same-site cookie policy.
 
+Production startup rejects the known development placeholder and also rejects
+deployments that reuse one value for `CRYPTO_SECRET` and
+`SERVER_CSRF_HMAC_SECRET`. Persist distinct random values in your secret
+manager. The production Compose profile requires both variables explicitly.
+
 Kubernetes production deployments may pre-create these Secrets to own their
 credentials and trust material. `scripts/k8s/setup.sh` preserves complete
 operator-provided Secrets and generates missing bootstrap material; it rejects
-partial Secrets and partial internal TLS trust chains:
+partial Secrets, insecure server secret placeholders, reused server secrets,
+and partial internal TLS trust chains:
 
 - `postgres-secret`: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`
 - `clickhouse-secret`: `CLICKHOUSE_PASSWORD`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ scripts/k8s/setup.sh --mode local
 scripts/k8s/setup.sh --mode production
 ```
 
-The setup script preserves complete pre-created Secrets and generates missing
+The setup script preserves valid, complete pre-created Secrets and generates missing
 bootstrap material. Patch public URLs and allowed origins for your deployment
 before exposing the HTTP entrypoint.
 
@@ -399,7 +399,7 @@ deployments that reuse one value for `CRYPTO_SECRET` and
 manager. The production Compose profile requires both variables explicitly.
 
 Kubernetes production deployments may pre-create these Secrets to own their
-credentials and trust material. `scripts/k8s/setup.sh` preserves complete
+credentials and trust material. `scripts/k8s/setup.sh` preserves valid, complete
 operator-provided Secrets and generates missing bootstrap material; it rejects
 partial Secrets, insecure server secret placeholders, reused server secrets,
 and partial internal TLS trust chains:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,8 +24,13 @@ ports for debugging.
 ### Production
 
 ```sh
+export CRYPTO_SECRET="$(openssl rand -hex 16)"
+export SERVER_CSRF_HMAC_SECRET="$(openssl rand -hex 32)"
 docker compose -f compose.prod.yaml up -d
 ```
+
+Persist these two distinct values in your secret manager and reuse them across
+server restarts.
 
 Useful endpoints:
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -90,13 +90,20 @@ scripts/k8s/setup.sh --mode local
 
 ## Secrets
 
-The setup script checks required Secrets before applying manifests. Complete
+The setup script checks required Secrets before applying manifests. Valid, complete
 operator-provided Secrets are preserved and never overwritten. Missing Secrets
 are generated and created. Partial Secrets fail with a clear missing-key error.
 Local generated data-store credentials are deterministic development defaults
 so retained hostPath data can survive a resource delete/recreate without
 drifting away from regenerated Secrets. Production generated fallback
 credentials remain random.
+
+For `chronoverse-server-security`, the setup script additionally rejects the
+known development placeholder, rejects reuse of one value for
+`CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET`, and requires
+`CRYPTO_SECRET` to be exactly 32 bytes. An invalid local Secret is replaced with
+the safe local values; an invalid production Secret stops setup so the operator
+can correct it.
 
 Production Secrets include:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,11 @@ package config
 
 import "time"
 
-const envPrefix = ""
+const (
+	envPrefix             = ""
+	productionEnvironment = "production"
+	insecureDefaultSecret = "a&1*~#^2^#!@#$%^&*()-_=+{}[]|<>?" //nolint:gosec // This known placeholder is explicitly rejected in production.
+)
 
 // Environment holds the environment configuration.
 type Environment struct {

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -59,6 +59,9 @@ func validateServerSecrets(cfg *ServerConfig) error {
 	if cfg.Secret == insecureDefaultSecret {
 		return errors.New("CRYPTO_SECRET must not use the insecure development default in production")
 	}
+	if cfg.CSRFHMACSecret == "" {
+		return errors.New("SERVER_CSRF_HMAC_SECRET must not be empty in production")
+	}
 	if cfg.CSRFHMACSecret == insecureDefaultSecret {
 		return errors.New("SERVER_CSRF_HMAC_SECRET must not use the insecure development default in production")
 	}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -44,5 +45,26 @@ func InitServerConfig() (*ServerConfig, error) {
 	if err := envconfig.Process(envPrefix, &cfg); err != nil {
 		return nil, err
 	}
+	if err := validateServerSecrets(&cfg); err != nil {
+		return nil, err
+	}
 	return &cfg, nil
+}
+
+func validateServerSecrets(cfg *ServerConfig) error {
+	if cfg.Env != productionEnvironment {
+		return nil
+	}
+
+	if cfg.Secret == insecureDefaultSecret {
+		return errors.New("CRYPTO_SECRET must not use the insecure development default in production")
+	}
+	if cfg.CSRFHMACSecret == insecureDefaultSecret {
+		return errors.New("SERVER_CSRF_HMAC_SECRET must not use the insecure development default in production")
+	}
+	if cfg.Secret == cfg.CSRFHMACSecret {
+		return errors.New("CRYPTO_SECRET and SERVER_CSRF_HMAC_SECRET must be different in production")
+	}
+
+	return nil
 }

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -40,6 +40,13 @@ func TestValidateServerSecrets(t *testing.T) {
 			wantErr:     true,
 		},
 		{
+			name:        "production csrf secret is empty",
+			environment: productionEnvironment,
+			crypto:      "0123456789abcdef0123456789abcdef",
+			csrf:        "",
+			wantErr:     true,
+		},
+		{
 			name:        "production secrets are reused",
 			environment: productionEnvironment,
 			crypto:      "0123456789abcdef0123456789abcdef",

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -1,0 +1,70 @@
+//nolint:testpackage // Tests unexported configuration validation directly.
+package config
+
+import "testing"
+
+func TestValidateServerSecrets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		environment string
+		crypto      string
+		csrf        string
+		wantErr     bool
+	}{
+		{
+			name:        "development defaults remain available",
+			environment: "development",
+			crypto:      insecureDefaultSecret,
+			csrf:        insecureDefaultSecret,
+		},
+		{
+			name:        "production secrets are distinct",
+			environment: productionEnvironment,
+			crypto:      "0123456789abcdef0123456789abcdef",
+			csrf:        "abcdef0123456789abcdef0123456789",
+		},
+		{
+			name:        "production crypto secret uses default",
+			environment: productionEnvironment,
+			crypto:      insecureDefaultSecret,
+			csrf:        "abcdef0123456789abcdef0123456789",
+			wantErr:     true,
+		},
+		{
+			name:        "production csrf secret uses default",
+			environment: productionEnvironment,
+			crypto:      "0123456789abcdef0123456789abcdef",
+			csrf:        insecureDefaultSecret,
+			wantErr:     true,
+		},
+		{
+			name:        "production secrets are reused",
+			environment: productionEnvironment,
+			crypto:      "0123456789abcdef0123456789abcdef",
+			csrf:        "0123456789abcdef0123456789abcdef",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &ServerConfig{
+				Environment: Environment{Env: tt.environment},
+				Crypto:      Crypto{Secret: tt.crypto},
+				Server:      Server{CSRFHMACSecret: tt.csrf},
+			}
+
+			err := validateServerSecrets(cfg)
+			if tt.wantErr && err == nil {
+				t.Fatal("validateServerSecrets() error = nil, want an error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateServerSecrets() error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/server/csrf.go
+++ b/internal/server/csrf.go
@@ -48,7 +48,7 @@ func verifyCSRFToken(csrfToken, session, secret string, maxAge time.Duration) er
 		return err
 	}
 
-	if sha != expectedSHA {
+	if !hmac.Equal([]byte(sha), []byte(expectedSHA)) {
 		return status.Error(codes.InvalidArgument, "invalid csrf token")
 	}
 

--- a/internal/server/csrf_test.go
+++ b/internal/server/csrf_test.go
@@ -1,0 +1,30 @@
+//nolint:testpackage // Tests unexported CSRF helpers directly.
+package server
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestVerifyCSRFToken(t *testing.T) {
+	const (
+		session = "session-token"
+		hmacKey = "test-hmac-key"
+	)
+
+	token, err := generateCSRFToken(session, hmacKey)
+	if err != nil {
+		t.Fatalf("generateCSRFToken() error = %v", err)
+	}
+
+	if err := verifyCSRFToken(token, session, hmacKey, time.Hour); err != nil {
+		t.Fatalf("verifyCSRFToken() error = %v", err)
+	}
+
+	parts := strings.Split(token, delimiter)
+	tamperedToken := strings.Repeat("0", len(parts[0])) + delimiter + parts[1]
+	if err := verifyCSRFToken(tamperedToken, session, hmacKey, time.Hour); err == nil {
+		t.Fatal("verifyCSRFToken() accepted a tampered token")
+	}
+}

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -66,6 +66,17 @@ func requestLogPath(r *http.Request) string {
 	return r.URL.Path
 }
 
+// withSecurityHeadersMiddleware adds browser security headers to all responses.
+func (s *Server) withSecurityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		next.ServeHTTP(w, r)
+	})
+}
+
 // withCORSMiddleware adds CORS headers to all responses.
 func (s *Server) withCORSMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/middlewares_test.go
+++ b/internal/server/middlewares_test.go
@@ -47,6 +47,37 @@ func TestCORSMiddlewareAllowsIdempotencyKeyHeader(t *testing.T) {
 	}
 }
 
+func TestSecurityHeadersMiddleware(t *testing.T) {
+	s := &Server{}
+	handlerCalled := false
+	handler := s.withSecurityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/health", http.NoBody))
+
+	if !handlerCalled {
+		t.Fatal("expected security headers middleware to call the next handler")
+	}
+	if res.Code != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %d", http.StatusAccepted, res.Code)
+	}
+
+	expectedHeaders := map[string]string{
+		"Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
+		"Referrer-Policy":         "no-referrer",
+		"X-Content-Type-Options":  "nosniff",
+		"X-Frame-Options":         "DENY",
+	}
+	for name, expected := range expectedHeaders {
+		if actual := res.Header().Get(name); actual != expected {
+			t.Errorf("expected %s header %q, got %q", name, expected, actual)
+		}
+	}
+}
+
 func TestOtelMiddlewareLogsTraceIdentifiers(t *testing.T) {
 	core, logs := observer.New(zapcore.InfoLevel)
 	tracerProvider := sdktrace.NewTracerProvider(

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,8 +140,10 @@ func New(
 	// Common middlewares
 	srv.httpServer.Handler = otelpkg.HTTPHandler(
 		srv.withRequestLoggingMiddleware(
-			srv.withCORSMiddleware(
-				srv.withCompressionMiddleware(router),
+			srv.withSecurityHeadersMiddleware(
+				srv.withCORSMiddleware(
+					srv.withCompressionMiddleware(router),
+				),
 			),
 		),
 		svcpkg.Info().GetName(),

--- a/scripts/k8s/setup.sh
+++ b/scripts/k8s/setup.sh
@@ -9,6 +9,7 @@ DRY_RUN=false
 SKIP_APPLY=false
 CREATE_KIND=false
 STORAGE_CLASS=""
+INSECURE_DEFAULT_SECRET='a&1*~#^2^#!@#$%^&*()-_=+{}[]|<>?'
 
 usage() {
   cat <<'EOF'
@@ -225,6 +226,15 @@ secret_decoded_length() {
   printf '%s' "$encoded" | openssl base64 -d -A | wc -c | tr -d ' '
 }
 
+secret_decoded_value() {
+  local name="$1"
+  local key="$2"
+  local encoded
+  encoded="$(kubectl_cmd -n "$NAMESPACE" get secret "$name" -o "go-template={{ index .data \"$key\" }}" 2>/dev/null || true)"
+  [ -n "$encoded" ] || return
+  printf '%s' "$encoded" | openssl base64 -d -A
+}
+
 apply_secret_yaml() {
   local yaml="$1"
   if [ "$DRY_RUN" = true ]; then
@@ -305,18 +315,30 @@ create_server_security_secret() {
   if secret_exists "$secret_name"; then
     validate_secret_complete "$secret_name"
 
-    local crypto_len
+    local crypto_len existing_crypto_secret existing_csrf_secret invalid_reason
     crypto_len="$(secret_decoded_length "$secret_name" CRYPTO_SECRET)"
-    if [ "$crypto_len" = "32" ]; then
+    existing_crypto_secret="$(secret_decoded_value "$secret_name" CRYPTO_SECRET)"
+    existing_csrf_secret="$(secret_decoded_value "$secret_name" SERVER_CSRF_HMAC_SECRET)"
+    invalid_reason=""
+
+    if [ "$existing_crypto_secret" = "$INSECURE_DEFAULT_SECRET" ] || [ "$existing_csrf_secret" = "$INSECURE_DEFAULT_SECRET" ]; then
+      invalid_reason="it contains the known insecure development placeholder"
+    elif [ "$existing_crypto_secret" = "$existing_csrf_secret" ]; then
+      invalid_reason="CRYPTO_SECRET and SERVER_CSRF_HMAC_SECRET must be different"
+    elif [ "$crypto_len" != "32" ]; then
+      invalid_reason="CRYPTO_SECRET is $crypto_len bytes; expected 32"
+    fi
+
+    if [ -z "$invalid_reason" ]; then
       info "Keeping existing complete secret $secret_name"
       return
     fi
 
     if [ "$MODE" != "local" ]; then
-      die "secret $secret_name has CRYPTO_SECRET length $crypto_len bytes; it must be exactly 32 bytes"
+      die "secret $secret_name is invalid: $invalid_reason"
     fi
 
-    info "Replacing invalid local secret $secret_name because CRYPTO_SECRET is $crypto_len bytes; expected 32"
+    info "Replacing invalid local secret $secret_name because $invalid_reason"
     if [ "$DRY_RUN" = true ]; then
       local yaml
       yaml="$(kubectl_cmd -n "$NAMESPACE" create secret generic "$secret_name" \

--- a/static/content/docs/deployment/configuration.mdx
+++ b/static/content/docs/deployment/configuration.mdx
@@ -10,6 +10,8 @@ All Go processes accept `ENV` as the runtime mode label. It defaults to `develop
 
 Host and timeouts use `SERVER_HOST`, `SERVER_PORT`, request/read/header/idle timeout values, request body limit, session and CSRF expiry, host URL, allowed origins, same-site mode, `SERVER_CSRF_HMAC_SECRET`, and `CRYPTO_SECRET`.
 
+Production requires persistent, distinct values for `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET`. Startup rejects the known development placeholder and reuse of one value for both purposes. The production Compose profile requires both variables explicitly; the Kubernetes setup workflow validates `chronoverse-server-security`.
+
 ## gRPC
 
 Servers use `GRPC_HOST`, `GRPC_PORT`, request timeout, and `GRPC_TLS_*`. Clients use per-service host, port, TLS enablement, CA path, plus shared client certificate and key paths.

--- a/static/content/docs/deployment/configuration.mdx
+++ b/static/content/docs/deployment/configuration.mdx
@@ -10,7 +10,7 @@ All Go processes accept `ENV` as the runtime mode label. It defaults to `develop
 
 Host and timeouts use `SERVER_HOST`, `SERVER_PORT`, request/read/header/idle timeout values, request body limit, session and CSRF expiry, host URL, allowed origins, same-site mode, `SERVER_CSRF_HMAC_SECRET`, and `CRYPTO_SECRET`.
 
-Production requires persistent, distinct values for `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET`. Startup rejects the known development placeholder and reuse of one value for both purposes. The production Compose profile requires both variables explicitly; the Kubernetes setup workflow validates `chronoverse-server-security`.
+Production requires persistent, distinct values for `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET`. Startup rejects empty values, the known development placeholder, and reuse of one value for both purposes. The production Compose profile requires both variables explicitly; the Kubernetes setup workflow validates `chronoverse-server-security`.
 
 ## gRPC
 

--- a/static/content/docs/deployment/kubernetes.mdx
+++ b/static/content/docs/deployment/kubernetes.mdx
@@ -13,7 +13,7 @@ scripts/k8s/setup.sh --mode production
 
 `production` is the self-hosted Chronoverse strategy for your Kubernetes infrastructure. It includes the same infrastructure dependencies in-cluster, plus production-oriented PVCs, HorizontalPodAutoscalers for stateless services and workers, runtime-agent, Docker proxy, migrations, and topic initialization.
 
-The script keeps complete operator-provided Secrets and generates only missing bootstrap material. Partial Secrets fail with a clear missing-key error.
+The script keeps valid, complete operator-provided Secrets and generates only missing bootstrap material. Partial Secrets fail with a clear missing-key error. For `chronoverse-server-security`, it also rejects the known development placeholder, rejects reuse of one value for `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET`, and requires `CRYPTO_SECRET` to be exactly 32 bytes.
 
 Useful non-interactive options include:
 
@@ -49,7 +49,7 @@ scripts/k8s/setup.sh --mode local
 
 ## Secrets and storage
 
-Production uses Kubernetes Secrets for credentials, server cookie/CSRF secrets, auth keys, CA material, Ingress TLS, service TLS, client mTLS, infrastructure TLS, and Kafka JKS material. You can pre-create those Secrets to control credentials and certificates. The setup script creates only missing non-TLS Secrets and never overwrites complete existing Secrets. Internal production TLS trust-chain Secrets are atomic: provide all of `chronoverse-ca`, `chronoverse-client-tls`, `chronoverse-service-tls`, `chronoverse-infra-tls`, and `chronoverse-kafka-tls`, or let setup generate the full fallback set. `chronoverse-ingress-tls` is edge TLS and can be managed independently. Local generated data-store credentials are deterministic development defaults so retained hostPath data can survive a resource delete/recreate without drifting away from regenerated Secrets; production generated fallback credentials remain random.
+Production uses Kubernetes Secrets for credentials, server cookie/CSRF secrets, auth keys, CA material, Ingress TLS, service TLS, client mTLS, infrastructure TLS, and Kafka JKS material. You can pre-create those Secrets to control credentials and certificates. The setup script creates only missing non-TLS Secrets and never overwrites valid, complete existing Secrets. Invalid local server-security Secrets are replaced with safe local values; invalid production server-security Secrets stop setup so the operator can correct them. Internal production TLS trust-chain Secrets are atomic: provide all of `chronoverse-ca`, `chronoverse-client-tls`, `chronoverse-service-tls`, `chronoverse-infra-tls`, and `chronoverse-kafka-tls`, or let setup generate the full fallback set. `chronoverse-ingress-tls` is edge TLS and can be managed independently. Local generated data-store credentials are deterministic development defaults so retained hostPath data can survive a resource delete/recreate without drifting away from regenerated Secrets; production generated fallback credentials remain random.
 
 The local strategy uses hostPath PVs for single-node validation. Those PVs use retained node-local paths; delete the kind cluster or clear those paths when you intentionally want an empty local data set. Production uses dynamic PVCs by default; provide `--storage-class <name>` to the setup script or rely on the cluster default StorageClass. Production requires dynamic storage; use the local strategy for single-node hostPath validation.
 

--- a/static/content/docs/deployment/production.mdx
+++ b/static/content/docs/deployment/production.mdx
@@ -8,7 +8,7 @@ export SERVER_CSRF_HMAC_SECRET="$(openssl rand -hex 32)"
 docker compose -f compose.prod.yaml up -d
 ```
 
-Persist these two distinct values in your secret manager and reuse them across server restarts. Production startup rejects the known development placeholder and reused server secrets.
+Persist these two distinct values in your secret manager and reuse them across server restarts. Production startup rejects empty values, the known development placeholder, and reused server secrets.
 
 For Kubernetes, use the setup script. It preserves valid, complete pre-created Secrets and generates missing bootstrap material:
 

--- a/static/content/docs/deployment/production.mdx
+++ b/static/content/docs/deployment/production.mdx
@@ -10,7 +10,7 @@ docker compose -f compose.prod.yaml up -d
 
 Persist these two distinct values in your secret manager and reuse them across server restarts. Production startup rejects the known development placeholder and reused server secrets.
 
-For Kubernetes, use the setup script. It preserves complete pre-created Secrets and generates missing bootstrap material:
+For Kubernetes, use the setup script. It preserves valid, complete pre-created Secrets and generates missing bootstrap material:
 
 ```bash
 scripts/k8s/setup.sh --mode production
@@ -49,7 +49,7 @@ The production profile declares replicated workers and resource reservations. Ef
 
 - Replace database and Meilisearch credentials.
 - Manage certificates and private keys with environment-specific controls.
-- Pre-create Kubernetes Secrets when you need operator-owned credentials or certificates; otherwise the setup script generates missing bootstrap material and never overwrites complete existing Secrets.
+- Pre-create Kubernetes Secrets when you need operator-owned credentials or certificates; otherwise the setup script generates missing bootstrap material and never overwrites valid, complete existing Secrets.
 - Configure the public host URL, allowed origins, secure cookies, and same-site policy.
 - Pin reviewed image tags instead of relying on mutable `latest` in controlled environments.
 - Restrict access to the LGTM dashboard.

--- a/static/content/docs/deployment/production.mdx
+++ b/static/content/docs/deployment/production.mdx
@@ -3,8 +3,12 @@
 ## Start
 
 ```bash
+export CRYPTO_SECRET="$(openssl rand -hex 16)"
+export SERVER_CSRF_HMAC_SECRET="$(openssl rand -hex 32)"
 docker compose -f compose.prod.yaml up -d
 ```
+
+Persist these two distinct values in your secret manager and reuse them across server restarts. Production startup rejects the known development placeholder and reused server secrets.
 
 For Kubernetes, use the setup script. It preserves complete pre-created Secrets and generates missing bootstrap material:
 

--- a/static/content/docs/deployment/security.mdx
+++ b/static/content/docs/deployment/security.mdx
@@ -4,7 +4,7 @@
 
 `init-certs` generates a local CA, server certificates, client certificates, Kafka keystore and truststore material, and Ed25519 authentication keys in the shared certificate volume.
 
-The Kubernetes local overlay uses the same bootstrap idea through Jobs and a local certificate PVC. The production setup script creates missing Kubernetes Secrets for bootstrap material and preserves complete operator-provided Secrets.
+The Kubernetes local overlay uses the same bootstrap idea through Jobs and a local certificate PVC. The production setup script creates missing Kubernetes Secrets for bootstrap material and preserves valid, complete operator-provided Secrets.
 
 ## Encrypted infrastructure
 
@@ -16,7 +16,9 @@ The HTTP gateway signs downstream authorization metadata. gRPC services validate
 
 ## Browser security
 
-Sessions are stored in encrypted cookies. Mutating browser requests require CSRF validation. CORS origins and same-site behavior are configurable.
+Sessions are stored in encrypted cookies. Mutating browser requests require CSRF validation, and token HMACs are compared in constant time. CORS origins and same-site behavior are configurable.
+
+The HTTP API adds `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, and an API-only Content Security Policy that disables resource loading and framing.
 
 ## Docker access
 
@@ -24,9 +26,9 @@ Execution components use a socket proxy with a narrow API surface instead of bro
 
 ## Production secrets
 
-Treat generated local material as a development convenience. Production should separately manage private keys, CA lifecycle, database credentials, Meilisearch master key, CSRF HMAC secret, encryption secret, hostnames, and certificate rotation.
+Treat generated local material as a development convenience. Production should separately manage private keys, CA lifecycle, database credentials, Meilisearch master key, CSRF HMAC secret, encryption secret, hostnames, and certificate rotation. `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET` must be persistent, distinct values; production startup rejects the known development placeholder and reuse of one value for both purposes.
 
-For Kubernetes, pre-create `chronoverse-server-security`, `chronoverse-auth`, `chronoverse-ca`, `chronoverse-ingress-tls`, `chronoverse-client-tls`, `chronoverse-service-tls`, `chronoverse-infra-tls`, `chronoverse-kafka-tls`, `postgres-secret`, `clickhouse-secret`, and `meilisearch-secret` when you need to bring your own material. Internal TLS trust-chain Secrets are treated as one atomic set; partial internal TLS material is rejected to avoid mixing certificates from different CAs. Ingress TLS is edge-facing and can be managed independently. Otherwise `scripts/k8s/setup.sh --mode production` generates missing fallback Secrets.
+For Kubernetes, pre-create `chronoverse-server-security`, `chronoverse-auth`, `chronoverse-ca`, `chronoverse-ingress-tls`, `chronoverse-client-tls`, `chronoverse-service-tls`, `chronoverse-infra-tls`, `chronoverse-kafka-tls`, `postgres-secret`, `clickhouse-secret`, and `meilisearch-secret` when you need to bring your own material. The setup script validates complete pre-created server-security Secrets before preserving them. Internal TLS trust-chain Secrets are treated as one atomic set; partial internal TLS material is rejected to avoid mixing certificates from different CAs. Ingress TLS is edge-facing and can be managed independently. Otherwise `scripts/k8s/setup.sh --mode production` generates missing fallback Secrets.
 
 <Callout title="Do not expose development ports" type="warning">
 The development profile publishes databases and gRPC services for debugging. That topology is not the production security boundary.

--- a/static/content/docs/engineering/service-boundaries.mdx
+++ b/static/content/docs/engineering/service-boundaries.mdx
@@ -2,7 +2,7 @@
 
 ## HTTP gateway
 
-The `server` process owns public HTTP concerns: method routing, request limits, CORS, compression, session validation, CSRF validation, idempotency headers, error mapping, and propagation of authorization metadata to gRPC.
+The `server` process owns public HTTP concerns: method routing, request limits, CORS, compression, browser security response headers, session validation, constant-time CSRF HMAC verification, idempotency headers, error mapping, and propagation of authorization metadata to gRPC.
 
 ## Users service
 
@@ -27,4 +27,3 @@ Reads user and workflow aggregates maintained by the analytics processor.
 ## Authorization boundary
 
 The HTTP gateway attaches service JWT metadata to downstream gRPC calls. Internal services validate the authorization context rather than trusting arbitrary callers on the network.
-


### PR DESCRIPTION
## Summary

- compare CSRF HMAC values with `hmac.Equal` and cover valid/tampered tokens
- add API-safe CSP, referrer, content-type, and framing response headers
- reject empty CSRF secrets, the known placeholder, and shared crypto/CSRF values in production
- require explicit production Compose secrets and reject insecure pre-created Kubernetes secrets
- document the behavior across the README, canonical docs, Kubernetes runbook, and static documentation site