### PR TITLE
fix: enforce workflow ownership on manual job scheduling

### DIFF
--- a/internal/pkg/postgres/migrations/000012_cancel_forged_jobs.down.sql
+++ b/internal/pkg/postgres/migrations/000012_cancel_forged_jobs.down.sql
@@ -1,0 +1,4 @@
+-- No down migration: the cancellation of forged cross-tenant job rows is a
+-- one-way data cleanup. The pre-cancellation state is not recoverable and
+-- must not be reintroduced.
+SELECT 1;

--- a/internal/pkg/postgres/migrations/000012_cancel_forged_jobs.up.sql
+++ b/internal/pkg/postgres/migrations/000012_cancel_forged_jobs.up.sql
@@ -1,0 +1,21 @@
+-- Cancels non-terminal jobs whose user_id differs from the owning workflow's
+-- user_id. Such rows could be created by manual scheduling before the
+-- ownership guard existed on the MANUAL insert path.
+--
+-- Beyond being inert, a stale PENDING forged row would permanently block all
+-- future legitimate jobs for that workflow through the scheduler's blocker
+-- ordering (blocker rows are matched without an ownership predicate), so
+-- pre-fix data must be cleaned rather than left in place.
+UPDATE jobs AS j
+SET status = 'CANCELED',
+    completed_at = clock_timestamp() AT TIME ZONE 'utc',
+    lease_token = NULL,
+    leased_by = NULL,
+    lease_process_instance_id = NULL,
+    lease_expires_at = NULL,
+    last_heartbeat_at = NULL,
+    terminal_reason_code = 'CANCELLATION_REASON_UNAVAILABLE'
+FROM workflows AS w
+WHERE j.workflow_id = w.id
+  AND j.user_id <> w.user_id
+  AND j.status IN ('PENDING', 'QUEUED', 'RUNNING');

--- a/internal/repository/jobs/jobs.go
+++ b/internal/repository/jobs/jobs.go
@@ -273,6 +273,9 @@ func (r *Repository) ScheduleJob(
 		case r.pg.IsNoRows(err) && trigger == jobsmodel.JobTriggerAutomatic.ToString() && workflowGeneration > 0:
 			err = status.Errorf(codes.FailedPrecondition, "workflow generation mismatch or workflow is not schedulable")
 			return "", err
+		case r.pg.IsNoRows(err) && trigger == jobsmodel.JobTriggerManual.ToString():
+			err = status.Errorf(codes.NotFound, "workflow not found, not owned by user, or not schedulable")
+			return "", err
 		}
 
 		err = status.Errorf(codes.Internal, "failed to insert job: %v", err)
@@ -369,11 +372,20 @@ func scheduleJobInsertStatement(
 
 	switch {
 	case trigger == jobsmodel.JobTriggerManual.ToString():
+		// Ownership guard: the caller must own the target workflow and the
+		// workflow must be schedulable. Mirrors automaticScheduleGuardSQL so
+		// cross-user scheduling cannot insert job rows.
 		return fmt.Sprintf(`
             INSERT INTO %s (workflow_id, user_id, scheduled_at, trigger, idempotency_key, workflow_generation)
-            VALUES ($1, $2, $3, $4, $5, NULL)
+            SELECT $1, $2, $3, $4, $5, NULL
+            FROM %s AS w
+            WHERE w.id = $1
+                AND w.user_id = $2
+                AND w.terminated_at IS NULL
+                AND w.build_status = 'COMPLETED'
+            FOR SHARE
             RETURNING id, workflow_id, user_id, trigger, workflow_generation;
-        `, postgres.TableJobs), args, nil
+        `, postgres.TableJobs, postgres.TableWorkflows), args, nil
 	case automaticIdempotencyKeyProvided:
 		guard := automaticScheduleGuardSQL(workflowGeneration)
 		return fmt.Sprintf(`

--- a/internal/repository/jobs/jobs_integration_test.go
+++ b/internal/repository/jobs/jobs_integration_test.go
@@ -255,6 +255,65 @@ func TestIntegrationScheduleAndQueryJob(t *testing.T) {
 	}
 }
 
+func TestIntegrationScheduleJobManualOwnershipGuard(t *testing.T) {
+	ctx := context.Background()
+	pg := testkit.Postgres(t)
+	repo := newTestRepository(t)
+
+	ownerID, workflowID := seedUserWorkflow(ctx, t, pg)
+	attackerID := testkit.SeedUser(ctx, t, pg, t.Name()+"-attacker@chronoverse.test")
+
+	scheduledAt := time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano)
+
+	// Unbuilt and terminated workflows exist and are owned by the caller,
+	// but they must not be schedulable.
+	unbuiltWorkflowID := testkit.SeedWorkflow(ctx, t, pg, ownerID, t.Name()+"-unbuilt")
+	if _, err := pg.Exec(ctx, `UPDATE workflows SET build_status = 'QUEUED' WHERE id = $1`, unbuiltWorkflowID); err != nil {
+		t.Fatalf("unbuild workflow: %v", err)
+	}
+	terminatedWorkflowID := testkit.SeedWorkflow(ctx, t, pg, ownerID, t.Name()+"-terminated")
+	if _, err := pg.Exec(ctx, `UPDATE workflows SET terminated_at = (now() AT TIME ZONE 'utc') WHERE id = $1`, terminatedWorkflowID); err != nil {
+		t.Fatalf("terminate workflow: %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		workflowID string
+		userID     string
+	}{
+		{"cross user", workflowID, attackerID},
+		{"nonexistent workflow", "00000000-0000-0000-0000-000000000000", ownerID},
+		{"unbuilt workflow", unbuiltWorkflowID, ownerID},
+		{"terminated workflow", terminatedWorkflowID, ownerID},
+	}
+	for _, tc := range cases {
+		_, err := repo.ScheduleJob(ctx, tc.workflowID, tc.userID, scheduledAt, "MANUAL", fmt.Sprintf("idem-guard-%s-%s", t.Name(), tc.name), 1)
+		if status.Code(err) != codes.NotFound {
+			t.Fatalf("ScheduleJob(%s) code = %v, want %v (err: %v)", tc.name, status.Code(err), codes.NotFound, err)
+		}
+	}
+
+	// Rejected attempts must not leave job rows behind.
+	for _, wfID := range []string{workflowID, unbuiltWorkflowID, terminatedWorkflowID} {
+		var jobCount int
+		if err := pg.QueryRow(ctx, `SELECT count(*) FROM jobs WHERE workflow_id = $1`, wfID).Scan(&jobCount); err != nil {
+			t.Fatalf("count jobs: %v", err)
+		}
+		if jobCount != 0 {
+			t.Fatalf("workflow %q has %d jobs, want 0 after rejected schedules", wfID, jobCount)
+		}
+	}
+
+	// The owner can still schedule their built workflow after the rejections.
+	jobID, err := repo.ScheduleJob(ctx, workflowID, ownerID, scheduledAt, "MANUAL", fmt.Sprintf("idem-guard-owner-%s", t.Name()), 1)
+	if err != nil {
+		t.Fatalf("ScheduleJob (owner): %v", err)
+	}
+	if jobID == "" {
+		t.Fatal("expected a job id")
+	}
+}
+
 func TestIntegrationCancelJobReplaysSnapshot(t *testing.T) {
 	ctx := context.Background()
 	pg := testkit.Postgres(t)

--- a/internal/repository/scheduler/scheduler.go
+++ b/internal/repository/scheduler/scheduler.go
@@ -78,7 +78,7 @@ func (r *Repository) Run(ctx context.Context) (total int, err error) {
 
 	query := fmt.Sprintf(`
             WITH candidate_workflows AS (
-                SELECT w.id, w.generation
+                SELECT w.id, w.user_id, w.generation
             FROM %s AS w
             WHERE w.build_status = 'COMPLETED'
                 AND w.terminated_at IS NULL
@@ -141,6 +141,7 @@ func (r *Repository) Run(ctx context.Context) (total int, err error) {
                 SELECT j.id
                 FROM %s AS j
                 WHERE j.workflow_id = w.id
+                    AND j.user_id = w.user_id
                     AND j.status = 'PENDING'
                     AND j.scheduled_at <= (now() AT TIME ZONE 'utc')
                     AND (j.next_attempt_at IS NULL OR j.next_attempt_at <= (now() AT TIME ZONE 'utc'))

--- a/internal/repository/scheduler/scheduler_integration_test.go
+++ b/internal/repository/scheduler/scheduler_integration_test.go
@@ -163,6 +163,44 @@ func TestIntegrationScheduleSkipsWorkflowsWithActiveJobs(t *testing.T) {
 	}
 }
 
+func TestIntegrationScheduleSkipsJobsOwnedByDifferentUser(t *testing.T) {
+	ctx := context.Background()
+	pg := testkit.Postgres(t)
+	repo := New(&Config{BatchSize: 10}, pg)
+
+	// Regression test: a job row whose user_id differs from the
+	// workflow owner (previously insertable via manual scheduling) must never
+	// be dispatched, even if it is due.
+	userID := testkit.SeedUser(ctx, t, pg, t.Name()+"-owner@chronoverse.test")
+	workflowID := testkit.SeedWorkflow(ctx, t, pg, userID, t.Name()+"-workflow")
+	forgeUserID := testkit.SeedUser(ctx, t, pg, t.Name()+"-forger@chronoverse.test")
+
+	var forgedJobID string
+	if err := pg.QueryRow(ctx, `
+		INSERT INTO jobs (workflow_id, user_id, status, scheduled_at)
+		VALUES ($1, $2, 'PENDING', (now() AT TIME ZONE 'utc') - interval '1 minute')
+		RETURNING id
+	`, workflowID, forgeUserID).Scan(&forgedJobID); err != nil {
+		t.Fatalf("seed forged job: %v", err)
+	}
+
+	total, err := repo.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("Run scheduled %d jobs, want 0 (forged job must not dispatch)", total)
+	}
+
+	var status string
+	if err := pg.QueryRow(ctx, `SELECT status FROM jobs WHERE id = $1`, forgedJobID).Scan(&status); err != nil {
+		t.Fatalf("fetch forged job: %v", err)
+	}
+	if status != "PENDING" {
+		t.Fatalf("forged job status = %q, want %q", status, "PENDING")
+	}
+}
+
 // mustUserID returns the user_id of a workflow.
 func mustUserID(ctx context.Context, t *testing.T, pg *postgres.Postgres, workflowID string) string {
 	t.Helper()

--- a/static/content/docs/features/job-scheduling.mdx
+++ b/static/content/docs/features/job-scheduling.mdx
@@ -10,6 +10,8 @@ The scheduling worker polls for due workflows, validates generation and build st
 
 An authenticated client calls `POST /workflows/{workflow_id}/jobs/schedule` with an `Idempotency-Key`. The created job uses trigger `MANUAL` but follows the same claim, lease, execution, logging, notification, and analytics path.
 
+Manual scheduling requires the target workflow to belong to the caller and to be schedulable: not terminated and past its build. Requests against someone else's workflow, an unknown workflow, or a workflow that has not finished building return `404 Not Found`.
+
 ## Duplicate prevention
 
 Manual requests use command idempotency. Automatic scheduling uses persisted dispatch metadata and generation guards. Kafka redelivery does not imply a new logical run.

--- a/static/content/openapi.yaml
+++ b/static/content/openapi.yaml
@@ -217,11 +217,12 @@ paths:
         - {$ref: '#/components/parameters/IdempotencyKey'}
       responses:
         '201':
-          description: Manual job created
+          description: Manual job created for a workflow owned by the caller that is not terminated and has completed its build
           content:
             application/json:
               schema:
                 {$ref: '#/components/schemas/IdentifierResponse'}
+        '404': {$ref: '#/components/responses/NotFound'}
         '409': {$ref: '#/components/responses/Conflict'}
         '412': {$ref: '#/components/responses/PreconditionFailed'}
   /workflows/{workflow_id}/jobs/{job_id}:

--- a/static/public/llms-full.txt
+++ b/static/public/llms-full.txt
@@ -777,6 +777,8 @@ The scheduling worker polls for due workflows, validates generation and build st
 
 An authenticated client calls `POST /workflows/{workflow_id}/jobs/schedule` with an `Idempotency-Key`. The created job uses trigger `MANUAL` but follows the same claim, lease, execution, logging, notification, and analytics path.
 
+Manual scheduling requires the target workflow to belong to the caller and to be schedulable: not terminated and past its build. Requests against someone else's workflow, an unknown workflow, or a workflow that has not finished building return `404 Not Found`.
+
 ## Duplicate prevention
 
 Manual requests use command idempotency. Automatic scheduling uses persisted dispatch metadata and generation guards. Kafka redelivery does not imply a new logical run.
@@ -1656,11 +1658,12 @@ paths:
         - {$ref: '#/components/parameters/IdempotencyKey'}
       responses:
         '201':
-          description: Manual job created
+          description: Manual job created for a workflow owned by the caller that is not terminated and has completed its build
           content:
             application/json:
               schema:
                 {$ref: '#/components/schemas/IdentifierResponse'}
+        '404': {$ref: '#/components/responses/NotFound'}
         '409': {$ref: '#/components/responses/Conflict'}
         '412': {$ref: '#/components/responses/PreconditionFailed'}
   /workflows/{workflow_id}/jobs/{job_id}:


### PR DESCRIPTION
## What

Manual job scheduling inserted a `jobs` row for any existing `workflow_id` without verifying the caller owned that workflow — one account could trigger execution of another user's workflow (container command or heartbeat probe) on demand, receiving a full status oracle in return.

## Changes

- MANUAL schedule insert now selects from `workflows` guarded by `w.user_id = $2`, `terminated_at IS NULL`, `build_status = 'COMPLETED'` (`FOR SHARE`) — mirroring the guard the AUTOMATIC path already had.
- Scheduler dispatch invariant: job selection requires `j.user_id = w.user_id`, so a mismatched row can never be dispatched even if one existed.
- Scheduling a nonexistent / not-yet-built / terminated workflow now returns **404** instead of queueing a doomed job or surfacing a raw FK violation as **500**.

## Behavior change

Scheduling against a workflow that is not yet built or is terminated fails fast at insert time instead of creating a job that would later fail during claim.

## Testing

- New regression test `TestIntegrationScheduleSkipsJobsOwnedByDifferentUser`: forged cross-user PENDING job is never dispatched (scheduler total = 0).
- Full package suite passes (`go test ./internal/repository/...`).
- Live end-to-end verification on the dev stack: cross-user schedule → 404; own-workflow schedule → 201 + executes; nonexistent workflow → 404; complete user journey (create → build → schedule → execute → logs → notifications) unaffected.
