### PR TITLE
fix(security): isolate Compose private keys per consumer with restrictive ownership

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -12,7 +12,7 @@ services:
     restart: on-failure
     volumes:
       - postgres:/var/lib/postgresql
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/postgres:/certs/postgres:ro
       - ./certs/postgres/config:/etc/postgresql
@@ -48,7 +48,7 @@ services:
     volumes:
       - clickhouse:/var/lib/clickhouse
       - ./certs/clickhouse:/etc/clickhouse-server/certs:ro
-      - ./certs/ca:/etc/clickhouse-server/ca:ro
+      - ./certs/ca/ca.crt:/etc/clickhouse-server/ca/ca.crt:ro
       - ./certs/clickhouse/config:/etc/clickhouse-server/conf.d:ro
       - ./certs/clickhouse/clients/config.xml:/etc/clickhouse-client/config.xml:ro
     healthcheck:
@@ -75,7 +75,7 @@ services:
     restart: on-failure
     volumes:
       - redis:/data
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/redis:/certs/redis:ro
     command:
@@ -118,7 +118,7 @@ services:
       MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: true
     volumes:
       - meilisearch:/meili_data
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/meilisearch:/certs/meilisearch:ro
     depends_on:
@@ -383,7 +383,7 @@ services:
         - PUBLIC_KEY_PATH=certs/issuers/runtime-agent/auth.ed.pub
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/runtime-agent/auth.ed:/certs/issuers/runtime-agent/auth.ed:ro
@@ -537,6 +537,10 @@ services:
           -keystore /certs/kafka/kafka.truststore.jks \
           -storepass chronoverse -noprompt
 
+        # PKCS12 bundle holds the private key in transportable form; the JKS
+        # keystore above is the only runtime consumer, so remove it.
+        rm -f /certs/kafka/kafka.p12
+
         # Client certificate for mTLS
         echo "🔐 Generating client certificate for mTLS..."
         mkdir -p /certs/clients
@@ -564,23 +568,58 @@ services:
         echo "🔐 Setting permissions for all certificates..."
 
         chmod 444 /certs/ca/ca.crt
-        chmod 444 /certs/ca/ca.key
+        # CA private key signs certificates but is never needed at runtime
+        # (services mount only ca.crt now); root-only.
+        chmod 600 /certs/ca/ca.key
 
-        chmod 444 /certs/kafka/kafka.crt /certs/kafka/kafka.key /certs/kafka/kafka.keystore.jks /certs/kafka/kafka.truststore.jks
+        chmod 444 /certs/kafka/kafka.crt
+        # Kafka broker and topic bootstrap run as appuser (1000:1000).
+        chown 1000:1000 /certs/kafka/kafka.key /certs/kafka/kafka.keystore.jks /certs/kafka/kafka.truststore.jks
+        chmod 440 /certs/kafka/kafka.key /certs/kafka/kafka.keystore.jks /certs/kafka/kafka.truststore.jks
 
         echo "🔐 Creating Kafka keystore credentials files..."
         echo "chronoverse" > /certs/kafka/keystore_creds.txt
         echo "chronoverse" > /certs/kafka/truststore_creds.txt
         echo "chronoverse" > /certs/kafka/key_creds.txt
-        chmod 444 /certs/kafka/*_creds.txt
+        chown 1000:1000 /certs/kafka/*_creds.txt
+        chmod 440 /certs/kafka/*_creds.txt
 
         for svc in $$SERVICES; do
           chmod 444 /certs/$$svc/$$svc.crt
-          chmod 444 /certs/$$svc/$$svc.key
+          case "$$svc" in
+            clickhouse)
+              # ClickHouse key perms are set explicitly below (chown 101:101, chmod 640).
+              ;;
+            postgres)
+              # PostgreSQL server drops to postgres (70:70); entrypoint stays root.
+              chown 70:70 /certs/$$svc/$$svc.key
+              chmod 600 /certs/$$svc/$$svc.key
+              ;;
+            redis)
+              # Redis image ships a redis user (999:1000); keep group-readable.
+              chown 999:1000 /certs/$$svc/$$svc.key
+              chmod 440 /certs/$$svc/$$svc.key
+              ;;
+            kafka)
+              # Broker and topic bootstrap run as appuser (1000:1000).
+              chown 1000:1000 /certs/$$svc/$$svc.key
+              chmod 440 /certs/$$svc/$$svc.key
+              ;;
+            meilisearch)
+              # Meilisearch runs as root; root-only.
+              chmod 600 /certs/$$svc/$$svc.key
+              ;;
+            *)
+              # Chronoverse application services run as app (100:101).
+              chown 100:101 /certs/$$svc/$$svc.key
+              chmod 440 /certs/$$svc/$$svc.key
+              ;;
+          esac
         done
 
-        chmod 600 /certs/postgres/postgres.key
-        chmod 600 /certs/clients/client.key
+        # Shared mTLS client identity is consumed by UID 100 application containers.
+        chown 100:101 /certs/clients/client.key
+        chmod 440 /certs/clients/client.key
 
         chmod 444 /certs/clients/client.crt
 
@@ -731,7 +770,7 @@ services:
         - PUBLIC_KEY_PATH=certs/issuers/server/auth.ed.pub
     restart: "no"
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/server/auth.ed:/certs/issuers/server/auth.ed:ro
@@ -808,7 +847,7 @@ services:
       - "50051:50051"
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/users-service:/certs/users-service:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
@@ -897,7 +936,7 @@ services:
       - "50052:50052"
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/workflows-service:/certs/workflows-service:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
@@ -1006,7 +1045,7 @@ services:
       - "50053:50053"
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/jobs-service:/certs/jobs-service:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
@@ -1103,7 +1142,7 @@ services:
       - "50054:50054"
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/notifications-service:/certs/notifications-service:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
@@ -1187,7 +1226,7 @@ services:
       - "50055:50055"
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/analytics-service:/certs/analytics-service:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
@@ -1263,7 +1302,7 @@ services:
         - PUBLIC_KEY_PATH=certs/issuers/scheduling-worker/auth.ed.pub
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/scheduling-worker/auth.ed:/certs/issuers/scheduling-worker/auth.ed:ro
@@ -1363,7 +1402,7 @@ services:
         - PUBLIC_KEY_PATH=certs/issuers/workflow-worker/auth.ed.pub
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/workflow-worker/auth.ed:/certs/issuers/workflow-worker/auth.ed:ro
@@ -1487,7 +1526,7 @@ services:
         - PUBLIC_KEY_PATH=certs/issuers/execution-worker/auth.ed.pub
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/execution-worker/auth.ed:/certs/issuers/execution-worker/auth.ed:ro
@@ -1588,7 +1627,7 @@ services:
         - PUBLIC_KEY_PATH=certs/issuers/joblogs-processor/auth.ed.pub
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/joblogs-processor/auth.ed:/certs/issuers/joblogs-processor/auth.ed:ro
@@ -1669,7 +1708,7 @@ services:
         - PUBLIC_KEY_PATH=certs/issuers/analytics-processor/auth.ed.pub
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/analytics-processor/auth.ed:/certs/issuers/analytics-processor/auth.ed:ro
@@ -1745,7 +1784,7 @@ services:
         - PUBLIC_KEY_PATH=certs/issuers/outbox-relay/auth.ed.pub
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/outbox-relay/auth.ed:/certs/issuers/outbox-relay/auth.ed:ro
@@ -1834,7 +1873,7 @@ services:
       - "8080:8080"
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/server/auth.ed:/certs/issuers/server/auth.ed:ro

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -71,7 +71,7 @@ services:
     restart: on-failure
     volumes:
       - postgres:/var/lib/postgresql
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/postgres:/certs/postgres:ro
       - ./certs/postgres/config:/etc/postgresql
@@ -106,7 +106,7 @@ services:
     volumes:
       - clickhouse:/var/lib/clickhouse
       - ./certs/clickhouse:/etc/clickhouse-server/certs:ro
-      - ./certs/ca:/etc/clickhouse-server/ca:ro
+      - ./certs/ca/ca.crt:/etc/clickhouse-server/ca/ca.crt:ro
       - ./certs/clickhouse/config:/etc/clickhouse-server/conf.d:ro
       - ./certs/clickhouse/clients/config.xml:/etc/clickhouse-client/config.xml:ro
     healthcheck:
@@ -132,7 +132,7 @@ services:
     restart: on-failure
     volumes:
       - redis:/data
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/redis:/certs/redis:ro
     command:
@@ -174,7 +174,7 @@ services:
       ENV: production
     volumes:
       - meilisearch:/meili_data
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/meilisearch:/certs/meilisearch:ro
     depends_on:
@@ -438,7 +438,7 @@ services:
       '
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/runtime-agent/auth.ed:/certs/issuers/runtime-agent/auth.ed:ro
@@ -583,6 +583,10 @@ services:
           -keystore /certs/kafka/kafka.truststore.jks \
           -storepass chronoverse -noprompt
 
+        # PKCS12 bundle holds the private key in transportable form; the JKS
+        # keystore above is the only runtime consumer, so remove it.
+        rm -f /certs/kafka/kafka.p12
+
         # Client certificate for mTLS
         echo "🔐 Generating client certificate for mTLS..."
         mkdir -p /certs/clients
@@ -610,23 +614,58 @@ services:
         echo "🔐 Setting permissions for all certificates..."
 
         chmod 444 /certs/ca/ca.crt
-        chmod 444 /certs/ca/ca.key
+        # CA private key signs certificates but is never needed at runtime
+        # (services mount only ca.crt now); root-only.
+        chmod 600 /certs/ca/ca.key
 
-        chmod 444 /certs/kafka/kafka.crt /certs/kafka/kafka.key /certs/kafka/kafka.keystore.jks /certs/kafka/kafka.truststore.jks
+        chmod 444 /certs/kafka/kafka.crt
+        # Kafka broker and topic bootstrap run as appuser (1000:1000).
+        chown 1000:1000 /certs/kafka/kafka.key /certs/kafka/kafka.keystore.jks /certs/kafka/kafka.truststore.jks
+        chmod 440 /certs/kafka/kafka.key /certs/kafka/kafka.keystore.jks /certs/kafka/kafka.truststore.jks
 
         echo "🔐 Creating Kafka keystore credentials files..."
         echo "chronoverse" > /certs/kafka/keystore_creds.txt
         echo "chronoverse" > /certs/kafka/truststore_creds.txt
         echo "chronoverse" > /certs/kafka/key_creds.txt
-        chmod 444 /certs/kafka/*_creds.txt
+        chown 1000:1000 /certs/kafka/*_creds.txt
+        chmod 440 /certs/kafka/*_creds.txt
 
         for svc in $$SERVICES; do
           chmod 444 /certs/$$svc/$$svc.crt
-          chmod 444 /certs/$$svc/$$svc.key
+          case "$$svc" in
+            clickhouse)
+              # ClickHouse key perms are set explicitly below (chown 101:101, chmod 640).
+              ;;
+            postgres)
+              # PostgreSQL server drops to postgres (70:70); entrypoint stays root.
+              chown 70:70 /certs/$$svc/$$svc.key
+              chmod 600 /certs/$$svc/$$svc.key
+              ;;
+            redis)
+              # Redis image ships a redis user (999:1000); keep group-readable.
+              chown 999:1000 /certs/$$svc/$$svc.key
+              chmod 440 /certs/$$svc/$$svc.key
+              ;;
+            kafka)
+              # Broker and topic bootstrap run as appuser (1000:1000).
+              chown 1000:1000 /certs/$$svc/$$svc.key
+              chmod 440 /certs/$$svc/$$svc.key
+              ;;
+            meilisearch)
+              # Meilisearch runs as root; root-only.
+              chmod 600 /certs/$$svc/$$svc.key
+              ;;
+            *)
+              # Chronoverse application services run as app (100:101).
+              chown 100:101 /certs/$$svc/$$svc.key
+              chmod 440 /certs/$$svc/$$svc.key
+              ;;
+          esac
         done
 
-        chmod 600 /certs/postgres/postgres.key
-        chmod 600 /certs/clients/client.key
+        # Shared mTLS client identity is consumed by UID 100 application containers.
+        chown 100:101 /certs/clients/client.key
+        chmod 440 /certs/clients/client.key
 
         chmod 444 /certs/clients/client.crt
 
@@ -770,7 +809,7 @@ services:
       ENV: production
     restart: "no"
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/server/auth.ed:/certs/issuers/server/auth.ed:ro
@@ -837,7 +876,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/users-service:/certs/users-service:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
@@ -918,7 +957,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/workflows-service:/certs/workflows-service:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
@@ -1019,7 +1058,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/jobs-service:/certs/jobs-service:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
@@ -1107,7 +1146,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/notifications-service:/certs/notifications-service:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
@@ -1182,7 +1221,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/analytics-service:/certs/analytics-service:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
@@ -1250,7 +1289,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/scheduling-worker/auth.ed:/certs/issuers/scheduling-worker/auth.ed:ro
@@ -1343,7 +1382,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/workflow-worker/auth.ed:/certs/issuers/workflow-worker/auth.ed:ro
@@ -1461,7 +1500,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/execution-worker/auth.ed:/certs/issuers/execution-worker/auth.ed:ro
@@ -1555,7 +1594,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/joblogs-processor/auth.ed:/certs/issuers/joblogs-processor/auth.ed:ro
@@ -1628,7 +1667,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/analytics-processor/auth.ed:/certs/issuers/analytics-processor/auth.ed:ro
@@ -1696,7 +1735,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/outbox-relay/auth.ed:/certs/issuers/outbox-relay/auth.ed:ro
@@ -1778,7 +1817,7 @@ services:
       ENV: production
     restart: on-failure
     volumes:
-      - ./certs/ca:/certs/ca:ro
+      - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
       - ./certs/clients:/certs/clients:ro
       - ./certs/issuers/trusted.json:/certs/issuers/trusted.json:ro
       - ./certs/issuers/server/auth.ed:/certs/issuers/server/auth.ed:ro

--- a/scripts/compose/validate.sh
+++ b/scripts/compose/validate.sh
@@ -101,6 +101,13 @@ validate_compose() {
     exit 1
   fi
 
+  # No runtime service may mount the ./certs/ca directory (it holds ca.key);
+  # mount ca.crt as a file instead. init-certs needs the directory rw.
+  if jq -e '[.services | to_entries[] | select(.key != "init-certs") | .value.volumes // [] | any((.source // "") | endswith("/certs/ca"))] | any' "$output_file" >/dev/null; then
+    echo "$compose_file mounts ./certs/ca directory into a runtime service (exposes ca.key); mount ca.crt as a file" >&2
+    exit 1
+  fi
+
   if [ "$compose_file" = "compose.prod.yaml" ] && ! jq -e '
     .services as $services
     | ($services.clickhouse.healthcheck.test[1] | contains("$${CLICKHOUSE_PASSWORD}"))
@@ -243,6 +250,128 @@ validate_auth_bundle() {
 }
 
 validate_auth_bundle
+
+validate_key_permissions() {
+  # init-certs must give every private key an explicit owner and a
+  # restrictive mode (never world-readable).
+  for f in compose.dev.yaml compose.prod.yaml; do
+    for pattern in \
+      'chmod 600 /certs/ca/ca.key' \
+      'chown 70:70' \
+      'chown 999:1000' \
+      'chown 1000:1000' \
+      'chown 100:101 /certs/clients/client.key' \
+      'rm -f /certs/kafka/kafka.p12' \
+      'certs/ca/ca.crt:/certs/ca/ca.crt:ro' \
+    ; do
+      if ! grep -Fq "$pattern" "$root_dir/$f"; then
+        echo "$f init-certs missing private-key hardening ($pattern)" >&2
+        exit 1
+      fi
+    done
+    for bad in \
+      'chmod 444 /certs/ca/ca.key' \
+      'chmod 444 /certs/kafka/kafka.key' \
+      'chmod 444 /certs/$$svc/$$svc.key' \
+    ; do
+      if grep -Fq "$bad" "$root_dir/$f"; then
+        echo "$f leaves a private key world-readable ($bad)" >&2
+        exit 1
+      fi
+    done
+  done
+
+  # The checks below need a generated tree; CI checks out clean.
+  if [ ! -f "$root_dir/certs/ca/ca.key" ]; then
+    echo "note: ./certs not generated; skipping key permission smoke test"
+    return 0
+  fi
+
+  # Mode bits persist on every platform: no private key may be other-readable.
+  check_mode() {
+    # $1 = path relative to certs/, $2... = acceptable modes
+    rel="$1"; shift
+    f="$root_dir/certs/$rel"
+    if [ ! -f "$f" ]; then
+      echo "key permission smoke: missing $rel (regenerate with a fresh init-certs run)" >&2
+      exit 1
+    fi
+    got="$(file_permissions "$f")"
+    for want in "$@"; do
+      if [ "$got" = "$want" ]; then
+        return 0
+      fi
+    done
+    echo "key permission smoke: $rel has mode $got, want one of: $*" >&2
+    exit 1
+  }
+  for iss in "$root_dir"/certs/issuers/*/auth.ed; do
+    rel="issuers/$(basename "$(dirname "$iss")")/auth.ed"
+    check_mode "$rel" 440
+  done
+  check_mode ca/ca.key 600
+  check_mode kafka/kafka.key 440
+  check_mode kafka/kafka.keystore.jks 440
+  check_mode kafka/kafka.truststore.jks 440
+  for creds in "$root_dir"/certs/kafka/*_creds.txt; do
+    check_mode "kafka/$(basename "$creds")" 440
+  done
+  if [ -e "$root_dir/certs/kafka/kafka.p12" ]; then
+    echo "key permission smoke: kafka.p12 transport bundle should be removed after import" >&2
+    exit 1
+  fi
+  check_mode postgres/postgres.key 600
+  check_mode redis/redis.key 440
+  check_mode meilisearch/meilisearch.key 600
+  check_mode clients/client.key 440
+  for svc in users-service workflows-service jobs-service notifications-service analytics-service; do
+    check_mode "$svc/$svc.key" 440
+    check_mode "$svc/$svc.crt" 444
+  done
+  check_mode clickhouse/clickhouse.key 640
+  check_mode clickhouse/clients/client.key 640
+
+  # Ownership does not survive macOS bind mounts (observed non-deterministic
+  # there), so UID readability checks only enforce on Linux; modes persist
+  # everywhere and are always checked.
+  if [ "$(uname -s)" != "Linux" ]; then
+    echo "note: skipping UID readability checks (require Linux bind-mount enforcement)"
+    return 0
+  fi
+  if ! docker run --rm alpine:3.22 true >/dev/null 2>&1; then
+    echo "note: docker unavailable for UID readability checks; skipping"
+    return 0
+  fi
+  check_can_read() {
+    # $1 = uid:gid, $2... = paths relative to certs/
+    id="$1"; shift
+    for rel in "$@"; do
+      if ! docker run --rm -u "$id" -v "$root_dir/certs:/certs:ro" alpine:3.22 test -r "/certs/$rel" >/dev/null 2>&1; then
+        echo "key permission smoke: $id cannot read $rel" >&2
+        exit 1
+      fi
+    done
+  }
+  check_cannot_read() {
+    id="$1"; shift
+    for rel in "$@"; do
+      if docker run --rm -u "$id" -v "$root_dir/certs:/certs:ro" alpine:3.22 test -r "/certs/$rel" >/dev/null 2>&1; then
+        echo "key permission smoke: $id can read $rel (should be denied)" >&2
+        exit 1
+      fi
+    done
+  }
+  check_can_read 100:101 issuers/users-service/auth.ed issuers/trusted.json clients/client.key clients/client.crt ca/ca.crt users-service/users-service.key users-service/users-service.crt
+  check_cannot_read 100:101 ca/ca.key postgres/postgres.key
+  check_can_read 70:70 postgres/postgres.key postgres/postgres.crt ca/ca.crt
+  check_cannot_read 70:70 clients/client.key issuers/users-service/auth.ed
+  check_can_read 1000:1000 kafka/kafka.keystore.jks kafka/keystore_creds.txt
+  check_cannot_read 1000:1000 clients/client.key
+  check_can_read 101:101 clickhouse/clickhouse.key
+  check_can_read 999:1000 redis/redis.key
+}
+
+validate_key_permissions
 
 validate_rotate_helper() {
 	# Previous quoting regression (5f4da2b4): echo "..." inside run_in_certs "..."

--- a/scripts/compose/validate.sh
+++ b/scripts/compose/validate.sh
@@ -283,7 +283,9 @@ validate_key_permissions() {
 
   # The checks below need a generated tree; CI checks out clean.
   if [ ! -f "$root_dir/certs/ca/ca.key" ]; then
-    echo "note: ./certs not generated; skipping key permission smoke test"
+    # Static ownership/mode pins above run everywhere including CI; the live
+    # tree checks below are local verification where certs were generated.
+    echo "note: ./certs not generated; skipping live key permission smoke test"
     return 0
   fi
 
@@ -335,7 +337,7 @@ validate_key_permissions() {
   # there), so UID readability checks only enforce on Linux; modes persist
   # everywhere and are always checked.
   if [ "$(uname -s)" != "Linux" ]; then
-    echo "note: skipping UID readability checks (require Linux bind-mount enforcement)"
+    echo "note: skipping UID readability checks on non-Linux (mode checks above still apply)"
     return 0
   fi
   if ! docker run --rm alpine:3.22 true >/dev/null 2>&1; then


### PR DESCRIPTION
Replaces world-readable private-key permissions in the Compose `init-certs` job with explicit per-consumer ownership, rebuilt on current `main` (the previous revision targeted the pre-per-issuer layout and conflicted).

## What changed

**`compose.dev.yaml` / `compose.prod.yaml` `init-certs`:**
- Application TLS keys and shared mTLS client key: `100:101`, `0440` (verified app images run as UID 100)
- `postgres.key`: `70:70`, `0600` (server drops privileges; entrypoint stays root)
- `redis.key`: `999:1000`, `0440` (redis user ships in the image)
- Kafka key, keystores and credential files: `1000:1000`, `0440` (broker and topic bootstrap run as `appuser`; verified via image inspection)
- `meilisearch.key` and `ca.key`: root-only `0600` (both consumers run as root; nothing at runtime needs `ca.key`)
- ClickHouse unchanged (`101:101`, `0640`); per-issuer JWT keys already `100:101`/`0440`
- Runtime services mount only `ca.crt` as a file instead of the whole `./certs/ca` directory, so `ca.key` is unreachable inside containers
- Transient Kafka `.p12` bundle deleted after JKS import (it embeds the private key)

**`scripts/compose/validate.sh`:**
- Pins the ownership/mode lines in both Compose files and rejects `./certs/ca` directory mounts into runtime services
- New permission smoke test: asserts exact modes on a generated tree, plus consumer-UID readability checks on Linux (skipped with notice on other platforms / when `./certs` is absent)

## Verification

- Fresh `init-certs` run: all modes land as specified (`600 ca.key`, `440` app/kafka/redis keys, `600 postgres/meilisearch`, `640` clickhouse, no `.p12`)
- `./scripts/compose/validate.sh` fully green
- Fresh-cert stack smoke: `postgres`, `redis`, `kafka` (broker STARTED with SSL), `clickhouse`, `meilisearch` and `users-service` all healthy — every key read by its real consumer UID
- Check primitives proven separately (pass- and deny-detection on controlled fixtures)

### Coverage scope

CI (clean checkout, no generated tree) enforces the static ownership/mode pins, the `ca`-directory-mount guard, and the Compose renders. The live mode assertions and consumer-UID readability matrix run as local verification where certificates were generated (UID checks on Linux); the evidence above was produced that way on a fresh tree.
