### PR TITLE
fix: make Grafana upgrades preserve auth hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,26 +111,41 @@ Development defaults expose internal ports for debugging:
 - Redis TLS: `6379`
 - Meilisearch HTTPS: `7700`
 - Kafka SSL/controller: `9094` / `9093`
-- LGTM dashboard: `http://localhost:3000`
+- LGTM Grafana: not host-published by default; OTLP gRPC remains available on
+  `4317`. For local UI access, use
+  `docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm`,
+  which binds Grafana to `127.0.0.1:${GRAFANA_HOST_PORT:-3000}`, or use
+  `kubectl port-forward svc/lgtm 3000:3000` with Kubernetes. Sign in with the
+  development default `admin` / `chronoverse-local-grafana-password`. After
+  upgrading an existing `lgtm:/data` volume, run
+  `scripts/grafana/reset-admin-password.sh`.
 
 ### Production Stack
 
 ```sh
 export CRYPTO_SECRET="$(openssl rand -hex 16)"
 export SERVER_CSRF_HMAC_SECRET="$(openssl rand -hex 32)"
+export GF_SECURITY_ADMIN_PASSWORD="$(openssl rand -hex 24)"
 docker compose -f compose.prod.yaml up -d
 ```
 
-Persist these two distinct values in your secret manager and reuse them across
-server restarts. Production startup rejects empty values, the known development
-placeholder, and reuse of one value for both purposes.
+Persist these values in your secret manager and reuse them across server
+restarts. `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET` must be distinct;
+production startup rejects empty values, the known development placeholder,
+and reuse of one value for both purposes.
 
 Production uses published images, internal service networking, resource limits,
 replicated workers, and a single Nginx entry point:
 
 - Dashboard and proxied API: `http://localhost`
 - API routes through Nginx: `/api/...`
-- LGTM dashboard: `http://localhost:3000`
+- LGTM Grafana: not host-published by default. Use
+  `docker compose -f compose.prod.yaml -f compose.grafana.yaml up -d lgtm` for
+  an opt-in loopback binding, or `kubectl port-forward svc/lgtm 3000:3000` for
+  Kubernetes. Compose uses `GF_SECURITY_ADMIN_USER` /
+  `GF_SECURITY_ADMIN_PASSWORD`; Kubernetes production uses `grafana-secret`.
+  Run `scripts/grafana/reset-admin-password.sh` after upgrading an existing
+  Compose `lgtm:/data` volume.
 
 Before running a real deployment, replace development secrets, default
 passwords, and generated local certificate assumptions with environment-specific

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Development defaults expose internal ports for debugging:
   `kubectl port-forward svc/lgtm 3000:3000` with Kubernetes. Sign in with the
   development default `admin` / `chronoverse-local-grafana-password`. After
   upgrading an existing `lgtm:/data` volume, run
-  `scripts/grafana/reset-admin-password.sh`.
+  `scripts/grafana/reset-admin-password.sh`; if its stored admin login is not
+  `admin`, set `GRAFANA_CURRENT_ADMIN_USER` to that login.
 
 ### Production Stack
 
@@ -145,7 +146,8 @@ replicated workers, and a single Nginx entry point:
   Kubernetes. Compose uses `GF_SECURITY_ADMIN_USER` /
   `GF_SECURITY_ADMIN_PASSWORD`; Kubernetes production uses `grafana-secret`.
   Run `scripts/grafana/reset-admin-password.sh` after upgrading an existing
-  Compose `lgtm:/data` volume.
+  Compose `lgtm:/data` volume, with `GRAFANA_CURRENT_ADMIN_USER` set when the
+  stored login is not the legacy default `admin`.
 
 Before running a real deployment, replace development secrets, default
 passwords, and generated local certificate assumptions with environment-specific

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -315,7 +315,6 @@ services:
     restart: on-failure
     volumes:
       - lgtm:/data
-      - otel-lgtm:/otel-lgtm
     ports:
       - "4317:4317"
     networks:
@@ -1639,7 +1638,6 @@ volumes:
   kafka:
   kafka-secrets:
   lgtm:
-  otel-lgtm:
 
 networks:
   # Dedicated network for tenant workload containers (VULN-004b). No platform

--- a/compose.grafana.yaml
+++ b/compose.grafana.yaml
@@ -4,6 +4,7 @@ name: chronoverse
 # This override publishes it only on loopback so it is not reachable from the LAN.
 # Usage:
 #   docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm
+#   docker compose -f compose.prod.yaml -f compose.grafana.yaml up -d lgtm
 #   # or for an arbitrary host port:
 #   GRAFANA_HOST_PORT=3002 docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm
 # Then open http://localhost:${GRAFANA_HOST_PORT:-3000} with GF_SECURITY_ADMIN_USER / GF_SECURITY_ADMIN_PASSWORD.

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -369,7 +369,6 @@ services:
     restart: on-failure
     volumes:
       - lgtm:/data
-      - otel-lgtm:/otel-lgtm
     networks:
       - chronoverse
 
@@ -1725,7 +1724,6 @@ volumes:
   kafka:
   kafka-secrets:
   lgtm:
-  otel-lgtm:
 
 networks:
   # Dedicated network for tenant workload containers (VULN-004b). No platform

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ Development builds local images and exposes internal ports for debugging:
 | Dashboard | `3001` | Next.js dashboard, built with `NEXT_PUBLIC_API_URL=http://localhost:8080` |
 | HTTP API | `8080` | Direct server access |
 | OTLP gRPC | `4317` | OpenTelemetry collector endpoint |
-| LGTM Grafana | — | Not host-published by default; use `kubectl port-forward svc/lgtm 3000:3000` (k8s) or `docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm` (`compose.grafana.yaml` publishes `127.0.0.1:${GRAFANA_HOST_PORT:-3000}:3000` on loopback). Anonymous access disabled (`GF_AUTH_ANONYMOUS_ENABLED=false`), authenticated via `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD` (dev defaults to `admin` / `chronoverse-local-grafana-password`, override via `GF_SECURITY_ADMIN_PASSWORD`). **Existing volumes**: Grafana sets `admin_password` only on first run (see `grafana/otel-lgtm` `run-grafana.sh`); after upgrading a persisted `lgtm:/data` volume, rotate with `docker compose exec lgtm grafana-cli admin reset-admin-password <new>` or `docker volume rm chronoverse_lgtm` (destroys dashboards) |
+| LGTM Grafana | — | Not host-published by default; use the loopback override or Kubernetes port-forward described in [Grafana access and Compose upgrades](#grafana-access-and-compose-upgrades). Anonymous access is disabled; development credentials default to `admin` / `chronoverse-local-grafana-password` |
 | PostgreSQL | `5432` | TLS-enabled database |
 | ClickHouse | `9440` | Secure native protocol |
 | Redis | `6379` | TLS-enabled Redis |
@@ -43,7 +43,41 @@ exposure is intentionally small:
 | Component | Host port | Notes |
 | --- | ---: | --- |
 | Nginx | `80` | Dashboard and `/api/...` reverse proxy |
-| LGTM Grafana | — | Not host-published. Access via SSH tunnel / `kubectl port-forward svc/lgtm 3000:3000`. Anonymous access disabled; credentials from `grafana-secret` (production) or `GF_SECURITY_ADMIN_PASSWORD` env (compose, required) |
+| LGTM Grafana | — | Not host-published by default. Access via the opt-in Compose loopback override or `kubectl port-forward`; anonymous access is disabled and production credentials come from `GF_SECURITY_ADMIN_PASSWORD` (Compose, required) or `grafana-secret` (Kubernetes) |
+
+### Grafana access and Compose upgrades
+
+Compose keeps Grafana private by default. To expose the UI only on the Docker
+host loopback interface, recreate `lgtm` with the opt-in override:
+
+```sh
+docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm
+# Production uses the same override and requires the production environment:
+docker compose -f compose.prod.yaml -f compose.grafana.yaml up -d lgtm
+```
+
+The host port defaults to `3000`; set `GRAFANA_HOST_PORT` to choose another.
+Kubernetes uses `kubectl port-forward svc/lgtm 3000:3000` instead.
+
+Grafana applies `GF_SECURITY_ADMIN_PASSWORD` only when it first creates its
+database. When upgrading an existing Compose `lgtm:/data` volume, first
+recreate the container from the updated Compose file. This detaches the old
+`/otel-lgtm` application volume so the pinned image supplies its hardened
+startup script and binaries. Then run the repository helper, which resets the
+database password from the container's configured
+`GF_SECURITY_ADMIN_PASSWORD` and verifies anonymous `401` plus authenticated
+`200` responses:
+
+```sh
+docker compose -f compose.dev.yaml up -d --force-recreate --no-deps lgtm
+# For production, use compose.prod.yaml with its required environment instead.
+scripts/grafana/reset-admin-password.sh
+```
+
+Set `GRAFANA_CONTAINER` when the container is not named `lgtm`. Do not remove
+the `lgtm` volume as an authentication migration: `/data` contains the Grafana
+database and dashboards together with persisted Prometheus metrics, Loki logs,
+Tempo traces, and Pyroscope profiles.
 
 Production Kafka topic partition defaults are:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,8 +65,9 @@ recreate the container from the updated Compose file. This detaches the old
 `/otel-lgtm` application volume so the pinned image supplies its hardened
 startup script and binaries. Then run the repository helper, which resets the
 database password from the container's configured
-`GF_SECURITY_ADMIN_PASSWORD` and verifies anonymous `401` plus authenticated
-`200` responses:
+`GF_SECURITY_ADMIN_PASSWORD`, migrates a legacy stored admin login to the
+configured `GF_SECURITY_ADMIN_USER`, and verifies anonymous `401` plus
+authenticated `200` responses:
 
 ```sh
 docker compose -f compose.dev.yaml up -d --force-recreate --no-deps lgtm
@@ -74,10 +75,19 @@ docker compose -f compose.dev.yaml up -d --force-recreate --no-deps lgtm
 scripts/grafana/reset-admin-password.sh
 ```
 
-Set `GRAFANA_CONTAINER` when the container is not named `lgtm`. Do not remove
-the `lgtm` volume as an authentication migration: `/data` contains the Grafana
-database and dashboards together with persisted Prometheus metrics, Loki logs,
-Tempo traces, and Pyroscope profiles.
+The helper assumes an old login of `admin` when the configured username does
+not already authenticate. If an existing database uses another login and you
+are changing it, supply that stored login explicitly:
+
+```sh
+GRAFANA_CURRENT_ADMIN_USER=old-login scripts/grafana/reset-admin-password.sh
+```
+
+Set `GRAFANA_CONTAINER` when the container is not named `lgtm`. Passwords are
+fed to Grafana through standard input, so values beginning with `-` are not
+parsed as CLI flags. Do not remove the `lgtm` volume as an authentication
+migration: `/data` contains the Grafana database and dashboards together with
+persisted Prometheus metrics, Loki logs, Tempo traces, and Pyroscope profiles.
 
 Production Kafka topic partition defaults are:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -15,7 +15,9 @@ Useful endpoints:
 
 - Dashboard: `http://localhost:3001`
 - API: `http://localhost:8080`
-- LGTM: `http://localhost:3000`
+- LGTM Grafana: not host-published by default; run
+  `docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm` for
+  loopback-only access on `http://127.0.0.1:${GRAFANA_HOST_PORT:-3000}`
 - gRPC: `localhost:50051` through `localhost:50055`
 
 Development builds local service images and exposes internal infrastructure
@@ -26,17 +28,19 @@ ports for debugging.
 ```sh
 export CRYPTO_SECRET="$(openssl rand -hex 16)"
 export SERVER_CSRF_HMAC_SECRET="$(openssl rand -hex 32)"
+export GF_SECURITY_ADMIN_PASSWORD="$(openssl rand -hex 24)"
 docker compose -f compose.prod.yaml up -d
 ```
 
-Persist these two distinct values in your secret manager and reuse them across
-server restarts.
+Persist these values in your secret manager and reuse them across server
+restarts. `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET` must be distinct.
 
 Useful endpoints:
 
 - Dashboard: `http://localhost`
 - API through Nginx: `http://localhost/api/...`
-- LGTM: `http://localhost:3000`
+- LGTM Grafana: not host-published by default; add `compose.grafana.yaml` for
+  opt-in loopback-only access
 
 Production uses published images, internal service ports, generated TLS
 configuration, resource limits, and replicated worker settings.

--- a/scripts/grafana/reset-admin-password.sh
+++ b/scripts/grafana/reset-admin-password.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 grafana_container="${GRAFANA_CONTAINER:-lgtm}"
+grafana_current_admin_user="${GRAFANA_CURRENT_ADMIN_USER:-admin}"
 
 die() {
   printf 'error: %s\n' "$*" >&2
@@ -26,7 +27,7 @@ if [ -n "$otel_lgtm_mount" ]; then
   die "Grafana container '$grafana_container' still mounts /otel-lgtm; recreate it with the updated Compose file first"
 fi
 
-docker exec "$grafana_container" /bin/sh -ec '
+docker exec -i "$grafana_container" /bin/sh -ec '
   test -n "${GF_SECURITY_ADMIN_USER:-}" || {
     echo "error: GF_SECURITY_ADMIN_USER is empty in the Grafana container" >&2
     exit 1
@@ -39,10 +40,63 @@ docker exec "$grafana_container" /bin/sh -ec '
     echo "error: Grafana executable is missing from the image" >&2
     exit 1
   }
-  exec /otel-lgtm/grafana/bin/grafana cli \
-    --homepath /otel-lgtm/grafana \
-    --configOverrides cfg:default.paths.data=/data/grafana/data \
-    admin reset-admin-password "$GF_SECURITY_ADMIN_PASSWORD"
+  printf "%s" "$GF_SECURITY_ADMIN_PASSWORD" | \
+    /otel-lgtm/grafana/bin/grafana cli \
+      --homepath /otel-lgtm/grafana \
+      --configOverrides cfg:default.paths.data=/data/grafana/data \
+      admin reset-admin-password --password-from-stdin
+'
+
+docker exec \
+  --env "GRAFANA_CURRENT_ADMIN_USER=$grafana_current_admin_user" \
+  "$grafana_container" /bin/sh -ec '
+  auth_status() {
+    curl --silent --show-error --output /dev/null --write-out "%{http_code}" \
+      --max-time 5 --user "$1:$GF_SECURITY_ADMIN_PASSWORD" \
+      http://127.0.0.1:3000/api/admin/settings
+  }
+
+  configured_status="$(auth_status "$GF_SECURITY_ADMIN_USER")"
+  if [ "$configured_status" = "200" ]; then
+    exit 0
+  fi
+
+  current_status="$(auth_status "$GRAFANA_CURRENT_ADMIN_USER")"
+  if [ "$current_status" != "200" ]; then
+    echo "error: neither GF_SECURITY_ADMIN_USER nor GRAFANA_CURRENT_ADMIN_USER authenticates after the password reset; set GRAFANA_CURRENT_ADMIN_USER to the login stored in the existing Grafana database" >&2
+    exit 1
+  fi
+
+  case "$GF_SECURITY_ADMIN_USER" in
+    *[![:print:]]*)
+      echo "error: GF_SECURITY_ADMIN_USER contains a control character and cannot be migrated safely" >&2
+      exit 1
+      ;;
+    *:*)
+      echo "error: GF_SECURITY_ADMIN_USER cannot contain a colon because Grafana Basic authentication uses it as a delimiter" >&2
+      exit 1
+      ;;
+  esac
+
+  escaped_admin_user="$(
+    printf "%s" "$GF_SECURITY_ADMIN_USER" |
+      sed -e "s/\\\\/\\\\\\\\/g" -e "s/\"/\\\\\"/g"
+  )"
+  update_payload="$(printf "{\"login\":\"%s\"}" "$escaped_admin_user")"
+  update_status="$(
+    curl --silent --show-error --output /dev/null --write-out "%{http_code}" \
+      --max-time 5 --user "$GRAFANA_CURRENT_ADMIN_USER:$GF_SECURITY_ADMIN_PASSWORD" \
+      --request PUT --header "Content-Type: application/json" \
+      --data-binary "$update_payload" \
+      http://127.0.0.1:3000/api/users/1
+  )"
+  if [ "$update_status" != "200" ]; then
+    echo "error: Grafana admin login migration returned HTTP $update_status, expected 200" >&2
+    exit 1
+  fi
+
+  printf "Grafana admin login migrated from %s to %s.\n" \
+    "$GRAFANA_CURRENT_ADMIN_USER" "$GF_SECURITY_ADMIN_USER"
 '
 
 anonymous_status="$(

--- a/scripts/grafana/reset-admin-password.sh
+++ b/scripts/grafana/reset-admin-password.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+grafana_container="${GRAFANA_CONTAINER:-lgtm}"
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+if ! docker container inspect "$grafana_container" >/dev/null 2>&1; then
+  die "Grafana container '$grafana_container' does not exist"
+fi
+
+if [ "$(docker container inspect --format '{{.State.Running}}' "$grafana_container")" != "true" ]; then
+  die "Grafana container '$grafana_container' is not running"
+fi
+
+otel_lgtm_mount="$(
+  docker container inspect \
+    --format '{{range .Mounts}}{{if eq .Destination "/otel-lgtm"}}{{.Type}}{{end}}{{end}}' \
+    "$grafana_container" 2>/dev/null
+)"
+if [ -n "$otel_lgtm_mount" ]; then
+  die "Grafana container '$grafana_container' still mounts /otel-lgtm; recreate it with the updated Compose file first"
+fi
+
+docker exec "$grafana_container" /bin/sh -ec '
+  test -n "${GF_SECURITY_ADMIN_USER:-}" || {
+    echo "error: GF_SECURITY_ADMIN_USER is empty in the Grafana container" >&2
+    exit 1
+  }
+  test -n "${GF_SECURITY_ADMIN_PASSWORD:-}" || {
+    echo "error: GF_SECURITY_ADMIN_PASSWORD is empty in the Grafana container" >&2
+    exit 1
+  }
+  test -x /otel-lgtm/grafana/bin/grafana || {
+    echo "error: Grafana executable is missing from the image" >&2
+    exit 1
+  }
+  exec /otel-lgtm/grafana/bin/grafana cli \
+    --homepath /otel-lgtm/grafana \
+    --configOverrides cfg:default.paths.data=/data/grafana/data \
+    admin reset-admin-password "$GF_SECURITY_ADMIN_PASSWORD"
+'
+
+anonymous_status="$(
+  docker exec "$grafana_container" /bin/sh -ec '
+    curl --silent --show-error --output /dev/null --write-out "%{http_code}" \
+      --max-time 5 http://127.0.0.1:3000/api/admin/settings
+  '
+)"
+authenticated_status="$(
+  docker exec "$grafana_container" /bin/sh -ec '
+    curl --silent --show-error --output /dev/null --write-out "%{http_code}" \
+      --max-time 5 --user "$GF_SECURITY_ADMIN_USER:$GF_SECURITY_ADMIN_PASSWORD" \
+      http://127.0.0.1:3000/api/admin/settings
+  '
+)"
+
+if [ "$anonymous_status" != "401" ]; then
+  die "anonymous Grafana admin request returned HTTP $anonymous_status, expected 401"
+fi
+if [ "$authenticated_status" != "200" ]; then
+  die "configured Grafana admin credentials returned HTTP $authenticated_status, expected 200"
+fi
+
+printf "Grafana admin password reset and authentication verified for container '%s'.\n" "$grafana_container"

--- a/static/content/docs/deployment/overview.mdx
+++ b/static/content/docs/deployment/overview.mdx
@@ -4,11 +4,16 @@ Chronoverse ships Docker Compose topologies and Kubernetes Kustomize overlays.
 
 ## Development
 
-`compose.dev.yaml` builds local images and exposes infrastructure, API, dashboard, gRPC, and observability ports for debugging.
+`compose.dev.yaml` builds local images and exposes infrastructure, API,
+dashboard, gRPC, and OTLP ports for debugging. Grafana is private by default;
+`compose.grafana.yaml` provides an opt-in loopback-only UI binding.
 
 ## Production
 
-`compose.prod.yaml` uses GHCR application images, keeps services on internal networks, applies resource constraints, runs replicated worker groups, and publishes Nginx plus the LGTM dashboard.
+`compose.prod.yaml` uses GHCR application images, keeps services on internal
+networks, applies resource constraints, runs replicated worker groups, and
+publishes only Nginx. Grafana remains internal unless the loopback override or
+a Kubernetes port-forward is used.
 
 `infra/k8s/overlays/local` provides a self-contained single-node Kubernetes profile for validation. `infra/k8s/overlays/production` provides the self-hosted Kubernetes deployment shape with in-cluster PostgreSQL, Redis, Kafka, ClickHouse, Meilisearch, runtime-agent, services, workers, dynamic PVCs, and HPAs.
 

--- a/static/content/docs/deployment/production.mdx
+++ b/static/content/docs/deployment/production.mdx
@@ -5,10 +5,14 @@
 ```bash
 export CRYPTO_SECRET="$(openssl rand -hex 16)"
 export SERVER_CSRF_HMAC_SECRET="$(openssl rand -hex 32)"
+export GF_SECURITY_ADMIN_PASSWORD="$(openssl rand -hex 24)"
 docker compose -f compose.prod.yaml up -d
 ```
 
-Persist these two distinct values in your secret manager and reuse them across server restarts. Production startup rejects empty values, the known development placeholder, and reused server secrets.
+Persist these values in your secret manager and reuse them across server
+restarts. `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET` must be distinct.
+Production startup rejects empty values, the known development placeholder, and
+reused server secrets.
 
 For Kubernetes, use the setup script. It preserves valid, complete pre-created Secrets and generates missing bootstrap material:
 

--- a/static/content/docs/operations/observability.mdx
+++ b/static/content/docs/operations/observability.mdx
@@ -33,10 +33,13 @@ scripts/grafana/reset-admin-password.sh
 
 The helper refuses containers that still mount the obsolete `/otel-lgtm`
 application volume. It uses Grafana's supported `grafana cli` command with the
-correct image home and data paths, then verifies anonymous requests return
-`401` and the configured credentials return `200`. Do not delete the `lgtm`
-volume for this migration: `/data` contains the Grafana database and dashboards,
-Prometheus metrics, Loki logs, Tempo traces, and Pyroscope profiles.
+correct image home and data paths, passes the password through standard input,
+and migrates the stored `admin` login to `GF_SECURITY_ADMIN_USER` when needed.
+If the stored login is not `admin`, run the helper with
+`GRAFANA_CURRENT_ADMIN_USER=old-login`. It then verifies anonymous requests
+return `401` and the configured credentials return `200`. Do not delete the
+`lgtm` volume for this migration: `/data` contains the Grafana database and
+dashboards, Prometheus metrics, Loki logs, Tempo traces, and Pyroscope profiles.
 
 ## Traces
 

--- a/static/content/docs/operations/observability.mdx
+++ b/static/content/docs/operations/observability.mdx
@@ -4,7 +4,39 @@ Chronoverse emits OpenTelemetry traces, metrics, and structured logs to the bund
 
 ## Collection
 
-Services and workers export over OTLP gRPC to `lgtm:4317`. The Grafana UI is available inside the `lgtm` container on port `3000` (not host-published by default; use `kubectl port-forward svc/lgtm 3000:3000` for k8s, or `docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm` for Compose — `compose.grafana.yaml` publishes `127.0.0.1:${GRAFANA_HOST_PORT:-3000}:3000` on loopback). Anonymous access is disabled (`GF_AUTH_ANONYMOUS_ENABLED=false`); authenticate with `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD`. For an existing `lgtm` volume, `admin_password` is only applied on first run — rotate with `docker compose exec lgtm grafana-cli admin reset-admin-password <new>` and verify anonymous `curl http://localhost:3000/api/admin/settings` returns `401` and the old `admin/admin` no longer works.
+Services and workers export over OTLP gRPC to `lgtm:4317`. The Grafana UI is
+available inside the `lgtm` container on port `3000`, but is not host-published
+by default. Anonymous access is disabled (`GF_AUTH_ANONYMOUS_ENABLED=false`);
+authenticate with `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD`.
+
+## Grafana access
+
+For Kubernetes, use `kubectl port-forward svc/lgtm 3000:3000`. For Compose, use
+the opt-in loopback override:
+
+```sh
+docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm
+```
+
+`compose.grafana.yaml` publishes
+`127.0.0.1:${GRAFANA_HOST_PORT:-3000}:3000`; it does not expose Grafana to the
+LAN.
+
+For an existing Compose `lgtm:/data` volume, recreate `lgtm` from the updated
+Compose file and reset the database credential from the configured container
+secret:
+
+```sh
+docker compose -f compose.dev.yaml up -d --force-recreate --no-deps lgtm
+scripts/grafana/reset-admin-password.sh
+```
+
+The helper refuses containers that still mount the obsolete `/otel-lgtm`
+application volume. It uses Grafana's supported `grafana cli` command with the
+correct image home and data paths, then verifies anonymous requests return
+`401` and the configured credentials return `200`. Do not delete the `lgtm`
+volume for this migration: `/data` contains the Grafana database and dashboards,
+Prometheus metrics, Loki logs, Tempo traces, and Pyroscope profiles.
 
 ## Traces
 

--- a/static/content/docs/quickstart.mdx
+++ b/static/content/docs/quickstart.mdx
@@ -28,8 +28,15 @@ The development endpoints are:
 | --- | --- |
 | Dashboard | `http://localhost:3001` |
 | HTTP API | `http://localhost:8080` |
-| LGTM | `http://localhost:3000` |
+| LGTM Grafana | Not host-published by default |
 | gRPC services | `localhost:50051` through `localhost:50055` |
+
+To open Grafana on the Docker host loopback interface, apply the opt-in
+override and sign in with `admin` / `chronoverse-local-grafana-password`:
+
+```bash
+docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm
+```
 
 <Callout title="Startup is dependency ordered" type="note">
 Certificates, infrastructure health, Kafka topics, and database migrations must complete before domain services and workers become ready.
@@ -42,4 +49,3 @@ docker compose -f compose.dev.yaml down
 ```
 
 Use `down -v` only when you intentionally want to delete local data and certificate volumes.
-

--- a/static/public/llms-full.txt
+++ b/static/public/llms-full.txt
@@ -2277,10 +2277,13 @@ scripts/grafana/reset-admin-password.sh
 
 The helper refuses containers that still mount the obsolete `/otel-lgtm`
 application volume. It uses Grafana's supported `grafana cli` command with the
-correct image home and data paths, then verifies anonymous requests return
-`401` and the configured credentials return `200`. Do not delete the `lgtm`
-volume for this migration: `/data` contains the Grafana database and dashboards,
-Prometheus metrics, Loki logs, Tempo traces, and Pyroscope profiles.
+correct image home and data paths, passes the password through standard input,
+and migrates the stored `admin` login to `GF_SECURITY_ADMIN_USER` when needed.
+If the stored login is not `admin`, run the helper with
+`GRAFANA_CURRENT_ADMIN_USER=old-login`. It then verifies anonymous requests
+return `401` and the configured credentials return `200`. Do not delete the
+`lgtm` volume for this migration: `/data` contains the Grafana database and
+dashboards, Prometheus metrics, Loki logs, Tempo traces, and Pyroscope profiles.
 
 ## Traces
 

--- a/static/public/llms-full.txt
+++ b/static/public/llms-full.txt
@@ -88,8 +88,15 @@ The development endpoints are:
 | --- | --- |
 | Dashboard | `http://localhost:3001` |
 | HTTP API | `http://localhost:8080` |
-| LGTM | `http://localhost:3000` |
+| LGTM Grafana | Not host-published by default |
 | gRPC services | `localhost:50051` through `localhost:50055` |
+
+To open Grafana on the Docker host loopback interface, apply the opt-in
+override and sign in with `admin` / `chronoverse-local-grafana-password`:
+
+```bash
+docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm
+```
 
 <Callout title="Startup is dependency ordered" type="note">
 Certificates, infrastructure health, Kafka topics, and database migrations must complete before domain services and workers become ready.
@@ -1076,11 +1083,16 @@ Chronoverse ships Docker Compose topologies and Kubernetes Kustomize overlays.
 
 ## Development
 
-`compose.dev.yaml` builds local images and exposes infrastructure, API, dashboard, gRPC, and observability ports for debugging.
+`compose.dev.yaml` builds local images and exposes infrastructure, API,
+dashboard, gRPC, and OTLP ports for debugging. Grafana is private by default;
+`compose.grafana.yaml` provides an opt-in loopback-only UI binding.
 
 ## Production
 
-`compose.prod.yaml` uses GHCR application images, keeps services on internal networks, applies resource constraints, runs replicated worker groups, and publishes Nginx plus the LGTM dashboard.
+`compose.prod.yaml` uses GHCR application images, keeps services on internal
+networks, applies resource constraints, runs replicated worker groups, and
+publishes only Nginx. Grafana remains internal unless the loopback override or
+a Kubernetes port-forward is used.
 
 `infra/k8s/overlays/local` provides a self-contained single-node Kubernetes profile for validation. `infra/k8s/overlays/production` provides the self-hosted Kubernetes deployment shape with in-cluster PostgreSQL, Redis, Kafka, ClickHouse, Meilisearch, runtime-agent, services, workers, dynamic PVCs, and HPAs.
 
@@ -1156,10 +1168,14 @@ This removes databases, Kafka data, and generated certificate volumes. Use it on
 ```bash
 export CRYPTO_SECRET="$(openssl rand -hex 16)"
 export SERVER_CSRF_HMAC_SECRET="$(openssl rand -hex 32)"
+export GF_SECURITY_ADMIN_PASSWORD="$(openssl rand -hex 24)"
 docker compose -f compose.prod.yaml up -d
 ```
 
-Persist these two distinct values in your secret manager and reuse them across server restarts. Production startup rejects empty values, the known development placeholder, and reused server secrets.
+Persist these values in your secret manager and reuse them across server
+restarts. `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET` must be distinct.
+Production startup rejects empty values, the known development placeholder, and
+reused server secrets.
 
 For Kubernetes, use the setup script. It preserves valid, complete pre-created Secrets and generates missing bootstrap material:
 
@@ -2232,7 +2248,39 @@ Chronoverse emits OpenTelemetry traces, metrics, and structured logs to the bund
 
 ## Collection
 
-Services and workers export over OTLP gRPC to `lgtm:4317`. The Grafana UI is available inside the `lgtm` container on port `3000` (not host-published by default; use `kubectl port-forward svc/lgtm 3000:3000` for k8s, or `docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm` for Compose — `compose.grafana.yaml` publishes `127.0.0.1:${GRAFANA_HOST_PORT:-3000}:3000` on loopback). Anonymous access is disabled (`GF_AUTH_ANONYMOUS_ENABLED=false`); authenticate with `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD`. For an existing `lgtm` volume, `admin_password` is only applied on first run — rotate with `docker compose exec lgtm grafana-cli admin reset-admin-password <new>` and verify anonymous `curl http://localhost:3000/api/admin/settings` returns `401` and the old `admin/admin` no longer works.
+Services and workers export over OTLP gRPC to `lgtm:4317`. The Grafana UI is
+available inside the `lgtm` container on port `3000`, but is not host-published
+by default. Anonymous access is disabled (`GF_AUTH_ANONYMOUS_ENABLED=false`);
+authenticate with `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD`.
+
+## Grafana access
+
+For Kubernetes, use `kubectl port-forward svc/lgtm 3000:3000`. For Compose, use
+the opt-in loopback override:
+
+```sh
+docker compose -f compose.dev.yaml -f compose.grafana.yaml up -d lgtm
+```
+
+`compose.grafana.yaml` publishes
+`127.0.0.1:${GRAFANA_HOST_PORT:-3000}:3000`; it does not expose Grafana to the
+LAN.
+
+For an existing Compose `lgtm:/data` volume, recreate `lgtm` from the updated
+Compose file and reset the database credential from the configured container
+secret:
+
+```sh
+docker compose -f compose.dev.yaml up -d --force-recreate --no-deps lgtm
+scripts/grafana/reset-admin-password.sh
+```
+
+The helper refuses containers that still mount the obsolete `/otel-lgtm`
+application volume. It uses Grafana's supported `grafana cli` command with the
+correct image home and data paths, then verifies anonymous requests return
+`401` and the configured credentials return `200`. Do not delete the `lgtm`
+volume for this migration: `/data` contains the Grafana database and dashboards,
+Prometheus metrics, Loki logs, Tempo traces, and Pyroscope profiles.
 
 ## Traces
 


### PR DESCRIPTION
## Summary

Stacked on #114. This closes the remaining Grafana upgrade gaps before #114 is merged.

- removes the `otel-lgtm:/otel-lgtm` application volume from development and production Compose so the pinned image supplies current startup scripts and binaries; `lgtm:/data` remains persistent for Grafana, Loki, Prometheus, Tempo, and Pyroscope data
- adds `scripts/grafana/reset-admin-password.sh` to reconcile an existing Grafana SQLite credential from the configured container secret, reject stale application-volume mounts, and verify anonymous HTTP 401 plus authenticated HTTP 200
- resets passwords with the supported `--password-from-stdin` path so leading-hyphen values are accepted
- migrates a persisted admin login to `GF_SECURITY_ADMIN_USER` through the container-local Grafana User API; legacy `admin` is automatic and custom stored logins use `GRAFANA_CURRENT_ADMIN_USER`
- corrects README, configuration, operations, quickstart, and deployment guidance for private-by-default Grafana access, the loopback-only override, required production credentials, and non-destructive upgrades
- regenerates LLM documentation

## Validation

- reproduced both review findings against `grafana/otel-lgtm:0.11.10` / Grafana 12.1.1 before changing the helper
- verified the pinned CLI exposes and accepts `--password-from-stdin`
- verified `PUT /api/users/1` with a login-only payload preserves the existing account fields and changes authentication to the configured login
- live persisted-volume upgrade: legacy `admin` to configured `ops` with a leading-hyphen password; old login 401, configured login 200, anonymous 401
- live persisted-volume upgrade from a non-default stored login using `GRAFANA_CURRENT_ADMIN_USER`; old login 401 and configured login 200
- stale `/otel-lgtm` mount rejection verified
- development/production Compose base and loopback override renders verified; no `/otel-lgtm` application mount remains
- `kubectl kustomize` base, local, and production renders pass
- `make lint`: 0 issues
- `make test/short`: pass
- `make build/all`: pass
- static `validate:docs` and `validate:llms`: pass
- all three commits signed and signature-verified