### PR TITLE
Use headless Services for gRPC discovery

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,8 +41,10 @@ backups, and production sizing.
 
 These services expose gRPC ports `50051` through `50055` inside the stack. The
 development compose file also exposes those ports on the host for direct
-debugging. Kubernetes services expose the same ports inside the `chronoverse`
-namespace.
+debugging. Kubernetes exposes the five domain services through headless Services
+inside the `chronoverse` namespace. Their DNS records return ready Pod IPs so
+the gRPC clients' `round_robin` policy can balance calls across resolved
+replicas. The HTTP `server` and `dashboard` retain ordinary ClusterIP Services.
 
 ### Workers
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -70,21 +70,6 @@ allowing the gRPC clients' `round_robin` policy to balance calls across the
 resolved replicas. The public HTTP server and dashboard continue to use normal
 ClusterIP Services.
 
-Changing an existing Service from an allocated ClusterIP to `clusterIP: None`
-updates an immutable field. When upgrading a cluster created from an older
-manifest, schedule a short discovery interruption, delete only the five gRPC
-Service objects, and reapply the overlay:
-
-```sh
-kubectl -n chronoverse delete service \
-  users-service workflows-service jobs-service \
-  notifications-service analytics-service
-scripts/k8s/setup.sh --mode production
-```
-
-Deleting these Service objects does not delete their Deployments or Pods. Do
-not delete the `server`, `dashboard`, or data-store Services for this migration.
-
 Headless discovery makes the current replicas visible to gRPC. A healthy,
 long-lived gRPC-Go channel may not immediately re-resolve DNS solely because an
 HPA added a replica, so proactive endpoint refresh remains a separate scaling

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -62,6 +62,34 @@ kubectl apply -k infra/k8s/overlays/local
 kubectl apply -k infra/k8s/overlays/production
 ```
 
+## gRPC Service Discovery
+
+The users, workflows, jobs, notifications, and analytics Services are headless.
+Kubernetes DNS publishes their ready Pod IPs instead of one virtual ClusterIP,
+allowing the gRPC clients' `round_robin` policy to balance calls across the
+resolved replicas. The public HTTP server and dashboard continue to use normal
+ClusterIP Services.
+
+Changing an existing Service from an allocated ClusterIP to `clusterIP: None`
+updates an immutable field. When upgrading a cluster created from an older
+manifest, schedule a short discovery interruption, delete only the five gRPC
+Service objects, and reapply the overlay:
+
+```sh
+kubectl -n chronoverse delete service \
+  users-service workflows-service jobs-service \
+  notifications-service analytics-service
+scripts/k8s/setup.sh --mode production
+```
+
+Deleting these Service objects does not delete their Deployments or Pods. Do
+not delete the `server`, `dashboard`, or data-store Services for this migration.
+
+Headless discovery makes the current replicas visible to gRPC. A healthy,
+long-lived gRPC-Go channel may not immediately re-resolve DNS solely because an
+HPA added a replica, so proactive endpoint refresh remains a separate scaling
+improvement.
+
 ## Cluster Prerequisites
 
 Kubernetes does not include a generic `kubectl` command to create a cluster.

--- a/infra/k8s/base/services.yaml
+++ b/infra/k8s/base/services.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/component: backend
 spec:
   type: ClusterIP
+  clusterIP: None
   selector:
     app.kubernetes.io/name: users-service
   ports:
@@ -23,6 +24,7 @@ metadata:
     app.kubernetes.io/component: backend
 spec:
   type: ClusterIP
+  clusterIP: None
   selector:
     app.kubernetes.io/name: workflows-service
   ports:
@@ -39,6 +41,7 @@ metadata:
     app.kubernetes.io/component: backend
 spec:
   type: ClusterIP
+  clusterIP: None
   selector:
     app.kubernetes.io/name: jobs-service
   ports:
@@ -55,6 +58,7 @@ metadata:
     app.kubernetes.io/component: backend
 spec:
   type: ClusterIP
+  clusterIP: None
   selector:
     app.kubernetes.io/name: notifications-service
   ports:
@@ -71,6 +75,7 @@ metadata:
     app.kubernetes.io/component: backend
 spec:
   type: ClusterIP
+  clusterIP: None
   selector:
     app.kubernetes.io/name: analytics-service
   ports:
@@ -109,4 +114,3 @@ spec:
   - name: http
     port: 3000
     targetPort: http
-

--- a/static/content/docs/deployment/kubernetes.mdx
+++ b/static/content/docs/deployment/kubernetes.mdx
@@ -57,6 +57,27 @@ The local strategy uses hostPath PVs for single-node validation. Those PVs use r
 
 The local strategy runs one replica per app deployment. The production strategy includes CPU/memory HorizontalPodAutoscalers for app services and background workers. Install metrics-server or provide equivalent `autoscaling/v2` resource metrics before relying on HPAs.
 
+The five domain gRPC Services are headless. Their DNS records publish ready Pod
+IPs so the gRPC clients' `round_robin` policy can balance calls across resolved
+replicas; the HTTP server and dashboard retain normal ClusterIP Services. A
+healthy, long-lived gRPC-Go channel may not immediately re-resolve DNS solely
+because an HPA added a replica, so proactive endpoint refresh is a separate
+scaling concern.
+
+`clusterIP` is immutable. Before applying this version to a cluster created
+from older manifests, recreate only the five gRPC Service objects and then
+reapply the selected overlay:
+
+```bash
+kubectl -n chronoverse delete service \
+  users-service workflows-service jobs-service \
+  notifications-service analytics-service
+scripts/k8s/setup.sh --mode production
+```
+
+The Deployments and Pods are not deleted, but gRPC service discovery is briefly
+unavailable while the Service objects are recreated.
+
 Kafka-lag-driven worker scaling is not built into the Kustomize overlay. Use KEDA or a custom metrics adapter when worker count should follow topic lag.
 
 ## Startup behavior

--- a/static/content/docs/deployment/kubernetes.mdx
+++ b/static/content/docs/deployment/kubernetes.mdx
@@ -64,20 +64,6 @@ healthy, long-lived gRPC-Go channel may not immediately re-resolve DNS solely
 because an HPA added a replica, so proactive endpoint refresh is a separate
 scaling concern.
 
-`clusterIP` is immutable. Before applying this version to a cluster created
-from older manifests, recreate only the five gRPC Service objects and then
-reapply the selected overlay:
-
-```bash
-kubectl -n chronoverse delete service \
-  users-service workflows-service jobs-service \
-  notifications-service analytics-service
-scripts/k8s/setup.sh --mode production
-```
-
-The Deployments and Pods are not deleted, but gRPC service discovery is briefly
-unavailable while the Service objects are recreated.
-
 Kafka-lag-driven worker scaling is not built into the Kustomize overlay. Use KEDA or a custom metrics adapter when worker count should follow topic lag.
 
 ## Startup behavior

--- a/static/content/docs/internal/grpc-services.mdx
+++ b/static/content/docs/internal/grpc-services.mdx
@@ -27,3 +27,8 @@ User and workflow aggregate reads.
 ## Transport security
 
 Compose configures service certificates, client certificates, CA trust, and signed authorization metadata. Direct host exposure of development ports is for debugging, not a substitute for authenticated service calls.
+
+In Kubernetes, these five services use headless Service discovery. DNS returns
+ready Pod IPs to the gRPC clients, whose `round_robin` policy distributes calls
+across the resolved replicas instead of multiplexing every call through one
+ClusterIP connection.

--- a/static/public/llms-full.txt
+++ b/static/public/llms-full.txt
@@ -1254,6 +1254,27 @@ The local strategy uses hostPath PVs for single-node validation. Those PVs use r
 
 The local strategy runs one replica per app deployment. The production strategy includes CPU/memory HorizontalPodAutoscalers for app services and background workers. Install metrics-server or provide equivalent `autoscaling/v2` resource metrics before relying on HPAs.
 
+The five domain gRPC Services are headless. Their DNS records publish ready Pod
+IPs so the gRPC clients' `round_robin` policy can balance calls across resolved
+replicas; the HTTP server and dashboard retain normal ClusterIP Services. A
+healthy, long-lived gRPC-Go channel may not immediately re-resolve DNS solely
+because an HPA added a replica, so proactive endpoint refresh is a separate
+scaling concern.
+
+`clusterIP` is immutable. Before applying this version to a cluster created
+from older manifests, recreate only the five gRPC Service objects and then
+reapply the selected overlay:
+
+```bash
+kubectl -n chronoverse delete service \
+  users-service workflows-service jobs-service \
+  notifications-service analytics-service
+scripts/k8s/setup.sh --mode production
+```
+
+The Deployments and Pods are not deleted, but gRPC service discovery is briefly
+unavailable while the Service objects are recreated.
+
 Kafka-lag-driven worker scaling is not built into the Kustomize overlay. Use KEDA or a custom metrics adapter when worker count should follow topic lag.
 
 ## Startup behavior
@@ -2003,6 +2024,11 @@ User and workflow aggregate reads.
 ## Transport security
 
 Compose configures service certificates, client certificates, CA trust, and signed authorization metadata. Direct host exposure of development ports is for debugging, not a substitute for authenticated service calls.
+
+In Kubernetes, these five services use headless Service discovery. DNS returns
+ready Pod IPs to the gRPC clients, whose `round_robin` policy distributes calls
+across the resolved replicas instead of multiplexing every call through one
+ClusterIP connection.
 </doc>
 
 <doc title="Kafka events" path="./docs/internal/kafka-events/">

--- a/static/public/llms-full.txt
+++ b/static/public/llms-full.txt
@@ -1261,20 +1261,6 @@ healthy, long-lived gRPC-Go channel may not immediately re-resolve DNS solely
 because an HPA added a replica, so proactive endpoint refresh is a separate
 scaling concern.
 
-`clusterIP` is immutable. Before applying this version to a cluster created
-from older manifests, recreate only the five gRPC Service objects and then
-reapply the selected overlay:
-
-```bash
-kubectl -n chronoverse delete service \
-  users-service workflows-service jobs-service \
-  notifications-service analytics-service
-scripts/k8s/setup.sh --mode production
-```
-
-The Deployments and Pods are not deleted, but gRPC service discovery is briefly
-unavailable while the Service objects are recreated.
-
 Kafka-lag-driven worker scaling is not built into the Kustomize overlay. Use KEDA or a custom metrics adapter when worker count should follow topic lag.
 
 ## Startup behavior


### PR DESCRIPTION
## Description

Convert the five internal gRPC Kubernetes Services from allocated ClusterIPs to headless Services. Kubernetes DNS now exposes ready Pod IPs to the existing gRPC `round_robin` clients instead of presenting one virtual IP backed by a connection-level kube-proxy decision.

The HTTP server and dashboard remain ordinary ClusterIP Services. Documentation explains the headless discovery behavior and the remaining proactive DNS refresh consideration for HPA scale-up.

## Type of change

- [x] Bug fix
- [x] Documentation update