### PR TITLE
fix(security): escape HTML in notifications drawer

### DIFF
--- a/dashboard/src/features/notifications/notifications-drawer.tsx
+++ b/dashboard/src/features/notifications/notifications-drawer.tsx
@@ -69,11 +69,28 @@ function dateHeading(iso: string) {
     return format(d, "MMM d, yyyy")
 }
 
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+}
+
 function highlightNotification(message: string): string {
-    return message.replace(
-        /'([^']+)'/g,
-        (_, p1) => `<span class="font-semibold">${p1}</span>`
-    );
+    let result = "";
+    let lastIndex = 0;
+    const regex = /'([^']+)'/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(message)) !== null) {
+        const before = message.slice(lastIndex, match.index);
+        result += escapeHtml(before);
+        const quoted = match[1] ?? "";
+        result += `<span class="font-semibold">${escapeHtml(quoted)}</span>`;
+        lastIndex = match.index + match[0].length;
+    }
+    result += escapeHtml(message.slice(lastIndex));
+    return result;
 }
 
 interface NotificationsDrawerProps {


### PR DESCRIPTION
Escape HTML in notifications drawer before highlighting.

The `highlightNotification` helper inserted quoted workflow names into `innerHTML` without escaping. Split the message, escape outside text and quoted segments separately, and wrap the escaped quoted text in the highlight span. Preserves the quoted-name highlight without raw attacker HTML.

Stack C C7.