### PR TITLE
refactor: consolidate build recipes, Go helpers, and dashboard forms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,118 +76,20 @@ tools:
 mockgen: tools
 	@go generate -v ./...
 
-.PHONY: build/users-service
-build/users-service: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=users-service' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/users-service/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/users-service/auth.ed.pub'" -o ./.bin/users-service ./cmd/users-service
+SERVICES := users-service workflows-service jobs-service notifications-service analytics-service scheduling-worker workflow-worker execution-worker runtime-agent joblogs-processor analytics-processor outbox-relay database-migration server
+BUILD_TARGETS := $(addprefix build/,$(SERVICES))
+RUN_TARGETS := $(addprefix run/,$(SERVICES))
 
-.PHONY: build/workflows-service
-build/workflows-service: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=workflows-service' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/workflows-service/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/workflows-service/auth.ed.pub'" -o ./.bin/workflows-service ./cmd/workflows-service
+.PHONY: $(BUILD_TARGETS) $(RUN_TARGETS) build/all
 
-.PHONY: build/jobs-service
-build/jobs-service: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=jobs-service' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/jobs-service/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/jobs-service/auth.ed.pub'" -o ./.bin/jobs-service ./cmd/jobs-service
+ISSUER = $*
+build/database-migration: ISSUER = server
 
-.PHONY: build/notifications-service
-build/notifications-service: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=notifications-service' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/notifications-service/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/notifications-service/auth.ed.pub'" -o ./.bin/notifications-service ./cmd/notifications-service
+$(BUILD_TARGETS): build/%: dependencies
+	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=$*' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/$(ISSUER)/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/$(ISSUER)/auth.ed.pub'" -o ./.bin/$* ./cmd/$*
 
-.PHONY: build/analytics-service
-build/analytics-service: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=analytics-service' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/analytics-service/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/analytics-service/auth.ed.pub'" -o ./.bin/analytics-service ./cmd/analytics-service
-
-.PHONY: build/scheduling-worker
-build/scheduling-worker: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=scheduling-worker' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/scheduling-worker/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/scheduling-worker/auth.ed.pub'" -o ./.bin/scheduling-worker ./cmd/scheduling-worker
-
-.PHONY: build/workflow-worker
-build/workflow-worker: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=workflow-worker' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/workflow-worker/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/workflow-worker/auth.ed.pub'" -o ./.bin/workflow-worker ./cmd/workflow-worker
-
-.PHONY: build/execution-worker
-build/execution-worker: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=execution-worker' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/execution-worker/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/execution-worker/auth.ed.pub'" -o ./.bin/execution-worker ./cmd/execution-worker
-
-.PHONY: build/runtime-agent
-build/runtime-agent: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=runtime-agent' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/runtime-agent/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/runtime-agent/auth.ed.pub'" -o ./.bin/runtime-agent ./cmd/runtime-agent
-
-.PHONY: build/joblogs-processor
-build/joblogs-processor: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=joblogs-processor' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/joblogs-processor/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/joblogs-processor/auth.ed.pub'" -o ./.bin/joblogs-processor ./cmd/joblogs-processor
-
-.PHONY: build/analytics-processor
-build/analytics-processor: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=analytics-processor' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/analytics-processor/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/analytics-processor/auth.ed.pub'" -o ./.bin/analytics-processor ./cmd/analytics-processor
-
-.PHONY: build/outbox-relay
-build/outbox-relay: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=outbox-relay' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/outbox-relay/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/outbox-relay/auth.ed.pub'" -o ./.bin/outbox-relay ./cmd/outbox-relay
-
-.PHONY: build/database-migration
-build/database-migration: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=database-migration' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/server/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/server/auth.ed.pub'" -o ./.bin/database-migration ./cmd/database-migration
-
-.PHONY: build/server
-build/server: dependencies
-	@CGO_ENABLED=0 go build -ldflags "-X '${PKG_PATH}.version=${APP_VERSION}' -X '${PKG_PATH}.name=server' -X '${PKG_PATH}.authPrivateKeyPath=certs/issuers/server/auth.ed' -X '${PKG_PATH}.authPublicKeyPath=certs/issuers/server/auth.ed.pub'" -o ./.bin/server ./cmd/server
-
-.PHONY: build/all
-build/all: build/users-service build/workflows-service build/jobs-service build/notifications-service build/analytics-service build/scheduling-worker build/workflow-worker build/execution-worker build/runtime-agent build/joblogs-processor build/analytics-processor build/outbox-relay build/database-migration build/server
+build/all: $(BUILD_TARGETS)
 	@echo "All services and workers built successfully."
 
-.PHONY: run/users-service
-run/users-service: build/users-service
-	@./.bin/users-service
-
-.PHONY: run/workflows-service
-run/workflows-service: build/workflows-service
-	@./.bin/workflows-service
-
-.PHONY: run/jobs-service
-run/jobs-service: build/jobs-service
-	@./.bin/jobs-service
-
-.PHONY: run/notifications-service
-run/notifications-service: build/notifications-service
-	@./.bin/notifications-service
-
-.PHONY: run/analytics-service
-run/analytics-service: build/analytics-service
-	@./.bin/analytics-service
-
-.PHONY: run/scheduling-worker
-run/scheduling-worker: build/scheduling-worker
-	@./.bin/scheduling-worker
-
-.PHONY: run/workflow-worker
-run/workflow-worker: build/workflow-worker
-	@./.bin/workflow-worker
-
-.PHONY: run/execution-worker
-run/execution-worker: build/execution-worker
-	@./.bin/execution-worker
-
-.PHONY: run/runtime-agent
-run/runtime-agent: build/runtime-agent
-	@./.bin/runtime-agent
-
-.PHONY: run/joblogs-processor
-run/joblogs-processor: build/joblogs-processor
-	@./.bin/joblogs-processor
-
-.PHONY: run/analytics-processor
-run/analytics-processor: build/analytics-processor
-	@./.bin/analytics-processor
-
-.PHONY: run/outbox-relay
-run/outbox-relay: build/outbox-relay
-	@./.bin/outbox-relay
-
-.PHONY: run/database-migration
-run/database-migration: build/database-migration
-	@./.bin/database-migration
-
-.PHONY: run/server
-run/server: build/server
-	@./.bin/server
+$(RUN_TARGETS): run/%: build/%
+	@./.bin/$*

--- a/cmd/execution-worker/main.go
+++ b/cmd/execution-worker/main.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 
+	"github.com/hitesh22rana/chronoverse/internal/pkg/imagepull"
 	jobspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
 	workflowspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/workflows"
 
@@ -125,7 +126,7 @@ func run() int {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
-	imagePullLockConfig := executorrepo.ImagePullLockConfig{
+	imagePullLockConfig := imagepull.Config{
 		TTL:           cfg.ImagePullLockTTL,
 		WaitTimeout:   cfg.ImagePullLockWaitTimeout,
 		RetryInterval: cfg.ImagePullLockRetryInterval,

--- a/cmd/workflow-worker/main.go
+++ b/cmd/workflow-worker/main.go
@@ -12,6 +12,7 @@ import (
 	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap"
 
+	"github.com/hitesh22rana/chronoverse/internal/pkg/imagepull"
 	jobpb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
 	notificationspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/notifications"
 	workflowspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/workflows"
@@ -149,7 +150,7 @@ func run() int {
 
 	// Workflow workers resolve image metadata through the runtime registry.
 	// Runtime identity scopes image pull locks to the owning Docker daemon.
-	imagePullLockConfig := workflowrepo.ImagePullLockConfig{
+	imagePullLockConfig := imagepull.Config{
 		TTL:           cfg.ImagePullLockTTL,
 		WaitTimeout:   cfg.ImagePullLockWaitTimeout,
 		RetryInterval: cfg.ImagePullLockRetryInterval,

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -27,7 +27,6 @@
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "date-fns": "4.4.0",
-        "event-source-polyfill": "1.0.31",
         "lucide-react": "1.25.0",
         "motion": "12.42.2",
         "next": "16.2.10",
@@ -46,7 +45,6 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "4.3.3",
-        "@types/event-source-polyfill": "1.0.5",
         "@types/node": "26.1.1",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
@@ -3165,13 +3163,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/event-source-polyfill": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz",
-      "integrity": "sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -5575,12 +5566,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/event-source-polyfill": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
-      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
-      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -35,7 +35,6 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "date-fns": "4.4.0",
-    "event-source-polyfill": "1.0.31",
     "lucide-react": "1.25.0",
     "motion": "12.42.2",
     "next": "16.2.10",
@@ -54,7 +53,6 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.3.3",
-    "@types/event-source-polyfill": "1.0.5",
     "@types/node": "26.1.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/dashboard/src/features/analytics/workflow-analytics-panel.tsx
+++ b/dashboard/src/features/analytics/workflow-analytics-panel.tsx
@@ -49,11 +49,6 @@ export function WorkflowAnalyticsPanel({
     onRetry,
     workflowKind,
 }: WorkflowAnalyticsPanelProps) {
-    const totalJobs = analytics?.total_jobs ?? 0
-    const totalLogs = analytics?.total_joblogs ?? 0
-    const totalRuntime = analytics?.total_job_execution_duration ?? 0
-    const averageRuntime = divide(totalRuntime, totalJobs)
-
     return (
         <section className="flex flex-col gap-3" aria-labelledby="workflow-analytics-title">
             <div className="flex items-start justify-between gap-4">
@@ -72,68 +67,7 @@ export function WorkflowAnalyticsPanel({
                 ) : null}
             </div>
 
-            {isLoading ? (
-                <WorkflowAnalyticsCardsSkeleton />
-            ) : error ? (
-                <Card className="gap-4 py-4">
-                    <CardHeader className="px-4">
-                        <CardTitle className="text-sm">Analytics unavailable</CardTitle>
-                        <CardDescription>{error.message}</CardDescription>
-                        <CardAction>
-                            <Button variant="outline" size="sm" onClick={onRetry} disabled={isFetching}>
-                                <RefreshCw data-icon="inline-start" className={cn(isFetching && "animate-spin")} />
-                                Try again
-                            </Button>
-                        </CardAction>
-                    </CardHeader>
-                </Card>
-            ) : analytics ? (
-                <>
-                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                        <AnalyticsMetricCard
-                            label="Job executions"
-                            value={formatInteger(totalJobs)}
-                            helper="Recorded after reaching a final state"
-                            icon={Activity}
-                        />
-                        <AnalyticsMetricCard
-                            label="Total runtime"
-                            value={formatSeconds(totalRuntime)}
-                            helper="Combined execution time"
-                            icon={Clock3}
-                        />
-                        <AnalyticsMetricCard
-                            label="Average runtime"
-                            value={formatSeconds(Math.round(averageRuntime))}
-                            helper="Per recorded job execution"
-                            icon={Gauge}
-                        />
-                        <AnalyticsMetricCard
-                            label="Generated logs"
-                            value={formatInteger(totalLogs)}
-                            helper={getLogHelper(workflowKind, logRetention, totalLogs, totalJobs)}
-                            icon={ScrollText}
-                        />
-                    </div>
-                    {!logRetention && (
-                        <p className="flex items-center gap-2 text-xs text-muted-foreground">
-                            <ScrollText className="size-3.5 shrink-0" />
-                            {workflowKind === "CONTAINER"
-                                ? "Generated logs are counted for analytics but are not retained for retrieval."
-                                : "This workflow kind does not retain execution logs."}
-                        </p>
-                    )}
-                </>
-            ) : (
-                <Card className="gap-4 py-4">
-                    <CardHeader className="px-4">
-                        <CardTitle className="text-sm">No analytics yet</CardTitle>
-                        <CardDescription>
-                            Metrics will appear after this workflow records its first completed execution.
-                        </CardDescription>
-                    </CardHeader>
-                </Card>
-            )}
+            <WorkflowAnalyticsContent analytics={analytics} error={error} isLoading={isLoading} isFetching={isFetching} logRetention={logRetention} onRetry={onRetry} workflowKind={workflowKind} />
         </section>
     )
 }
@@ -148,4 +82,75 @@ function getLogHelper(workflowKind: string, logRetention: boolean, totalLogs: nu
     }
 
     return formatLogsPerJob(totalLogs, totalJobs) ?? "No logs generated"
+}
+
+function WorkflowAnalyticsContent({ analytics, error, isLoading, isFetching, logRetention, onRetry, workflowKind }: WorkflowAnalyticsPanelProps) {
+    if (isLoading) return <WorkflowAnalyticsCardsSkeleton />
+    if (error) return (
+        <Card className="gap-4 py-4">
+            <CardHeader className="px-4">
+                <CardTitle className="text-sm">Analytics unavailable</CardTitle>
+                <CardDescription>{error.message}</CardDescription>
+                <CardAction>
+                    <Button variant="outline" size="sm" onClick={onRetry} disabled={isFetching}>
+                        <RefreshCw data-icon="inline-start" className={cn(isFetching && "animate-spin")} />
+                        Try again
+                    </Button>
+                </CardAction>
+            </CardHeader>
+        </Card>
+    )
+    if (!analytics) return (
+        <Card className="gap-4 py-4">
+            <CardHeader className="px-4">
+                <CardTitle className="text-sm">No analytics yet</CardTitle>
+                <CardDescription>
+                    Metrics will appear after this workflow records its first completed execution.
+                </CardDescription>
+            </CardHeader>
+        </Card>
+    )
+    const totalJobs = analytics?.total_jobs ?? 0
+    const totalLogs = analytics?.total_joblogs ?? 0
+    const totalRuntime = analytics?.total_job_execution_duration ?? 0
+    const averageRuntime = divide(totalRuntime, totalJobs)
+
+    return (
+        <>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <AnalyticsMetricCard
+                    label="Job executions"
+                    value={formatInteger(totalJobs)}
+                    helper="Recorded after reaching a final state"
+                    icon={Activity}
+                />
+                <AnalyticsMetricCard
+                    label="Total runtime"
+                    value={formatSeconds(totalRuntime)}
+                    helper="Combined execution time"
+                    icon={Clock3}
+                />
+                <AnalyticsMetricCard
+                    label="Average runtime"
+                    value={formatSeconds(Math.round(averageRuntime))}
+                    helper="Per recorded job execution"
+                    icon={Gauge}
+                />
+                <AnalyticsMetricCard
+                    label="Generated logs"
+                    value={formatInteger(totalLogs)}
+                    helper={getLogHelper(workflowKind, logRetention, totalLogs, totalJobs)}
+                    icon={ScrollText}
+                />
+            </div>
+            {!logRetention && (
+                <p className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <ScrollText className="size-3.5 shrink-0" />
+                    {workflowKind === "CONTAINER"
+                        ? "Generated logs are counted for analytics but are not retained for retrieval."
+                        : "This workflow kind does not retain execution logs."}
+                </p>
+            )}
+        </>
+    )
 }

--- a/dashboard/src/features/auth/auth-input.tsx
+++ b/dashboard/src/features/auth/auth-input.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { useFormContext } from "react-hook-form"
+import { Input } from "@/components/ui/input"
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+
+export function AuthInput({ name, label, type, placeholder }: {
+    name: "email" | "password" | "confirmPassword"
+    label: string
+    type?: "password"
+    placeholder: string
+}) {
+    const { control } = useFormContext()
+    return (
+        <FormField control={control} name={name} render={({ field }) => (
+            <FormItem>
+                <FormLabel>{label}</FormLabel>
+                <FormControl><Input type={type} placeholder={placeholder} {...field} /></FormControl>
+                <FormMessage />
+            </FormItem>
+        )} />
+    )
+}

--- a/dashboard/src/features/auth/login-page.tsx
+++ b/dashboard/src/features/auth/login-page.tsx
@@ -6,7 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { Loader2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { AuthInput } from "./auth-input"
 import {
   Card,
   CardContent,
@@ -15,14 +15,7 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card"
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage
-} from "@/components/ui/form"
+import { Form } from "@/components/ui/form"
 
 import { useAuth } from "@/features/auth/use-auth"
 import { loginSchema, type LoginValues } from "@/features/auth/auth-schemas"
@@ -55,33 +48,9 @@ export default function LoginPage() {
         <CardContent>
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-              <FormField
-                control={form.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input placeholder="Enter your email address" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              <AuthInput name="email" label="Email" placeholder="Enter your email address" />
 
-              <FormField
-                control={form.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Password</FormLabel>
-                    <FormControl>
-                      <Input type="password" placeholder="••••••••" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              <AuthInput name="password" label="Password" type="password" placeholder="••••••••" />
 
               <Button type="submit" className="w-full" disabled={isLoading}>
                 {isLoading ? (

--- a/dashboard/src/features/auth/signup-page.tsx
+++ b/dashboard/src/features/auth/signup-page.tsx
@@ -6,7 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { Loader2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { AuthInput } from "./auth-input"
 import {
   Card,
   CardContent,
@@ -15,14 +15,7 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card"
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage
-} from "@/components/ui/form"
+import { Form } from "@/components/ui/form"
 
 import { useAuth } from "@/features/auth/use-auth"
 import { signupSchema, type SignupValues } from "@/features/auth/auth-schemas"
@@ -56,47 +49,11 @@ export default function SignupPage() {
         <CardContent>
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-              <FormField
-                control={form.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input placeholder="Enter your email address" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              <AuthInput name="email" label="Email" placeholder="Enter your email address" />
 
-              <FormField
-                control={form.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Password</FormLabel>
-                    <FormControl>
-                      <Input type="password" placeholder="Create a password" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              <AuthInput name="password" label="Password" type="password" placeholder="Create a password" />
 
-              <FormField
-                control={form.control}
-                name="confirmPassword"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Confirm Password</FormLabel>
-                    <FormControl>
-                      <Input type="password" placeholder="Confirm your password" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              <AuthInput name="confirmPassword" label="Confirm Password" type="password" placeholder="Confirm your password" />
 
               <Button type="submit" className="w-full" disabled={isLoading}>
                 {isLoading ? (

--- a/dashboard/src/features/jobs/job-details-page.tsx
+++ b/dashboard/src/features/jobs/job-details-page.tsx
@@ -24,6 +24,8 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { LogsViewer } from "@/features/logs/logs-viewer"
 import { JobStatusBadge } from "@/features/jobs/job-status-badge"
 
+import type { Job } from "./types"
+
 import { useJobDetails } from "@/features/jobs/use-job-details"
 
 export default function JobDetailsAndLogsPage() {
@@ -149,57 +151,7 @@ export default function JobDetailsAndLogsPage() {
                                 </div>
                             </Fragment>
                         ) : job && (
-                            <Fragment>
-                                {/* Timing Information */}
-                                <div className="space-y-3">
-                                    <h3 className="font-medium text-sm">Timeline</h3>
-                                    <div className="space-y-2">
-                                        <div className="flex justify-between text-sm">
-                                            <span className="text-muted-foreground">Created:</span>
-                                            <span>{format(new Date(job.created_at), "MMM d, yyyy HH:mm:ss")}</span>
-                                        </div>
-                                        <div className="flex justify-between text-sm">
-                                            <span className="text-muted-foreground">Scheduled:</span>
-                                            <span>{format(new Date(job.scheduled_at), "MMM d, yyyy HH:mm:ss")}</span>
-                                        </div>
-                                        {job.started_at ? (
-                                            <div className="flex justify-between text-sm">
-                                                <span className="text-muted-foreground">Started:</span>
-                                                <span>{format(new Date(job.started_at), "MMM d, yyyy HH:mm:ss")}</span>
-                                            </div>
-                                        ) : (
-                                            <div className="flex justify-between text-sm">
-                                                <span className="text-muted-foreground">Started:</span>
-                                                <span className="text-gray-400">Not started yet</span>
-                                            </div>
-                                        )}
-                                        {job.completed_at ? (
-                                            <div className="flex justify-between text-sm">
-                                                <span className="text-muted-foreground">Completed:</span>
-                                                <span>{format(new Date(job.completed_at), "MMM d, yyyy HH:mm:ss")}</span>
-                                            </div>
-                                        ) : (
-                                            <div className="flex justify-between text-sm">
-                                                <span className="text-muted-foreground">Completed:</span>
-                                                <span className="text-gray-400">Not completed yet</span>
-                                            </div>
-                                        )}
-                                        {(job.started_at && job.completed_at) ? (
-                                            <div className="flex justify-between text-sm">
-                                                <span className="text-muted-foreground">Duration:</span>
-                                                <span>
-                                                    {formatDuration(new Date(job.started_at), new Date(job.completed_at))}
-                                                </span>
-                                            </div>
-                                        ) : (
-                                            <div className="flex justify-between text-sm">
-                                                <span className="text-muted-foreground">Duration:</span>
-                                                <span className="text-gray-400">Not available</span>
-                                            </div>
-                                        )}
-                                    </div>
-                                </div>
-                            </Fragment>
+                            <JobTimeline job={job} />
                         )}
                     </CardContent>
                 </Card>
@@ -236,4 +188,31 @@ function formatDuration(start: Date, end: Date): string {
     const remainingMinutes = minutes % 60;
 
     return `${hours} hour${hours !== 1 ? 's' : ''} ${remainingMinutes} minute${remainingMinutes !== 1 ? 's' : ''}`;
+}
+
+function JobTimeline({ job }: { job: Job }) {
+    const timestamps = [
+        { label: "Created", date: job.created_at, empty: "" },
+        { label: "Scheduled", date: job.scheduled_at, empty: "" },
+        { label: "Started", date: job.started_at, empty: "Not started yet" },
+        { label: "Completed", date: job.completed_at, empty: "Not completed yet" },
+    ]
+    const duration = job.started_at && job.completed_at ? formatDuration(new Date(job.started_at), new Date(job.completed_at)) : null
+    return (
+        <div className="space-y-3">
+            <h3 className="font-medium text-sm">Timeline</h3>
+            <div className="space-y-2">
+                {timestamps.map(({ label, date, empty }) => (
+                    <div key={label} className="flex justify-between text-sm">
+                        <span className="text-muted-foreground">{label}:</span>
+                        <span className={date ? undefined : "text-gray-400"}>{date ? format(new Date(date), "MMM d, yyyy HH:mm:ss") : empty}</span>
+                    </div>
+                ))}
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Duration:</span>
+                    <span className={duration ? undefined : "text-gray-400"}>{duration ?? "Not available"}</span>
+                </div>
+            </div>
+        </div>
+    )
 }

--- a/dashboard/src/features/logs/logs-viewer.tsx
+++ b/dashboard/src/features/logs/logs-viewer.tsx
@@ -551,21 +551,10 @@ export function LogsViewer({
 
 function LogsViewerView({ model }: { model: any }) {
     const {
+        streamFilter,
         jobStatus,
         logs,
-        isLogsLoading,
-        isWorkflowLoading,
-        logsError,
-        isLogsUnsupportedForKind,
-        workflowKind,
-        isRetentionDisabled,
-        searchQuery,
-        streamFilter,
         isFetchingNextPage,
-        virtuosoRef,
-        renderLogRow,
-        handleEndReached,
-        handleRenderedRangeChanged,
         parseJson,
         updateJsonRendering,
         completedAt,
@@ -756,63 +745,7 @@ function LogsViewerView({ model }: { model: any }) {
             </CardHeader>
 
             <CardContent className="flex flex-col flex-1 w-full h-full font-mono text-sm md:p-2 p-0">
-                {isLogsLoading || !jobStatus || isWorkflowLoading ? (
-                    <div className="flex items-center justify-center h-full m-auto">
-                        <div className="flex items-center gap-2">
-                            <Loader2 className="h-6 w-6 animate-spin" />
-                            <span>Loading logs...</span>
-                        </div>
-                    </div>
-                ) : logsError ? (
-                    <div className="flex items-center justify-center h-full m-auto">
-                        <div className="text-center">
-                            <div className="text-red-500 mb-2">Error loading logs</div>
-                            <div className="text-sm text-muted-foreground">{logsError.message}</div>
-                        </div>
-                    </div>
-                ) : logs.length > 0 ? (
-                    <Virtuoso
-                        ref={virtuosoRef}
-                        totalCount={logs.length}
-                        itemContent={renderLogRow}
-                        endReached={handleEndReached}
-                        rangeChanged={handleRenderedRangeChanged}
-                        overscan={200}
-                        className="flex flex-1 w-full h-full"
-                    />
-                ) : isLogsUnsupportedForKind ? (
-                    <div className="flex flex-col items-center justify-center h-full text-muted-foreground m-auto">
-                        <div className="text-lg mb-2">No logs available</div>
-                        <div className="text-sm text-center">
-                            Logs are not available for <span className="dark:text-white text-black font-semibold">{workflowKind?.charAt(0) + workflowKind?.substring(1).toLowerCase()}</span> workflows.
-                        </div>
-                    </div>
-                ) : isRetentionDisabled ? (
-                    <div className="flex flex-col items-center justify-center h-full text-muted-foreground m-auto">
-                        <div className="text-lg mb-2">No logs available</div>
-                        <div className="text-sm text-center">Log retention is disabled for this <span className="dark:text-white text-black font-semibold">{workflowKind?.charAt(0) + workflowKind?.substring(1).toLowerCase()}</span> workflow</div>
-                    </div>
-                ) : (!!searchQuery || !!streamFilter) ? (
-                    <div className="flex flex-col items-center justify-center h-full text-muted-foreground m-auto">
-                        <div className="text-lg mb-2">No logs found</div>
-                        <div className="text-sm text-center">Try adjusting your search query or filters</div>
-                    </div>
-                ) : (
-                    <div className="flex flex-col items-center justify-center h-full text-muted-foreground m-auto">
-                        <div className="text-lg mb-2">No logs available</div>
-                        <div className="text-sm text-center">
-                            {jobStatus === "RUNNING"
-                                ? "Logs will appear here as the job executes"
-                                : jobStatus === "PENDING" || jobStatus === "QUEUED"
-                                    ? "Job is waiting to start"
-                                    : jobStatus === "FAILED"
-                                        ? "Job failed to execute, no logs available"
-                                        : jobStatus === "COMPLETED"
-                                            ? "Job completed successfully, but no logs were produced"
-                                            : "This job did not produce any logs"}
-                        </div>
-                    </div>
-                )}
+                <LogResults model={model} />
                 {isFetchingNextPage && (
                     <div className="flex items-center justify-center py-4">
                         <Loader2 className="h-4 w-4 animate-spin mr-2" />
@@ -821,5 +754,62 @@ function LogsViewerView({ model }: { model: any }) {
                 )}
             </CardContent>
         </Card>
+    )
+}
+
+const emptyLogMessages: Record<string, string> = {
+    RUNNING: "Logs will appear here as the job executes",
+    PENDING: "Job is waiting to start",
+    QUEUED: "Job is waiting to start",
+    FAILED: "Job failed to execute, no logs available",
+    COMPLETED: "Job completed successfully, but no logs were produced",
+}
+
+function LogResults({ model }: { model: any }) {
+    const { isLogsLoading, jobStatus, isWorkflowLoading, logsError, logs, virtuosoRef, renderLogRow, handleEndReached, handleRenderedRangeChanged, isLogsUnsupportedForKind, isRetentionDisabled, workflowKind, searchQuery, streamFilter } = model
+    if (isLogsLoading || !jobStatus || isWorkflowLoading) return (
+        <div className="flex items-center justify-center h-full m-auto">
+            <div className="flex items-center gap-2">
+                <Loader2 className="h-6 w-6 animate-spin" />
+                <span>Loading logs...</span>
+            </div>
+        </div>
+    )
+    if (logsError) return (
+        <div className="flex items-center justify-center h-full m-auto">
+            <div className="text-center">
+                <div className="text-red-500 mb-2">Error loading logs</div>
+                <div className="text-sm text-muted-foreground">{logsError.message}</div>
+            </div>
+        </div>
+    )
+    if (logs.length > 0) return (
+        <Virtuoso
+            ref={virtuosoRef}
+            totalCount={logs.length}
+            itemContent={renderLogRow}
+            endReached={handleEndReached}
+            rangeChanged={handleRenderedRangeChanged}
+            overscan={200}
+            className="flex flex-1 w-full h-full"
+        />
+    )
+
+    let title = "No logs available"
+    let description: React.ReactNode = emptyLogMessages[jobStatus] ?? "This job did not produce any logs"
+    const kind = <span className="dark:text-white text-black font-semibold">{workflowKind?.charAt(0) + workflowKind?.substring(1).toLowerCase()}</span>
+    if (isLogsUnsupportedForKind) {
+        description = <>Logs are not available for {kind} workflows.</>
+    } else if (isRetentionDisabled) {
+        description = <>Log retention is disabled for this {kind} workflow</>
+    } else if (searchQuery || streamFilter) {
+        title = "No logs found"
+        description = "Try adjusting your search query or filters"
+    }
+    return (
+        <div className="flex flex-col items-center justify-center h-full text-muted-foreground m-auto">
+            <div className="text-lg mb-2">{title}</div>
+            <div className="text-sm text-center">{description}</div>
+        </div>
     )
 }

--- a/dashboard/src/features/logs/use-job-logs.test.ts
+++ b/dashboard/src/features/logs/use-job-logs.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
     query: vi.fn(),
     params: new URLSearchParams(),
     setLogs: vi.fn(),
+    push: vi.fn(),
+    workflow: undefined as { kind: string, log_retention: boolean } | undefined,
 }))
 
 vi.mock("react", () => ({
@@ -13,7 +15,7 @@ vi.mock("react", () => ({
 }))
 vi.mock("next/navigation", () => ({
     usePathname: () => "/workflows/w/jobs/j",
-    useRouter: () => ({ push: vi.fn() }),
+    useRouter: () => ({ push: mocks.push }),
     useSearchParams: () => mocks.params,
 }))
 vi.mock("@tanstack/react-query", () => ({
@@ -21,7 +23,7 @@ vi.mock("@tanstack/react-query", () => ({
     useMutation: () => ({ isPending: false }),
 }))
 vi.mock("@/features/workflows/use-workflow-details", () => ({
-    useWorkflowDetails: () => ({ workflow: { kind: "CONTAINER", log_retention: true } }),
+    useWorkflowDetails: () => ({ workflow: mocks.workflow }),
 }))
 vi.mock("@/lib/api/client", () => ({ fetchApi: vi.fn(), fetchApiJson: vi.fn() }))
 
@@ -32,6 +34,8 @@ const retained = { data: { pages: [{ logs: [log] }] }, fetchNextPage: vi.fn(), i
 const searched = { ...retained, data: { pages: [{ logs: [{ ...log, message: "found" }] }] } }
 
 beforeEach(() => {
+    mocks.workflow = { kind: "CONTAINER", log_retention: true }
+    mocks.push.mockClear()
     mocks.effects.length = 0
     mocks.params = new URLSearchParams()
     mocks.setLogs.mockClear()
@@ -86,4 +90,32 @@ it.each(["COMPLETED", "QUEUED", "filtered"])("does not open a stream for %s", (s
     useJobLogs("w", "j", state === "filtered" ? "RUNNING" : state)
     expect(mocks.effects[0]()).toBeUndefined()
     expect(constructor).not.toHaveBeenCalled()
+})
+
+it.each([
+    [undefined, false, false],
+    [{ kind: "HEARTBEAT", log_retention: false }, true, false],
+    [{ kind: "CONTAINER", log_retention: false }, false, true],
+] as const)("does not fetch unavailable logs for %j", (workflow, unsupported, disabled) => {
+    mocks.workflow = workflow
+    const result = useJobLogs("w", "j", "RUNNING")
+    expect(result.isLogsUnsupportedForKind).toBe(unsupported)
+    expect(result.isRetentionDisabled).toBe(disabled)
+    expect(mocks.query.mock.calls.map(([options]) => options.enabled)).toEqual([false, false])
+    expect(mocks.effects[0]()).toBeUndefined()
+})
+
+it("updates and clears filters while preserving unrelated URL parameters", () => {
+    mocks.params = new URLSearchParams("json=true&q=old&stream=stderr")
+    const result = useJobLogs("w", "j", "RUNNING")
+    result.updateSearchQuery("new value")
+    result.updateSearchQuery("")
+    result.applyStreamFilter("stdout")
+    result.applyStreamFilter("")
+    expect(mocks.push.mock.calls.flat()).toEqual([
+        "/workflows/w/jobs/j?json=true&q=new+value&stream=stderr",
+        "/workflows/w/jobs/j?json=true&stream=stderr",
+        "/workflows/w/jobs/j?json=true&q=old&stream=stdout",
+        "/workflows/w/jobs/j?json=true&q=old",
+    ])
 })

--- a/dashboard/src/features/logs/use-job-logs.test.ts
+++ b/dashboard/src/features/logs/use-job-logs.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+    effects: [] as (() => void | (() => void))[],
+    query: vi.fn(),
+    params: new URLSearchParams(),
+    setLogs: vi.fn(),
+}))
+
+vi.mock("react", () => ({
+    useEffect: (effect: () => void | (() => void)) => mocks.effects.push(effect),
+    useState: (initial: unknown) => [initial, mocks.setLogs],
+}))
+vi.mock("next/navigation", () => ({
+    usePathname: () => "/workflows/w/jobs/j",
+    useRouter: () => ({ push: vi.fn() }),
+    useSearchParams: () => mocks.params,
+}))
+vi.mock("@tanstack/react-query", () => ({
+    useInfiniteQuery: mocks.query,
+    useMutation: () => ({ isPending: false }),
+}))
+vi.mock("@/features/workflows/use-workflow-details", () => ({
+    useWorkflowDetails: () => ({ workflow: { kind: "CONTAINER", log_retention: true } }),
+}))
+vi.mock("@/lib/api/client", () => ({ fetchApi: vi.fn(), fetchApiJson: vi.fn() }))
+
+import { useJobLogs } from "./use-job-logs"
+
+const log = { event_id: "e:1", sequence_num: 1, message: "saved", timestamp: "", stream: "stdout" }
+const retained = { data: { pages: [{ logs: [log] }] }, fetchNextPage: vi.fn(), isLoading: true, hasNextPage: true }
+const searched = { ...retained, data: { pages: [{ logs: [{ ...log, message: "found" }] }] } }
+
+beforeEach(() => {
+    mocks.effects.length = 0
+    mocks.params = new URLSearchParams()
+    mocks.setLogs.mockClear()
+    mocks.query.mockReset().mockReturnValueOnce(retained).mockReturnValueOnce(searched)
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+it.each(["RUNNING", "COMPLETED", "FAILED", "CANCELED"])("returns retained logs for %s", (status) => {
+    const result = useJobLogs("w", "j", status)
+    expect(result.logs).toEqual([log])
+    expect(result.fetchNextPage).toBe(retained.fetchNextPage)
+    expect(result.isLoading).toBe(true)
+})
+
+it.each(["PENDING", "QUEUED"])("returns an empty state for %s", (status) => {
+    const result = useJobLogs("w", "j", status)
+    expect(result.logs).toEqual([])
+    expect(result.isLoading).toBe(false)
+    expect(result.hasNextPage).toBe(false)
+})
+
+it("uses search results when a filter is present", () => {
+    mocks.params.set("stream", "stderr")
+    expect(useJobLogs("w", "j", "RUNNING").logs[0].message).toBe("found")
+})
+
+it("opens a credentialed native stream, normalizes logs, and cleans up", () => {
+    const source = Object.assign(new EventTarget(), { close: vi.fn() })
+    const constructor = vi.fn(function () { return source })
+    vi.stubGlobal("EventSource", constructor)
+    useJobLogs("w", "j", "RUNNING")
+    const cleanup = mocks.effects[0]()
+    expect(constructor).toHaveBeenCalledWith(expect.stringContaining("/events"), { withCredentials: true })
+
+    source.dispatchEvent(new MessageEvent("log", { data: JSON.stringify(log) }))
+    expect(mocks.setLogs.mock.calls[0][0]([])).toEqual([log])
+    source.dispatchEvent(new MessageEvent("log", { data: "invalid json" }))
+    expect(mocks.setLogs).toHaveBeenCalledTimes(1)
+
+    if (typeof cleanup !== "function") throw new Error("missing stream cleanup")
+    cleanup()
+    expect(source.close).toHaveBeenCalledOnce()
+    source.dispatchEvent(new MessageEvent("log", { data: JSON.stringify(log) }))
+    expect(mocks.setLogs).toHaveBeenCalledTimes(1)
+})
+
+it.each(["COMPLETED", "QUEUED", "filtered"])("does not open a stream for %s", (state) => {
+    const constructor = vi.fn()
+    vi.stubGlobal("EventSource", constructor)
+    if (state === "filtered") mocks.params.set("q", "error")
+    useJobLogs("w", "j", state === "filtered" ? "RUNNING" : state)
+    expect(mocks.effects[0]()).toBeUndefined()
+    expect(constructor).not.toHaveBeenCalled()
+})

--- a/dashboard/src/features/logs/use-job-logs.ts
+++ b/dashboard/src/features/logs/use-job-logs.ts
@@ -40,16 +40,11 @@ type DownloadLogsOptions = {
 }
 
 const kindsWithLogs = ['CONTAINER']
-const terminalJobStatus = ['COMPLETED', 'FAILED', 'CANCELED']
+const statusesWithLogs = ['RUNNING', 'COMPLETED', 'FAILED', 'CANCELED']
 
 export function useJobLogs(workflowId: string, jobId: string, jobStatus: string) {
     const { workflow, isLoading: isWorkflowLoading } = useWorkflowDetails(workflowId)
-    const pathname = usePathname()
-    const router = useRouter()
-    const searchParams = useSearchParams()
-
-    const searchQuery = searchParams.get("q") || ""
-    const streamFilter = searchParams.get("stream") || ""
+    const { searchQuery, streamFilter, updateSearchQuery, applyStreamFilter, getSearchQueryParams } = useLogFilters()
 
     const [liveLogs, setLiveLogs] = useState<JobLog[]>([])
 
@@ -59,59 +54,14 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
     const searchURL = apiEndpoints.workflows.jobs.searchLogs(workflowId, jobId)
 
     const isRunning = jobStatus === "RUNNING"
-    const isCompleted = terminalJobStatus.includes(jobStatus)
+    const hasLogs = statusesWithLogs.includes(jobStatus)
     const workflowKind = workflow?.kind || ""
-    const isLogsUnsupportedForKind = Boolean(workflow && !kindsWithLogs.includes(workflow.kind))
-    const isRetentionDisabled = Boolean(workflow && !isLogsUnsupportedForKind && !workflow.log_retention)
-    const shouldFetch = Boolean(
-        workflow &&
-        !isLogsUnsupportedForKind &&
-        workflow.log_retention &&
-        (isCompleted || isRunning)
-    )
+    const supportsLogs = kindsWithLogs.includes(workflowKind)
+    const isLogsUnsupportedForKind = Boolean(workflow) && !supportsLogs
+    const isRetentionDisabled = supportsLogs && !workflow.log_retention
+    const shouldFetch = supportsLogs && !isRetentionDisabled && hasLogs
 
-    // Update search query in URL params
-    const updateSearchQuery = (newSearchQuery: string) => {
-        const params = new URLSearchParams(searchParams.toString())
-
-        if (newSearchQuery) {
-            params.set("q", newSearchQuery)
-        } else {
-            params.delete("q")
-        }
-
-        const query = params.toString()
-        router.push(buildLogViewerUrl(pathname, query, ""))
-    }
-
-    // Apply stream filter in URL params
-    const applyStreamFilter = (newStreamFilter: string) => {
-        const params = new URLSearchParams(searchParams.toString())
-
-        if (newStreamFilter) {
-            params.set("stream", newStreamFilter)
-        } else {
-            params.delete("stream")
-        }
-
-        const query = params.toString()
-        router.push(buildLogViewerUrl(pathname, query, ""))
-    }
-
-    // Build query parameters for the search job logs request
-    const getSearchQueryParams = (() => {
-        const params = new URLSearchParams()
-
-        if (searchQuery) {
-            params.set("q", searchQuery)
-        }
-
-        if (streamFilter) {
-            params.set("stream", streamFilter)
-        }
-
-        return params.toString()
-    })()
+    const canFetch = shouldFetch && Boolean(workflowId) && Boolean(jobId)
 
     // Download raw logs from backend and trigger browser file download
     const downloadLogsMutation = useMutation({
@@ -169,7 +119,7 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         initialPageParam: null,
         getNextPageParam: (lastPage) => lastPage?.cursor || null,
         refetchOnMount: "always",
-        enabled: shouldFetch && !getSearchQueryParams && Boolean(workflowId) && Boolean(jobId),
+        enabled: canFetch && !getSearchQueryParams,
     })
 
     // Search job logs query
@@ -199,7 +149,7 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         initialPageParam: null,
         getNextPageParam: (lastPage) => lastPage?.cursor || null,
         refetchOnMount: "always",
-        enabled: shouldFetch && Boolean(getSearchQueryParams) && Boolean(workflowId) && Boolean(jobId),
+        enabled: canFetch && Boolean(getSearchQueryParams),
     });
 
     // Handle SSE connection for running jobs
@@ -251,17 +201,23 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
     }, [jobLogsSearchInfiniteQuery.error, jobLogsInfiniteQuery.error])
 
     const isSearching = shouldFetch && Boolean(getSearchQueryParams)
-    const query = isSearching ? jobLogsSearchInfiniteQuery : jobLogsInfiniteQuery
-    const hasLogs = isSearching || isCompleted || isRunning
-    const logs = hasLogs ? logsFromPages(query.data?.pages) : []
+    const query = hasLogs ? (isSearching ? jobLogsSearchInfiniteQuery : jobLogsInfiniteQuery) : {
+        data: undefined,
+        isLoading: false,
+        error: null,
+        fetchNextPage: () => Promise.resolve(),
+        isFetchingNextPage: false,
+        hasNextPage: false,
+    }
+    const logs = logsFromPages(query.data?.pages)
 
     return {
         logs: isRunning && !isSearching ? mergeLiveLogs(logs, liveLogs) : logs,
-        isLoading: hasLogs ? query.isLoading : false,
-        error: hasLogs ? query.error : null,
-        fetchNextPage: hasLogs ? query.fetchNextPage : () => Promise.resolve(),
-        isFetchingNextPage: hasLogs ? query.isFetchingNextPage : false,
-        hasNextPage: hasLogs ? query.hasNextPage : false,
+        isLoading: query.isLoading,
+        error: query.error,
+        fetchNextPage: query.fetchNextPage,
+        isFetchingNextPage: query.isFetchingNextPage,
+        hasNextPage: query.hasNextPage,
         searchQuery,
         updateSearchQuery,
         streamFilter,
@@ -272,5 +228,36 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         isLogsUnsupportedForKind,
         workflowKind,
         isWorkflowLoading,
+    }
+}
+
+function useLogFilters() {
+    const pathname = usePathname()
+    const router = useRouter()
+    const searchParams = useSearchParams()
+
+    const searchQuery = searchParams.get("q") || ""
+    const streamFilter = searchParams.get("stream") || ""
+
+    const updateFilter = (name: string, value: string) => {
+        const params = new URLSearchParams(searchParams.toString())
+        if (value) {
+            params.set(name, value)
+        } else {
+            params.delete(name)
+        }
+        router.push(buildLogViewerUrl(pathname, params.toString(), ""))
+    }
+
+    const params = new URLSearchParams()
+    if (searchQuery) params.set("q", searchQuery)
+    if (streamFilter) params.set("stream", streamFilter)
+
+    return {
+        searchQuery,
+        streamFilter,
+        updateSearchQuery: (value: string) => updateFilter("q", value),
+        applyStreamFilter: (value: string) => updateFilter("stream", value),
+        getSearchQueryParams: params.toString(),
     }
 }

--- a/dashboard/src/features/logs/use-job-logs.ts
+++ b/dashboard/src/features/logs/use-job-logs.ts
@@ -2,7 +2,6 @@
 
 import {
     useEffect,
-    useRef,
     useState,
 } from "react"
 import {
@@ -14,11 +13,6 @@ import {
     useInfiniteQuery,
     useMutation,
 } from "@tanstack/react-query"
-import {
-    EventSourcePolyfill,
-    type Event as EventSourceEvent,
-    type MessageEvent as EventSourceMessageEvent,
-} from "event-source-polyfill"
 import { toast } from "sonner"
 
 import { useWorkflowDetails } from "@/features/workflows/use-workflow-details"
@@ -57,9 +51,7 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
     const searchQuery = searchParams.get("q") || ""
     const streamFilter = searchParams.get("stream") || ""
 
-    const [isConnected, setIsConnected] = useState(false)
     const [liveLogs, setLiveLogs] = useState<JobLog[]>([])
-    const eventSourceRef = useRef<EventSourcePolyfill | null>(null)
 
     const logsURL = apiEndpoints.workflows.jobs.logs(workflowId, jobId)
     const sseURL = apiEndpoints.workflows.jobs.logEvents(workflowId, jobId)
@@ -216,20 +208,13 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
             return
         }
 
-        const eventSource = new EventSourcePolyfill(sseURL, {
+        const eventSource = new EventSource(sseURL, {
             withCredentials: true,
         })
 
-        eventSourceRef.current = eventSource
-
-        eventSource.onopen = () => {
-            setIsConnected(true)
-        }
-
-        const handleLog = (event: EventSourceEvent) => {
+        const handleLog = (event: MessageEvent<string>) => {
             try {
-                const messageEvent = event as EventSourceMessageEvent
-                const logData = normalizeJobLog(JSON.parse(messageEvent.data) as JobLogWire)
+                const logData = normalizeJobLog(JSON.parse(event.data) as JobLogWire)
 
                 setLiveLogs((existingLogs) => mergeLiveLogs(existingLogs, [logData]))
             } catch { /* ignore parsing errors */ }
@@ -239,17 +224,10 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
             toast.error('Log streaming error occurred')
         }
 
-        const handleEnd = () => {
-            setIsConnected(false)
-        }
-
         eventSource.addEventListener('log', handleLog)
         eventSource.addEventListener('error', handleError)
-        eventSource.addEventListener('end', handleEnd)
 
         eventSource.onerror = () => {
-            setIsConnected(false)
-
             // No error toast for normal disconnections
             if (eventSource.readyState !== EventSource.CLOSED) {
                 toast.error('Lost connection to log stream')
@@ -259,10 +237,7 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         return () => {
             eventSource.removeEventListener('log', handleLog)
             eventSource.removeEventListener('error', handleError)
-            eventSource.removeEventListener('end', handleEnd)
             eventSource.close()
-            eventSourceRef.current = null
-            setIsConnected(false)
         }
     }, [sseURL, isRunning, shouldFetch, getSearchQueryParams, workflowId, jobId])
 
@@ -275,114 +250,24 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         }
     }, [jobLogsSearchInfiniteQuery.error, jobLogsInfiniteQuery.error])
 
-    const retainedLogs = logsFromPages(jobLogsInfiniteQuery.data?.pages)
-    const runningLogs = mergeLiveLogs(retainedLogs, liveLogs)
-    const searchLogs = logsFromPages(jobLogsSearchInfiniteQuery.data?.pages)
+    const isSearching = shouldFetch && Boolean(getSearchQueryParams)
+    const query = isSearching ? jobLogsSearchInfiniteQuery : jobLogsInfiniteQuery
+    const hasLogs = isSearching || isCompleted || isRunning
+    const logs = hasLogs ? logsFromPages(query.data?.pages) : []
 
-    if (shouldFetch && Boolean(getSearchQueryParams)) {
-        return {
-            logs: searchLogs,
-            isLoading: jobLogsSearchInfiniteQuery.isLoading,
-            error: jobLogsSearchInfiniteQuery.error,
-            fetchNextPage: jobLogsSearchInfiniteQuery.fetchNextPage,
-            isFetchingNextPage: jobLogsSearchInfiniteQuery.isFetchingNextPage,
-            hasNextPage: jobLogsSearchInfiniteQuery.hasNextPage,
-            refetch: jobLogsSearchInfiniteQuery.refetch,
-            searchQuery: searchQuery,
-            updateSearchQuery: updateSearchQuery,
-            streamFilter: streamFilter,
-            applyStreamFilter: applyStreamFilter,
-            downloadLogsMutation,
-            isDownloadLogsMutationLoading: downloadLogsMutation.isPending,
-            isDownloadLogsMutationError: downloadLogsMutation.error,
-            isRetentionDisabled,
-            isLogsUnsupportedForKind,
-            workflowKind,
-            isWorkflowLoading,
-        };
-    }
-
-    if (isCompleted) {
-        return {
-            logs: retainedLogs,
-            isLoading: jobLogsInfiniteQuery.isLoading,
-            error: jobLogsInfiniteQuery.error,
-            fetchNextPage: jobLogsInfiniteQuery.fetchNextPage,
-            isFetchingNextPage: jobLogsInfiniteQuery.isFetchingNextPage,
-            hasNextPage: jobLogsInfiniteQuery.hasNextPage,
-            refetch: jobLogsInfiniteQuery.refetch,
-            searchQuery: searchQuery,
-            updateSearchQuery: updateSearchQuery,
-            streamFilter: streamFilter,
-            applyStreamFilter: applyStreamFilter,
-            isConnected: false,
-            isSSEEnabled: false,
-            disconnect: () => { },
-            getMaxSequenceNum: () => 0,
-            downloadLogsMutation,
-            isDownloadLogsMutationLoading: downloadLogsMutation.isPending,
-            isDownloadLogsMutationError: downloadLogsMutation.error,
-            isRetentionDisabled,
-            isLogsUnsupportedForKind,
-            workflowKind,
-            isWorkflowLoading,
-        }
-    }
-
-    if (isRunning) {
-        const isSSEEnabled = shouldFetch && !getSearchQueryParams
-
-        return {
-            logs: runningLogs,
-            isLoading: jobLogsInfiniteQuery.isLoading,
-            error: jobLogsInfiniteQuery.error,
-            fetchNextPage: jobLogsInfiniteQuery.fetchNextPage,
-            isFetchingNextPage: jobLogsInfiniteQuery.isFetchingNextPage,
-            hasNextPage: jobLogsInfiniteQuery.hasNextPage,
-            refetch: jobLogsInfiniteQuery.refetch,
-            searchQuery: searchQuery,
-            updateSearchQuery: updateSearchQuery,
-            streamFilter: streamFilter,
-            applyStreamFilter: applyStreamFilter,
-            isConnected,
-            isSSEEnabled,
-            disconnect: () => {
-                if (eventSourceRef.current) {
-                    eventSourceRef.current.close()
-                    eventSourceRef.current = null
-                    setIsConnected(false)
-                }
-            },
-            downloadLogsMutation,
-            isDownloadLogsMutationLoading: downloadLogsMutation.isPending,
-            isDownloadLogsMutationError: downloadLogsMutation.error,
-            isRetentionDisabled,
-            isLogsUnsupportedForKind,
-            workflowKind,
-            isWorkflowLoading,
-        }
-    }
-
-    // For PENDING and QUEUED - return empty state
     return {
-        logs: [],
-        isLoading: false,
-        error: null,
-        fetchNextPage: () => Promise.resolve(),
-        isFetchingNextPage: false,
-        hasNextPage: false,
-        refetch: () => Promise.resolve(),
-        searchQuery: searchQuery,
-        updateSearchQuery: updateSearchQuery,
-        streamFilter: streamFilter,
-        applyStreamFilter: applyStreamFilter,
-        isConnected: false,
-        isSSEEnabled: false,
-        disconnect: () => { },
-        getMaxSequenceNum: () => 0,
+        logs: isRunning && !isSearching ? mergeLiveLogs(logs, liveLogs) : logs,
+        isLoading: hasLogs ? query.isLoading : false,
+        error: hasLogs ? query.error : null,
+        fetchNextPage: hasLogs ? query.fetchNextPage : () => Promise.resolve(),
+        isFetchingNextPage: hasLogs ? query.isFetchingNextPage : false,
+        hasNextPage: hasLogs ? query.hasNextPage : false,
+        searchQuery,
+        updateSearchQuery,
+        streamFilter,
+        applyStreamFilter,
         downloadLogsMutation,
         isDownloadLogsMutationLoading: downloadLogsMutation.isPending,
-        isDownloadLogsMutationError: downloadLogsMutation.error,
         isRetentionDisabled,
         isLogsUnsupportedForKind,
         workflowKind,

--- a/dashboard/src/features/render-states.test.tsx
+++ b/dashboard/src/features/render-states.test.tsx
@@ -1,0 +1,69 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { beforeEach, expect, it, vi } from "vitest"
+import { WorkflowAnalyticsPanel } from "./analytics/workflow-analytics-panel"
+import { WorkflowCard } from "./workflows/workflow-card"
+import JobDetailsAndLogsPage from "./jobs/job-details-page"
+import { LogsViewer } from "./logs/logs-viewer"
+
+const mocks = vi.hoisted(() => ({ logs: {} as Record<string, any>, job: {} as Record<string, any> }))
+vi.mock("next/navigation", () => ({
+    useParams: () => ({ workflowId: "w", jobId: "j" }),
+    usePathname: () => "/workflows/w/jobs/j",
+    useSearchParams: () => new URLSearchParams(),
+    useRouter: () => ({}),
+}))
+vi.mock("./logs/use-job-logs", () => ({ useJobLogs: () => mocks.logs }))
+vi.mock("./jobs/use-job-details", () => ({ useJobDetails: () => mocks.job }))
+vi.mock("react-virtuoso", () => ({ Virtuoso: ({ totalCount }: { totalCount: number }) => <div>Rows: {totalCount}</div> }))
+
+beforeEach(() => {
+    mocks.logs = { logs: [], searchQuery: "", streamFilter: "", workflowKind: "CONTAINER" }
+    mocks.job = {}
+})
+
+it.each([
+    [{ isLoading: true, error: new Error("offline") }, 'data-slot="skeleton"'],
+    [{ error: new Error("offline") }, "Analytics unavailable"],
+    [{}, "No analytics yet"],
+    [{ analytics: { workflow_id: "w", total_jobs: 2, total_joblogs: 8, total_job_execution_duration: 10 } }, "Job executions"],
+])("preserves analytics state priority for %j", (state, text) => {
+    const html = renderToStaticMarkup(<WorkflowAnalyticsPanel isLoading={false} logRetention={false} workflowKind="CONTAINER" onRetry={() => {}} {...state} />)
+    expect(html).toContain(text)
+    if ("isLoading" in state && state.isLoading) expect(html).not.toContain("Analytics unavailable")
+})
+
+it.each([
+    [{ isLoading: true, error: new Error("offline") }, "RUNNING", "Loading logs..."],
+    [{ error: new Error("offline"), logs: [{}] }, "RUNNING", "Error loading logs"],
+    [{ logs: [{}], isRetentionDisabled: true }, "RUNNING", "Rows: 1"],
+    [{ isLogsUnsupportedForKind: true, searchQuery: "x" }, "COMPLETED", "Logs are not available for"],
+    [{ isRetentionDisabled: true, searchQuery: "x" }, "COMPLETED", "Log retention is disabled"],
+    [{ searchQuery: "x" }, "COMPLETED", "No logs found"],
+    [{}, "RUNNING", "Logs will appear here as the job executes"],
+    [{}, "QUEUED", "Job is waiting to start"],
+    [{}, "FAILED", "Job failed to execute"],
+    [{}, "COMPLETED", "Job completed successfully"],
+    [{}, "CANCELED", "This job did not produce any logs"],
+])("preserves log state priority for %j / %s", (state, status, text) => {
+    Object.assign(mocks.logs, state)
+    expect(renderToStaticMarkup(<LogsViewer workflowId="w" jobId="j" jobStatus={status} completedAt="" />)).toContain(text)
+})
+
+it("renders unfinished and completed job timelines", () => {
+    mocks.job = { job: { created_at: "2026-01-01T00:00:00Z", scheduled_at: "2026-01-01T00:00:00Z", status: "QUEUED" } }
+    let html = renderToStaticMarkup(<JobDetailsAndLogsPage />)
+    expect(html).toContain("Not started yet")
+    expect(html).toContain("Not completed yet")
+    expect(html).toContain("Not available")
+    Object.assign(mocks.job.job, { started_at: "2026-01-01T00:00:00Z", completed_at: "2026-01-01T00:01:05Z" })
+    html = renderToStaticMarkup(<JobDetailsAndLogsPage />)
+    expect(html).toContain("1 minute 5 seconds")
+    expect(html).not.toContain("Not started yet")
+})
+
+it("uses the same failure defaults for text and progress", () => {
+    const html = renderToStaticMarkup(<WorkflowCard workflow={{ id: "w", name: "Workflow", kind: "CONTAINER", payload: "", build_status: "COMPLETED", interval: 60, log_retention: true, created_at: "2026-01-01", updated_at: "2026-01-01", max_consecutive_job_failures_allowed: 3 }} />)
+    expect(html).toContain("0 / 3")
+    expect(html).toContain("width:0%")
+    expect(html).toContain("Runs every 1 hour")
+})

--- a/dashboard/src/features/workflows/create-workflow-dialog.tsx
+++ b/dashboard/src/features/workflows/create-workflow-dialog.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { WorkflowNumberField, ContainerListField } from "./workflow-form-fields"
+
 import { Fragment } from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm, useWatch, type Resolver } from "react-hook-form"
@@ -343,12 +345,7 @@ function renderCreateWorkflowDialogView(model: any) {
                 </DialogHeader>
 
                 <Form {...form}>
-                    <form onSubmit={(e) => {
-                        e.preventDefault();
-                        form.handleSubmit((data: WorkflowFormValues) => {
-                            handleSubmit(data);
-                        })(e);
-                    }} className="space-y-6 pt-2">
+                    <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6 pt-2">
                         <FormField
                             control={form.control}
                             name="name"
@@ -426,31 +423,7 @@ function renderCreateWorkflowDialogView(model: any) {
                                             )}
                                         />
 
-                                        <FormField
-                                            control={form.control}
-                                            name="heartbeatPayload.expectedStatusCode"
-                                            render={({ field }) => (
-                                                <FormItem>
-                                                    <FormLabel>Expected Status Code</FormLabel>
-                                                    <FormControl>
-                                                        <Input
-                                                            type="number"
-                                                            min={100}
-                                                            max={599}
-                                                            {...field}
-                                                            value={field.value === undefined ? "" : field.value}
-                                                            onChange={(e) => {
-                                                                field.onChange(e.target.value === "" ? "" : Number(e.target.value));
-                                                            }}
-                                                        />
-                                                    </FormControl>
-                                                    <FormDescription>
-                                                        The HTTP status code expected from the endpoint (default: 200)
-                                                    </FormDescription>
-                                                    <FormMessage />
-                                                </FormItem>
-                                            )}
-                                        />
+                                        <WorkflowNumberField name="heartbeatPayload.expectedStatusCode" />
 
                                         <div className="space-y-2">
                                             <FormLabel>
@@ -481,6 +454,7 @@ function renderCreateWorkflowDialogView(model: any) {
                                                         name={`heartbeatPayload.headers.${index}.key`}
                                                         render={({ field }) => (
                                                             <FormItem className="flex-1">
+                                                                <FormLabel className="sr-only">Header {index + 1} name</FormLabel>
                                                                 <FormControl>
                                                                     <Input
                                                                         placeholder="Header name"
@@ -497,6 +471,7 @@ function renderCreateWorkflowDialogView(model: any) {
                                                         name={`heartbeatPayload.headers.${index}.value`}
                                                         render={({ field }) => (
                                                             <FormItem className="flex-1">
+                                                                <FormLabel className="sr-only">Header {index + 1} value</FormLabel>
                                                                 <FormControl>
                                                                     <Input
                                                                         placeholder="Value"
@@ -519,6 +494,7 @@ function renderCreateWorkflowDialogView(model: any) {
                                                         }}
                                                     >
                                                         <Trash2 className="h-4 w-4" />
+                                                        <span className="sr-only">Remove header {index + 1}</span>
                                                     </Button>
                                                 </div>
                                             ))}
@@ -570,131 +546,9 @@ function renderCreateWorkflowDialogView(model: any) {
                                             )}
                                         />
 
-                                        <div className="space-y-2">
-                                            <FormLabel>
-                                                Command (optional)
-                                                <Button
-                                                    type="button"
-                                                    variant="outline"
-                                                    size="sm"
-                                                    className="ml-2"
-                                                    onClick={() => {
-                                                        form.setValue("containerPayload.cmd", [
-                                                            ...cmdFields,
-                                                            ""
-                                                        ])
-                                                        form.setValue("containerPayload.cmdIds", [
-                                                            ...cmdFieldIds,
-                                                            crypto.randomUUID()
-                                                        ])
-                                                    }}
-                                                >
-                                                    <Plus className="mr-1 h-3 w-3" /> Add argument
-                                                </Button>
-                                            </FormLabel>
-                                            <FormDescription>
-                                                Optional command and arguments to run in the container
-                                            </FormDescription>
+                                        <ContainerListField name="cmd" values={cmdFields} ids={cmdFieldIds} />
 
-                                            {cmdFields?.map((_: string, index: number) => (
-                                                <div key={cmdFieldIds[index]} className="flex items-center gap-2 mt-2">
-                                                    <FormField
-                                                        control={form.control}
-                                                        name={`containerPayload.cmd.${index}`}
-                                                        render={({ field }) => (
-                                                            <FormItem className="flex-1">
-                                                                <FormControl>
-                                                                    <Input
-                                                                        placeholder={"sh -c 'echo hello'"}
-                                                                        {...field}
-                                                                        value={field.value || ""}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-                                                    <Button
-                                                        type="button"
-                                                        variant="ghost"
-                                                        size="sm"
-                                                        onClick={() => {
-                                                            const updatedCmds = [...cmdFields]
-                                                            const updatedCmdIds = [...cmdFieldIds]
-                                                            updatedCmds.splice(index, 1)
-                                                            updatedCmdIds.splice(index, 1)
-                                                            form.setValue("containerPayload.cmd", updatedCmds)
-                                                            form.setValue("containerPayload.cmdIds", updatedCmdIds)
-                                                        }}
-                                                    >
-                                                        <Trash2 className="h-4 w-4" />
-                                                    </Button>
-                                                </div>
-                                            ))}
-                                        </div>
-
-                                        <div className="space-y-2">
-                                            <FormLabel>
-                                                Environment variables (optional)
-                                                <Button
-                                                    type="button"
-                                                    variant="outline"
-                                                    size="sm"
-                                                    className="ml-2"
-                                                    onClick={() => {
-                                                        form.setValue("containerPayload.env", [
-                                                            ...envFields,
-                                                            ""
-                                                        ])
-                                                        form.setValue("containerPayload.envIds", [
-                                                            ...envFieldIds,
-                                                            crypto.randomUUID()
-                                                        ])
-                                                    }}
-                                                >
-                                                    <Plus className="mr-1 h-3 w-3" /> Add variable
-                                                </Button>
-                                            </FormLabel>
-                                            <FormDescription>
-                                                Optional environment variables to set in the container
-                                            </FormDescription>
-
-                                            {envFields.map((_: string, index: number) => (
-                                                <div key={envFieldIds[index]} className="flex items-center gap-2 mt-2">
-                                                    <FormField
-                                                        control={form.control}
-                                                        name={`containerPayload.env.${index}`}
-                                                        render={({ field }) => (
-                                                            <FormItem className="flex-1">
-                                                                <FormControl>
-                                                                    <Input
-                                                                        placeholder={"MY_ENV=VALUE"}
-                                                                        {...field}
-                                                                        value={field.value || ""}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-                                                    <Button
-                                                        type="button"
-                                                        variant="ghost"
-                                                        size="sm"
-                                                        onClick={() => {
-                                                            const updatedEnvs = [...envFields]
-                                                            const updatedEnvIds = [...envFieldIds]
-                                                            updatedEnvs.splice(index, 1)
-                                                            updatedEnvIds.splice(index, 1)
-                                                            form.setValue("containerPayload.env", updatedEnvs)
-                                                            form.setValue("containerPayload.envIds", updatedEnvIds)
-                                                        }}
-                                                    >
-                                                        <Trash2 className="h-4 w-4" />
-                                                    </Button>
-                                                </div>
-                                            ))}
-                                        </div>
+                                        <ContainerListField name="env" values={envFields} ids={envFieldIds} />
 
                                         <FormField
                                             control={form.control}
@@ -721,55 +575,9 @@ function renderCreateWorkflowDialogView(model: any) {
                             </CardContent>
                         </Card>
 
-                        <FormField
-                            control={form.control}
-                            name="interval"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Interval (minutes)</FormLabel>
-                                    <FormControl>
-                                        <Input
-                                            type="number"
-                                            min={1}
-                                            {...field}
-                                            value={field.value === undefined ? "" : field.value}
-                                            onChange={(e) => {
-                                                field.onChange(e.target.value === "" ? "" : Number(e.target.value));
-                                            }}
-                                        />
-                                    </FormControl>
-                                    <FormDescription>
-                                        How often to run this workflow.
-                                    </FormDescription>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                        <WorkflowNumberField name="interval" />
 
-                        <FormField
-                            control={form.control}
-                            name="maxConsecutiveJobFailuresAllowed"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Max consecutive failures allowed</FormLabel>
-                                    <FormControl>
-                                        <Input
-                                            type="number"
-                                            min={3}
-                                            {...field}
-                                            value={field.value === undefined ? "" : field.value}
-                                            onChange={(e) => {
-                                                field.onChange(e.target.value === "" ? "" : Number(e.target.value));
-                                            }}
-                                        />
-                                    </FormControl>
-                                    <FormDescription>
-                                        Maximum number of consecutive failures before the workflow is auto-disabled (default: 3).
-                                    </FormDescription>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                        <WorkflowNumberField name="maxConsecutiveJobFailuresAllowed" />
 
                         {selectedKind === "CONTAINER" && (
                             <FormField

--- a/dashboard/src/features/workflows/delete-workflow-dialog.tsx
+++ b/dashboard/src/features/workflows/delete-workflow-dialog.tsx
@@ -1,142 +1,19 @@
 "use client"
 
-import { Fragment } from "react"
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { z } from "zod"
-import {
-    AlertTriangle,
-    Loader2
-} from "lucide-react"
+import { WorkflowActionDialog, type WorkflowActionDialogProps } from "./workflow-action-dialog"
+import { useWorkflowDetails } from "./use-workflow-details"
 
-import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle
-} from "@/components/ui/dialog"
-import {
-    Form,
-    FormControl,
-    FormField,
-    FormItem,
-    FormMessage
-} from "@/components/ui/form"
-import { Input } from "@/components/ui/input"
-import { Button } from "@/components/ui/button"
-
-import { useWorkflowDetails } from "@/features/workflows/use-workflow-details"
-import type { Workflow } from "@/features/workflows/types"
-
-interface DeleteWorkflowDialogProps {
-    workflow: Workflow
-    open: boolean
-    onOpenChange: (_open: boolean) => void
-}
-
-export function DeleteWorkflowDialog({
-    workflow,
-    open,
-    onOpenChange
-}: DeleteWorkflowDialogProps) {
-    const { deleteWorkflow, isDeleting } = useWorkflowDetails(workflow.id)
-
-    const FormSchema = z.object({
-        confirmName: z.string().refine(value => value === workflow.name, {
-            message: "Workflow name doesn't match"
-        })
-    })
-
-    const form = useForm<z.infer<typeof FormSchema>>({
-        resolver: zodResolver(FormSchema),
-        defaultValues: {
-            confirmName: ""
-        },
-        mode: "onSubmit",
-    })
-
-    const handleDelete = () => {
-        deleteWorkflow()
-        onOpenChange(false)
-    }
-
+export function DeleteWorkflowDialog(props: WorkflowActionDialogProps) {
+    const { deleteWorkflow, isDeleting } = useWorkflowDetails(props.workflow.id)
     return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="sm:max-w-lg">
-                <DialogHeader>
-                    <DialogTitle className="flex items-center gap-2">
-                        <AlertTriangle className="h-5 w-5 text-destructive" />
-                        Delete workflow
-                    </DialogTitle>
-                    <DialogDescription>
-                        This action cannot be undone, and will delete the workflow
-                    </DialogDescription>
-                </DialogHeader>
-
-                <div className="py-2">
-                    <div className="rounded-md bg-destructive/10 p-4 mb-4">
-                        <p className="grow sm:text-sm text-xs text-destructive">
-                            Deleting this workflow will remove it permanently from the system, including all its jobs and history. This action cannot be undone.
-                        </p>
-                    </div>
-
-                    <Form {...form}>
-                        <form onSubmit={form.handleSubmit(handleDelete)} className="space-y-4">
-                            <FormField
-                                control={form.control}
-                                name="confirmName"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormControl>
-                                            <div className="space-y-2">
-                                                <p className="text-sm text-muted-foreground">
-                                                    To confirm, type <span className="font-medium text-foreground">{workflow.name}</span>
-                                                </p>
-                                                <Input
-                                                    placeholder="Enter workflow name"
-                                                    {...field}
-                                                    autoComplete="off"
-                                                    disabled={isDeleting}
-                                                />
-                                            </div>
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
-
-                            <DialogFooter className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    onClick={() => onOpenChange(false)}
-                                    disabled={isDeleting}
-                                    className="cursor-pointer w-full"
-                                >
-                                    Cancel
-                                </Button>
-                                <Button
-                                    type="submit"
-                                    variant="destructive"
-                                    disabled={isDeleting || !form.formState.isValid}
-                                    className="cursor-pointer w-full"
-                                >
-                                    {isDeleting ? (
-                                        <Fragment>
-                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                            Deleting...
-                                        </Fragment>
-                                    ) : (
-                                        "Delete workflow"
-                                    )}
-                                </Button>
-                            </DialogFooter>
-                        </form>
-                    </Form>
-                </div>
-            </DialogContent>
-        </Dialog>
+        <WorkflowActionDialog
+            {...props}
+            onConfirm={deleteWorkflow}
+            isPending={isDeleting}
+            title="Delete workflow"
+            pendingLabel="Deleting..."
+            description="This action cannot be undone, and will delete the workflow"
+            warning="Deleting this workflow will remove it permanently from the system, including all its jobs and history. This action cannot be undone."
+        />
     )
 }

--- a/dashboard/src/features/workflows/terminate-workflow-dialog.tsx
+++ b/dashboard/src/features/workflows/terminate-workflow-dialog.tsx
@@ -1,143 +1,19 @@
 "use client"
 
-import { Fragment } from "react"
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { z } from "zod"
-import {
-    AlertTriangle,
-    Loader2
-} from "lucide-react"
+import { WorkflowActionDialog, type WorkflowActionDialogProps } from "./workflow-action-dialog"
+import { useWorkflowDetails } from "./use-workflow-details"
 
-import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle
-} from "@/components/ui/dialog"
-import {
-    Form,
-    FormControl,
-    FormField,
-    FormItem,
-    FormMessage
-} from "@/components/ui/form"
-import { Input } from "@/components/ui/input"
-import { Button } from "@/components/ui/button"
-
-import { useWorkflowDetails } from "@/features/workflows/use-workflow-details"
-import type { Workflow } from "@/features/workflows/types"
-
-interface TerminateWorkflowDialogProps {
-    workflow: Workflow
-    open: boolean
-    onOpenChange: (_open: boolean) => void
-}
-
-export function TerminateWorkflowDialog({
-    workflow,
-    open,
-    onOpenChange
-}: TerminateWorkflowDialogProps) {
-    const { terminateWorkflow, isTerminating } = useWorkflowDetails(workflow.id)
-
-    const FormSchema = z.object({
-        confirmName: z.string().refine(value => value === workflow.name, {
-            message: "Workflow name doesn't match"
-        })
-    })
-
-    const form = useForm<z.infer<typeof FormSchema>>({
-        resolver: zodResolver(FormSchema),
-        defaultValues: {
-            confirmName: ""
-        },
-        mode: "onSubmit",
-    })
-
-    const handleTerminate = () => {
-        terminateWorkflow()
-        onOpenChange(false)
-    }
-
+export function TerminateWorkflowDialog(props: WorkflowActionDialogProps) {
+    const { terminateWorkflow, isTerminating } = useWorkflowDetails(props.workflow.id)
     return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="sm:max-w-lg">
-                <DialogHeader>
-                    <DialogTitle className="flex items-center gap-2">
-                        <AlertTriangle className="h-5 w-5 text-destructive" />
-                        Terminate workflow
-                    </DialogTitle>
-                    <DialogDescription>
-                        This action will cancel all remaining jobs and scheduled executions for this workflow.
-                    </DialogDescription>
-                </DialogHeader>
-
-                <div className="py-2">
-                    <div className="rounded-md bg-destructive/10 p-4 mb-4">
-                        <p className="grow sm:text-sm text-xs text-destructive">
-                            Terminating this workflow will terminate all ongoing jobs
-                            and prevent any future scheduled executions.
-                        </p>
-                    </div>
-
-                    <Form {...form}>
-                        <form onSubmit={form.handleSubmit(handleTerminate)} className="space-y-4">
-                            <FormField
-                                control={form.control}
-                                name="confirmName"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormControl>
-                                            <div className="space-y-2">
-                                                <p className="text-sm text-muted-foreground">
-                                                    To confirm, type <span className="font-medium text-foreground">{workflow.name}</span>
-                                                </p>
-                                                <Input
-                                                    placeholder="Enter workflow name"
-                                                    {...field}
-                                                    autoComplete="off"
-                                                    disabled={isTerminating}
-                                                />
-                                            </div>
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
-
-                            <DialogFooter className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    onClick={() => onOpenChange(false)}
-                                    disabled={isTerminating}
-                                    className="cursor-pointer w-full"
-                                >
-                                    Cancel
-                                </Button>
-                                <Button
-                                    type="submit"
-                                    variant="destructive"
-                                    disabled={isTerminating || !form.formState.isValid}
-                                    className="cursor-pointer w-full"
-                                >
-                                    {isTerminating ? (
-                                        <Fragment>
-                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                            Terminating...
-                                        </Fragment>
-                                    ) : (
-                                        "Terminate workflow"
-                                    )}
-                                </Button>
-                            </DialogFooter>
-                        </form>
-                    </Form>
-                </div>
-            </DialogContent>
-        </Dialog>
+        <WorkflowActionDialog
+            {...props}
+            onConfirm={terminateWorkflow}
+            isPending={isTerminating}
+            title="Terminate workflow"
+            pendingLabel="Terminating..."
+            description="This action will cancel all remaining jobs and scheduled executions for this workflow."
+            warning="Terminating this workflow will terminate all ongoing jobs and prevent any future scheduled executions."
+        />
     )
 }

--- a/dashboard/src/features/workflows/update-workflow-dialog.tsx
+++ b/dashboard/src/features/workflows/update-workflow-dialog.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { WorkflowNumberField, ContainerListField } from "./workflow-form-fields"
+
 import { Fragment, useEffect } from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm, useWatch, type Resolver } from "react-hook-form"
@@ -389,31 +391,7 @@ function renderUpdateWorkflowDialogView(model: any) {
                                                 )}
                                             />
 
-                                            <FormField
-                                                control={form.control}
-                                                name="heartbeatPayload.expectedStatusCode"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <FormLabel>Expected Status Code</FormLabel>
-                                                        <FormControl>
-                                                            <Input
-                                                                type="number"
-                                                                min={100}
-                                                                max={599}
-                                                                {...field}
-                                                                value={field.value === undefined ? "" : field.value}
-                                                                onChange={(e) => {
-                                                                    field.onChange(e.target.value === "" ? "" : Number(e.target.value));
-                                                                }}
-                                                            />
-                                                        </FormControl>
-                                                        <FormDescription>
-                                                            The expected HTTP status code from the endpoint
-                                                        </FormDescription>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
+                                            <WorkflowNumberField name="heartbeatPayload.expectedStatusCode" />
 
                                             <div className="space-y-2">
                                                 <FormLabel>
@@ -444,6 +422,7 @@ function renderUpdateWorkflowDialogView(model: any) {
                                                             name={`heartbeatPayload.headers.${index}.key`}
                                                             render={({ field }) => (
                                                                 <FormItem className="flex-1">
+                                                                    <FormLabel className="sr-only">Header {index + 1} name</FormLabel>
                                                                     <FormControl>
                                                                         <Input
                                                                             placeholder="Header Name"
@@ -459,6 +438,7 @@ function renderUpdateWorkflowDialogView(model: any) {
                                                             name={`heartbeatPayload.headers.${index}.value`}
                                                             render={({ field }) => (
                                                                 <FormItem className="flex-1">
+                                                                    <FormLabel className="sr-only">Header {index + 1} value</FormLabel>
                                                                     <FormControl>
                                                                         <Input
                                                                             placeholder="Value"
@@ -480,6 +460,7 @@ function renderUpdateWorkflowDialogView(model: any) {
                                                             }}
                                                         >
                                                             <Trash2 className="h-4 w-4" />
+                                                            <span className="sr-only">Remove header {index + 1}</span>
                                                         </Button>
                                                     </div>
                                                 ))}
@@ -529,131 +510,9 @@ function renderUpdateWorkflowDialogView(model: any) {
                                                 )}
                                             />
 
-                                            <div className="space-y-2">
-                                                <FormLabel>
-                                                    Command (optional)
-                                                    <Button
-                                                        type="button"
-                                                        variant="outline"
-                                                        size="sm"
-                                                        className="ml-2"
-                                                        onClick={() => {
-                                                            form.setValue("containerPayload.cmd", [
-                                                                ...cmdFields,
-                                                                ""
-                                                            ])
-                                                            form.setValue("containerPayload.cmdIds", [
-                                                                ...cmdFieldIds,
-                                                                crypto.randomUUID()
-                                                            ])
-                                                        }}
-                                                    >
-                                                        <Plus className="mr-1 h-3 w-3" /> Add argument
-                                                    </Button>
-                                                </FormLabel>
-                                                <FormDescription>
-                                                    Optional command and arguments to run in the container
-                                                </FormDescription>
+                                            <ContainerListField name="cmd" values={cmdFields} ids={cmdFieldIds} />
 
-                                                {cmdFields.map((_: string, index: number) => (
-                                                    <div key={cmdFieldIds[index]} className="flex items-center gap-2 mt-2">
-                                                        <FormField
-                                                            control={form.control}
-                                                            name={`containerPayload.cmd.${index}`}
-                                                            render={({ field }) => (
-                                                                <FormItem className="flex-1">
-                                                                    <FormControl>
-                                                                        <Input
-                                                                            placeholder={"sh -c 'echo hello'"}
-                                                                            {...field}
-                                                                            value={field.value || ""}
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-                                                        <Button
-                                                            type="button"
-                                                            variant="ghost"
-                                                            size="sm"
-                                                            onClick={() => {
-                                                                const updatedCmds = [...cmdFields]
-                                                                const updatedCmdIds = [...cmdFieldIds]
-                                                                updatedCmds.splice(index, 1)
-                                                                updatedCmdIds.splice(index, 1)
-                                                                form.setValue("containerPayload.cmd", updatedCmds)
-                                                                form.setValue("containerPayload.cmdIds", updatedCmdIds)
-                                                            }}
-                                                        >
-                                                            <Trash2 className="h-4 w-4" />
-                                                        </Button>
-                                                    </div>
-                                                ))}
-                                            </div>
-
-                                            <div className="space-y-2">
-                                                <FormLabel>
-                                                    Environment Variables (optional)
-                                                    <Button
-                                                        type="button"
-                                                        variant="outline"
-                                                        size="sm"
-                                                        className="ml-2"
-                                                        onClick={() => {
-                                                            form.setValue("containerPayload.env", [
-                                                                ...envFields,
-                                                                ""
-                                                            ])
-                                                            form.setValue("containerPayload.envIds", [
-                                                                ...envFieldIds,
-                                                                crypto.randomUUID()
-                                                            ])
-                                                        }}
-                                                    >
-                                                        <Plus className="mr-1 h-3 w-3" /> Add variable
-                                                    </Button>
-                                                </FormLabel>
-                                                <FormDescription>
-                                                    Optional environment variables to set in the container
-                                                </FormDescription>
-
-                                                {envFields.map((_: string, index: number) => (
-                                                    <div key={envFieldIds[index]} className="flex items-center gap-2 mt-2">
-                                                        <FormField
-                                                            control={form.control}
-                                                            name={`containerPayload.env.${index}`}
-                                                            render={({ field }) => (
-                                                                <FormItem className="flex-1">
-                                                                    <FormControl>
-                                                                        <Input
-                                                                            placeholder={"MY_ENV=VALUE"}
-                                                                            {...field}
-                                                                            value={field.value || ""}
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-                                                        <Button
-                                                            type="button"
-                                                            variant="ghost"
-                                                            size="sm"
-                                                            onClick={() => {
-                                                                const updatedEnvs = [...envFields]
-                                                                const updatedEnvIds = [...envFieldIds]
-                                                                updatedEnvs.splice(index, 1)
-                                                                updatedEnvIds.splice(index, 1)
-                                                                form.setValue("containerPayload.env", updatedEnvs)
-                                                                form.setValue("containerPayload.envIds", updatedEnvIds)
-                                                            }}
-                                                        >
-                                                            <Trash2 className="h-4 w-4" />
-                                                        </Button>
-                                                    </div>
-                                                ))}
-                                            </div>
+                                            <ContainerListField name="env" values={envFields} ids={envFieldIds} />
 
                                             <FormField
                                                 control={form.control}
@@ -679,55 +538,9 @@ function renderUpdateWorkflowDialogView(model: any) {
                                 </CardContent>
                             </Card>
 
-                            <FormField
-                                control={form.control}
-                                name="interval"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>Interval (minutes)</FormLabel>
-                                        <FormControl>
-                                            <Input
-                                                type="number"
-                                                min={1}
-                                                {...field}
-                                                value={field.value === undefined ? "" : field.value}
-                                                onChange={(e) => {
-                                                    field.onChange(e.target.value === "" ? "" : Number(e.target.value));
-                                                }}
-                                            />
-                                        </FormControl>
-                                        <FormDescription>
-                                            How often to run this workflow.
-                                        </FormDescription>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
+                            <WorkflowNumberField name="interval" />
 
-                            <FormField
-                                control={form.control}
-                                name="maxConsecutiveJobFailuresAllowed"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>Max consecutive failures allowed</FormLabel>
-                                        <FormControl>
-                                            <Input
-                                                type="number"
-                                                min={3}
-                                                {...field}
-                                                value={field.value === undefined ? "" : field.value}
-                                                onChange={(e) => {
-                                                    field.onChange(e.target.value === "" ? "" : Number(e.target.value));
-                                                }}
-                                            />
-                                        </FormControl>
-                                        <FormDescription>
-                                            Maximum number of consecutive failures before the workflow is auto-disabled (default: 3).
-                                        </FormDescription>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
+                            <WorkflowNumberField name="maxConsecutiveJobFailuresAllowed" />
 
                             <DialogFooter className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                 <Button

--- a/dashboard/src/features/workflows/workflow-action-dialog.tsx
+++ b/dashboard/src/features/workflows/workflow-action-dialog.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { Fragment } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import {
+    AlertTriangle,
+    Loader2
+} from "lucide-react"
+
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle
+} from "@/components/ui/dialog"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+import type { Workflow } from "@/features/workflows/types"
+
+export interface WorkflowActionDialogProps {
+    workflow: Workflow
+    open: boolean
+    onOpenChange: (_open: boolean) => void
+}
+
+export function WorkflowActionDialog({ workflow, open, onOpenChange, onConfirm, isPending, title, description, warning, pendingLabel }: WorkflowActionDialogProps & {
+    onConfirm: () => void
+    isPending: boolean
+    title: string
+    description: string
+    warning: string
+    pendingLabel: string
+}) {
+
+    const FormSchema = z.object({
+        confirmName: z.string().refine(value => value === workflow.name, {
+            message: "Workflow name doesn't match"
+        })
+    })
+
+    const form = useForm<z.infer<typeof FormSchema>>({
+        resolver: zodResolver(FormSchema),
+        defaultValues: {
+            confirmName: ""
+        },
+        mode: "onSubmit",
+    })
+
+    const handleConfirm = () => {
+        onConfirm()
+        onOpenChange(false)
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <AlertTriangle className="h-5 w-5 text-destructive" />
+                        {title}
+                    </DialogTitle>
+                    <DialogDescription>
+                        {description}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="py-2">
+                    <div className="rounded-md bg-destructive/10 p-4 mb-4">
+                        <p className="grow sm:text-sm text-xs text-destructive">
+                            {warning}
+                        </p>
+                    </div>
+
+                    <Form {...form}>
+                        <form onSubmit={form.handleSubmit(handleConfirm)} className="space-y-4">
+                            <FormField
+                                control={form.control}
+                                name="confirmName"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel className="text-sm text-muted-foreground">
+                                            To confirm, type <span className="font-medium text-foreground">{workflow.name}</span>
+                                        </FormLabel>
+                                        <FormControl>
+                                            <Input placeholder="Enter workflow name" {...field} autoComplete="off" disabled={isPending} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <DialogFooter className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={() => onOpenChange(false)}
+                                    disabled={isPending}
+                                    className="cursor-pointer w-full"
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    type="submit"
+                                    variant="destructive"
+                                    disabled={isPending || !form.formState.isValid}
+                                    className="cursor-pointer w-full"
+                                >
+                                    {isPending ? (
+                                        <Fragment>
+                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                            {pendingLabel}
+                                        </Fragment>
+                                    ) : (
+                                        title
+                                    )}
+                                </Button>
+                            </DialogFooter>
+                        </form>
+                    </Form>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/dashboard/src/features/workflows/workflow-card.tsx
+++ b/dashboard/src/features/workflows/workflow-card.tsx
@@ -23,8 +23,11 @@ interface WorkflowCardProps {
 }
 
 export function WorkflowCard({ workflow }: WorkflowCardProps) {
+    const failureCount = workflow.consecutive_job_failures_count ?? 0
+    const failureLimit = workflow.max_consecutive_job_failures_allowed ?? 1
+
     // Determine status
-    const status = workflow?.terminated_at ? "TERMINATED" : workflow.build_status
+    const status = workflow.terminated_at ? "TERMINATED" : workflow.build_status
 
     // Format dates
     const updatedAt = formatDistanceToNow(new Date(workflow.updated_at), { addSuffix: true })
@@ -102,7 +105,7 @@ export function WorkflowCard({ workflow }: WorkflowCardProps) {
                                 <span className="text-xs font-medium">Failures</span>
                             </div>
                             <span className="text-xs font-medium">
-                                {workflow?.consecutive_job_failures_count ?? 0} / {workflow?.max_consecutive_job_failures_allowed ?? 1}
+                                {failureCount} / {failureLimit}
                             </span>
                         </div>
 
@@ -110,7 +113,7 @@ export function WorkflowCard({ workflow }: WorkflowCardProps) {
                             <div
                                 className="bg-orange-500 h-1 rounded-full"
                                 style={{
-                                    width: `${(workflow?.consecutive_job_failures_count ?? 0) / (workflow?.max_consecutive_job_failures_allowed ?? 1) * 100}%`
+                                    width: `${(failureCount) / (failureLimit) * 100}%`
                                 }}
                             />
                         </div>

--- a/dashboard/src/features/workflows/workflow-form-fields.tsx
+++ b/dashboard/src/features/workflows/workflow-form-fields.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useFormContext } from "react-hook-form"
+import { Plus, Trash2 } from "lucide-react"
+import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+const numberFields = {
+    "heartbeatPayload.expectedStatusCode": {
+        label: "Expected Status Code", min: 100, max: 599,
+        description: "The HTTP status code expected from the endpoint (default: 200)",
+    },
+    interval: {
+        label: "Interval (minutes)", min: 1, max: undefined,
+        description: "How often to run this workflow.",
+    },
+    maxConsecutiveJobFailuresAllowed: {
+        label: "Max consecutive failures allowed", min: 3, max: undefined,
+        description: "Maximum number of consecutive failures before the workflow is auto-disabled (default: 3).",
+    },
+}
+
+export function WorkflowNumberField({ name }: { name: keyof typeof numberFields }) {
+    const { control } = useFormContext()
+    const { label, min, max, description } = numberFields[name]
+    return (
+        <FormField control={control} name={name} render={({ field }) => (
+            <FormItem>
+                <FormLabel>{label}</FormLabel>
+                <FormControl>
+                    <Input type="number" min={min} max={max} {...field}
+                        value={field.value === undefined ? "" : field.value}
+                        onChange={(e) => field.onChange(e.target.value === "" ? "" : Number(e.target.value))}
+                    />
+                </FormControl>
+                <FormDescription>{description}</FormDescription>
+                <FormMessage />
+            </FormItem>
+        )} />
+    )
+}
+
+const containerLists = {
+    cmd: { title: "Command", label: "Command argument", add: "Add argument", placeholder: "sh -c 'echo hello'", description: "Optional command and arguments to run in the container" },
+    env: { title: "Environment variables", label: "Environment variable", add: "Add variable", placeholder: "MY_ENV=VALUE", description: "Optional environment variables to set in the container" },
+}
+
+export function ContainerListField({ name, values, ids }: { name: "cmd" | "env", values: string[], ids: string[] }) {
+    const form = useFormContext()
+    const labels = containerLists[name]
+    return (
+        <div className="space-y-2">
+            <div className="text-sm font-medium">
+                {labels.title} (optional)
+                <Button type="button" variant="outline" size="sm" className="ml-2" onClick={() => {
+                    form.setValue(`containerPayload.${name}`, [...values, ""])
+                    form.setValue(`containerPayload.${name}Ids`, [...ids, crypto.randomUUID()])
+                }}>
+                    <Plus className="mr-1 h-3 w-3" /> {labels.add}
+                </Button>
+            </div>
+            <p className="text-muted-foreground text-sm">{labels.description}</p>
+            {values.map((_, index) => (
+                <div key={ids[index]} className="flex items-center gap-2 mt-2">
+                    <FormField control={form.control} name={`containerPayload.${name}.${index}`} render={({ field }) => (
+                        <FormItem className="flex-1">
+                            <FormLabel className="sr-only">{labels.label} {index + 1}</FormLabel>
+                            <FormControl><Input placeholder={labels.placeholder} {...field} value={field.value || ""} /></FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )} />
+                    <Button type="button" variant="ghost" size="sm" onClick={() => {
+                        form.setValue(`containerPayload.${name}`, values.filter((_, i) => i !== index))
+                        form.setValue(`containerPayload.${name}Ids`, ids.filter((_, i) => i !== index))
+                    }}>
+                        <Trash2 className="h-4 w-4" />
+                        <span className="sr-only">Remove {labels.label.toLowerCase()} {index + 1}</span>
+                    </Button>
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/dashboard/src/features/workflows/workflow-forms.test.tsx
+++ b/dashboard/src/features/workflows/workflow-forms.test.tsx
@@ -1,0 +1,87 @@
+import { Children, isValidElement, type ReactElement, type ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import * as rhf from "react-hook-form"
+import { afterEach, expect, it, vi } from "vitest"
+import { Form } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { WorkflowActionDialog } from "./workflow-action-dialog"
+import type { Workflow } from "./types"
+import { ContainerListField, WorkflowNumberField } from "./workflow-form-fields"
+
+vi.mock("react-hook-form", async (importOriginal) => {
+    const actual = await importOriginal<typeof rhf>()
+    return { ...actual, useForm: vi.fn(actual.useForm), useFormContext: vi.fn(actual.useFormContext) }
+})
+
+function descendants(node: ReactNode): ReactElement<any>[] {
+    return Children.toArray(node).flatMap((child) => isValidElement<{ children?: ReactNode }>(child)
+        ? [child, ...descendants(child.props.children)] : [])
+}
+
+function renderForm(children: ReactNode) {
+    let form!: rhf.UseFormReturn
+    function Harness() {
+        form = rhf.useForm<rhf.FieldValues>({ defaultValues: { containerPayload: { cmd: ["one", "two"], env: ["A=1", "B=2"] } } })
+        return <Form {...form}>{children}</Form>
+    }
+    const html = renderToStaticMarkup(<Harness />)
+    vi.mocked(rhf.useFormContext).mockReturnValue(form)
+    return { form, html }
+}
+
+afterEach(() => { vi.restoreAllMocks(); vi.resetAllMocks() })
+
+it.each(["cmd", "env"] as const)("labels %s fields and keeps values paired with stable IDs", (name) => {
+    const props = { name, values: ["one", "two"], ids: ["first", "second"] }
+    const { form, html } = renderForm(<ContainerListField {...props} />)
+    for (const input of html.matchAll(/<input[^>]*\sid="([^"]+)"/g)) {
+        expect(html).toContain(`for="${input[1]}"`)
+    }
+    expect(html.match(/<input/g)).toHaveLength(2)
+    const buttons = descendants(ContainerListField(props)).filter((node) => node.type === Button)
+    const setValue = vi.spyOn(form, "setValue")
+    buttons[0].props.onClick()
+    expect(setValue).toHaveBeenCalledWith(`containerPayload.${name}`, ["one", "two", ""])
+    expect(setValue).toHaveBeenCalledWith(`containerPayload.${name}Ids`, ["first", "second", expect.any(String)])
+    setValue.mockClear()
+    buttons[1].props.onClick()
+    expect(setValue).toHaveBeenCalledWith(`containerPayload.${name}`, ["two"])
+    expect(setValue).toHaveBeenCalledWith(`containerPayload.${name}Ids`, ["second"])
+})
+
+it.each([
+    ["heartbeatPayload.expectedStatusCode", 100, 599],
+    ["interval", 1, undefined],
+    ["maxConsecutiveJobFailuresAllowed", 3, undefined],
+] as const)("preserves %s numeric input bounds and empty values", (name, min, max) => {
+    renderForm(<WorkflowNumberField name={name} />)
+    const onChange = vi.fn()
+    const tree = WorkflowNumberField({ name }).props.render({ field: { value: undefined, onChange } })
+    const input = descendants(tree).find((node) => node.type === Input)!
+    expect(input.props).toMatchObject({ min, max, value: "", type: "number" })
+    input.props.onChange({ target: { value: "" } })
+    input.props.onChange({ target: { value: "200" } })
+    expect(onChange.mock.calls).toEqual([[""], [200]])
+})
+
+it("requires the exact workflow name before confirming a destructive action", async () => {
+    const onConfirm = vi.fn()
+    const onOpenChange = vi.fn()
+    let tree!: ReactElement
+    function Harness() {
+        tree = WorkflowActionDialog({ workflow: { name: "My workflow" } as Workflow, open: true, onOpenChange, onConfirm, isPending: false, title: "Delete workflow", description: "Delete", warning: "Cannot be undone", pendingLabel: "Deleting..." })
+        return null
+    }
+    renderToStaticMarkup(<Harness />)
+    const form = vi.mocked(rhf.useForm).mock.results.at(-1)!.value as rhf.UseFormReturn
+    const submit = descendants(tree).find((node) => node.type === "form")!.props.onSubmit
+    form.setValue("confirmName", "wrong")
+    await submit()
+    expect(onConfirm).not.toHaveBeenCalled()
+    expect(onOpenChange).not.toHaveBeenCalled()
+    form.setValue("confirmName", "My workflow")
+    await submit()
+    expect(onConfirm).toHaveBeenCalledOnce()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+})

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -1,0 +1,6 @@
+import { fileURLToPath } from "node:url"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+    resolve: { alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) } },
+})

--- a/internal/pkg/cache/singleflight.go
+++ b/internal/pkg/cache/singleflight.go
@@ -1,0 +1,35 @@
+package cache
+
+import (
+	"context"
+	"errors"
+
+	"golang.org/x/sync/singleflight"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// WaitSingleflightResult waits for a shared result while respecting the caller's context.
+func WaitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
+	var zero T
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
+		}
+
+		return zero, status.Error(codes.Canceled, ctx.Err().Error())
+	case result := <-resultCh:
+		if result.Err != nil {
+			return zero, result.Err
+		}
+
+		typed, ok := result.Val.(T)
+		if !ok {
+			return zero, status.Error(codes.Internal, "invalid singleflight result type")
+		}
+
+		return typed, nil
+	}
+}

--- a/internal/pkg/cache/singleflight_test.go
+++ b/internal/pkg/cache/singleflight_test.go
@@ -1,0 +1,52 @@
+package cache_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	cachepkg "github.com/hitesh22rana/chronoverse/internal/pkg/cache"
+)
+
+func TestWaitSingleflightResult(t *testing.T) {
+	repoErr := errors.New("repository failed")
+	for _, tt := range []struct {
+		name   string
+		result singleflight.Result
+		want   string
+		err    error
+	}{
+		{name: "value", result: singleflight.Result{Val: "shared"}, want: "shared"},
+		{name: "error", result: singleflight.Result{Err: repoErr}, err: repoErr},
+		{name: "wrong type", result: singleflight.Result{Val: 42}, err: status.Error(codes.Internal, "invalid singleflight result type")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			results := make(chan singleflight.Result, 1)
+			results <- tt.result
+			got, err := cachepkg.WaitSingleflightResult[string](t.Context(), results)
+			if got != tt.want || !errors.Is(err, tt.err) {
+				t.Fatalf("got (%q, %v), want (%q, %v)", got, err, tt.want, tt.err)
+			}
+		})
+	}
+
+	for _, code := range []codes.Code{codes.Canceled, codes.DeadlineExceeded} {
+		t.Run(code.String(), func(t *testing.T) {
+			deadline := time.Now().Add(time.Hour)
+			if code == codes.DeadlineExceeded {
+				deadline = time.Unix(0, 0)
+			}
+			ctx, cancel := context.WithDeadline(t.Context(), deadline)
+			cancel()
+			got, err := cachepkg.WaitSingleflightResult[string](ctx, make(chan singleflight.Result))
+			if got != "" || status.Code(err) != code {
+				t.Fatalf("got (%q, %v), want empty value and %s", got, err, code)
+			}
+		})
+	}
+}

--- a/internal/repository/executor/executor_integration_test.go
+++ b/internal/repository/executor/executor_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
+	"github.com/hitesh22rana/chronoverse/internal/pkg/imagepull"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/joblogevents"
 	kafkapkg "github.com/hitesh22rana/chronoverse/internal/pkg/kafka"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/testkit"
@@ -23,7 +24,7 @@ func TestIntegrationImagePullLockSerializesBuilds(t *testing.T) {
 	ctx := context.Background()
 	inner := testkit.NewFakeContainerSvc(200 * time.Millisecond)
 
-	svc := NewImagePullLockedContainerSvc(inner, testkit.Redis(t), ImagePullLockConfig{
+	svc := NewImagePullLockedContainerSvc(inner, testkit.Redis(t), imagepull.Config{
 		TTL:           5 * time.Second,
 		WaitTimeout:   10 * time.Second,
 		RetryInterval: 10 * time.Millisecond,

--- a/internal/repository/executor/image_pull_lock.go
+++ b/internal/repository/executor/image_pull_lock.go
@@ -2,25 +2,16 @@ package executor
 
 import (
 	"context"
-	"time"
 
 	"github.com/hitesh22rana/chronoverse/internal/pkg/imagepull"
 )
 
-// ImagePullLockConfig configures runtime-local Docker image pull coordination.
-type ImagePullLockConfig struct {
-	TTL           time.Duration
-	WaitTimeout   time.Duration
-	RetryInterval time.Duration
-	LockScope     string
-}
-
 // NewImagePullLockedContainerSvc wraps a container service with Redis-backed image pull coordination.
-func NewImagePullLockedContainerSvc(inner ContainerSvc, locks imagepull.LockStore, cfg ImagePullLockConfig) ContainerSvc {
+func NewImagePullLockedContainerSvc(inner ContainerSvc, locks imagepull.LockStore, cfg imagepull.Config) ContainerSvc {
 	return &imagePullLockedContainerSvc{
 		ContainerSvc: inner,
 		locks:        locks,
-		cfg:          imagepull.Config(cfg),
+		cfg:          cfg,
 	}
 }
 

--- a/internal/repository/workflow/image_pull_lock.go
+++ b/internal/repository/workflow/image_pull_lock.go
@@ -2,25 +2,16 @@ package workflow
 
 import (
 	"context"
-	"time"
 
 	"github.com/hitesh22rana/chronoverse/internal/pkg/imagepull"
 )
 
-// ImagePullLockConfig configures distributed Docker image pull coordination.
-type ImagePullLockConfig struct {
-	TTL           time.Duration
-	WaitTimeout   time.Duration
-	RetryInterval time.Duration
-	LockScope     string
-}
-
 // NewImagePullLockedContainerSvc wraps a container service with Redis-backed image pull coordination.
-func NewImagePullLockedContainerSvc(inner ContainerSvc, locks imagepull.LockStore, cfg ImagePullLockConfig) ContainerSvc {
+func NewImagePullLockedContainerSvc(inner ContainerSvc, locks imagepull.LockStore, cfg imagepull.Config) ContainerSvc {
 	return &imagePullLockedContainerSvc{
 		ContainerSvc: inner,
 		locks:        locks,
-		cfg:          imagepull.Config(cfg),
+		cfg:          cfg,
 	}
 }
 

--- a/internal/repository/workflow/image_pull_lock_test.go
+++ b/internal/repository/workflow/image_pull_lock_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
+	"github.com/hitesh22rana/chronoverse/internal/pkg/imagepull"
 	workflowrepo "github.com/hitesh22rana/chronoverse/internal/repository/workflow"
 )
 
@@ -15,7 +16,7 @@ func TestImagePullLockedContainerSvcBuildDelegatesToSharedEnsure(t *testing.T) {
 
 	inner := &fakeContainerSvc{dockerHost: "tcp://docker-a:2375"}
 	locks := &fakeImagePullLockStore{acquireResults: []bool{true}}
-	svc := workflowrepo.NewImagePullLockedContainerSvc(inner, locks, workflowrepo.ImagePullLockConfig{
+	svc := workflowrepo.NewImagePullLockedContainerSvc(inner, locks, imagepull.Config{
 		TTL:           time.Minute,
 		WaitTimeout:   time.Minute,
 		RetryInterval: time.Millisecond,

--- a/internal/repository/workflow/workflow_integration_test.go
+++ b/internal/repository/workflow/workflow_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hitesh22rana/chronoverse/internal/pkg/imagepull"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/testkit"
 )
 
@@ -18,7 +19,7 @@ func TestIntegrationImagePullLockSerializesBuilds(t *testing.T) {
 	ctx := context.Background()
 	inner := testkit.NewFakeContainerSvc(200 * time.Millisecond)
 
-	svc := NewImagePullLockedContainerSvc(inner, testkit.Redis(t), ImagePullLockConfig{
+	svc := NewImagePullLockedContainerSvc(inner, testkit.Redis(t), imagepull.Config{
 		TTL:           5 * time.Second,
 		WaitTimeout:   10 * time.Second,
 		RetryInterval: 10 * time.Millisecond,

--- a/internal/service/analytics/analytics.go
+++ b/internal/service/analytics/analytics.go
@@ -4,7 +4,6 @@ package analytics
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/go-playground/validator/v10"
@@ -16,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	analyticsmodel "github.com/hitesh22rana/chronoverse/internal/model/analytics"
+	cachepkg "github.com/hitesh22rana/chronoverse/internal/pkg/cache"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 	analyticspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/analytics"
 )
@@ -71,7 +71,7 @@ func (s *Service) GetUserAnalytics(ctx context.Context, req *analyticspb.GetUser
 		return s.repo.GetUserAnalytics(ctx, req.GetUserId())
 	})
 
-	res, err = waitSingleflightResult[*analyticsmodel.GetUserAnalyticsResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*analyticsmodel.GetUserAnalyticsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -112,34 +112,10 @@ func (s *Service) GetWorkflowAnalytics(ctx context.Context, req *analyticspb.Get
 		},
 	)
 
-	res, err = waitSingleflightResult[*analyticsmodel.GetWorkflowAnalyticsResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*analyticsmodel.GetWorkflowAnalyticsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
 
 	return res, nil
-}
-
-func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
-	var zero T
-
-	select {
-	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
-		}
-
-		return zero, status.Error(codes.Canceled, ctx.Err().Error())
-	case result := <-resultCh:
-		if result.Err != nil {
-			return zero, result.Err
-		}
-
-		typed, ok := result.Val.(T)
-		if !ok {
-			return zero, status.Error(codes.Internal, "invalid singleflight result type")
-		}
-
-		return typed, nil
-	}
 }

--- a/internal/service/jobs/jobs.go
+++ b/internal/service/jobs/jobs.go
@@ -560,7 +560,7 @@ func (s *Service) GetJobByID(ctx context.Context, req *jobspb.GetJobByIDRequest)
 		return s.repo.GetJobByID(ctx, req.GetId())
 	})
 
-	res, err = waitSingleflightResult[*jobsmodel.GetJobByIDResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*jobsmodel.GetJobByIDResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -682,7 +682,7 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		return _res, nil
 	})
 
-	res, err = waitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -890,7 +890,7 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 		return _res, nil
 	})
 
-	res, err = waitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*jobsmodel.GetJobLogsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -967,7 +967,7 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 		return s.repo.ListJobs(ctx, req.GetWorkflowId(), req.GetUserId(), cursor, filters)
 	})
 
-	res, err = waitSingleflightResult[*jobsmodel.ListJobsResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*jobsmodel.ListJobsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -1059,28 +1059,4 @@ func decodeListJobsCursor(token string) (string, error) {
 	}
 
 	return string(decoded), nil
-}
-
-func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
-	var zero T
-
-	select {
-	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
-		}
-
-		return zero, status.Error(codes.Canceled, ctx.Err().Error())
-	case result := <-resultCh:
-		if result.Err != nil {
-			return zero, result.Err
-		}
-
-		typed, ok := result.Val.(T)
-		if !ok {
-			return zero, status.Error(codes.Internal, "invalid singleflight result type")
-		}
-
-		return typed, nil
-	}
 }

--- a/internal/service/notifications/notifications.go
+++ b/internal/service/notifications/notifications.go
@@ -5,7 +5,6 @@ package notifications
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 
 	"github.com/go-playground/validator/v10"
@@ -17,6 +16,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	notificationsmodel "github.com/hitesh22rana/chronoverse/internal/model/notifications"
+	cachepkg "github.com/hitesh22rana/chronoverse/internal/pkg/cache"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/idempotency"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 	notificationspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/notifications"
@@ -177,7 +177,7 @@ func (s *Service) ListNotifications(
 		},
 	)
 
-	res, err = waitSingleflightResult[*notificationsmodel.ListNotificationsResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*notificationsmodel.ListNotificationsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -192,28 +192,4 @@ func decodeCursor(token string) (string, error) {
 	}
 
 	return string(decoded), nil
-}
-
-func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
-	var zero T
-
-	select {
-	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
-		}
-
-		return zero, status.Error(codes.Canceled, ctx.Err().Error())
-	case result := <-resultCh:
-		if result.Err != nil {
-			return zero, result.Err
-		}
-
-		typed, ok := result.Val.(T)
-		if !ok {
-			return zero, status.Error(codes.Internal, "invalid singleflight result type")
-		}
-
-		return typed, nil
-	}
 }

--- a/internal/service/users/users.go
+++ b/internal/service/users/users.go
@@ -259,7 +259,7 @@ func (s *Service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (res 
 		return _res, nil
 	})
 
-	res, err = waitSingleflightResult[*usersmodel.GetUserResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*usersmodel.GetUserResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -334,28 +334,4 @@ func normalizeLoginError(err error) error {
 	}
 
 	return err
-}
-
-func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
-	var zero T
-
-	select {
-	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
-		}
-
-		return zero, status.Error(codes.Canceled, ctx.Err().Error())
-	case result := <-resultCh:
-		if result.Err != nil {
-			return zero, result.Err
-		}
-
-		typed, ok := result.Val.(T)
-		if !ok {
-			return zero, status.Error(codes.Internal, "invalid singleflight result type")
-		}
-
-		return typed, nil
-	}
 }

--- a/internal/service/workflows/workflows.go
+++ b/internal/service/workflows/workflows.go
@@ -428,7 +428,7 @@ func (s *Service) GetWorkflow(ctx context.Context, req *workflowspb.GetWorkflowR
 		return _res, nil
 	})
 
-	res, err = waitSingleflightResult[*workflowsmodel.GetWorkflowResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*workflowsmodel.GetWorkflowResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +466,7 @@ func (s *Service) GetWorkflowByID(ctx context.Context, req *workflowspb.GetWorkf
 		return s.repo.GetWorkflowByID(ctx, req.GetId())
 	})
 
-	res, err = waitSingleflightResult[*workflowsmodel.GetWorkflowByIDResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*workflowsmodel.GetWorkflowByIDResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -801,7 +801,7 @@ func (s *Service) ListWorkflows(ctx context.Context, req *workflowspb.ListWorkfl
 		return _res, nil
 	})
 
-	res, err = waitSingleflightResult[*workflowsmodel.ListWorkflowsResponse](ctx, resultCh)
+	res, err = cachepkg.WaitSingleflightResult[*workflowsmodel.ListWorkflowsResponse](ctx, resultCh)
 	if err != nil {
 		return nil, err
 	}
@@ -920,29 +920,5 @@ func (s *Service) invalidateWorkflowsCache(ctx context.Context, userID string, l
 			zap.String("user_id", userID),
 			zap.String("cache_key", cacheKey),
 			zap.Int64("count", count))
-	}
-}
-
-func waitSingleflightResult[T any](ctx context.Context, resultCh <-chan singleflight.Result) (T, error) {
-	var zero T
-
-	select {
-	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return zero, status.Error(codes.DeadlineExceeded, ctx.Err().Error())
-		}
-
-		return zero, status.Error(codes.Canceled, ctx.Err().Error())
-	case result := <-resultCh:
-		if result.Err != nil {
-			return zero, result.Err
-		}
-
-		typed, ok := result.Val.(T)
-		if !ok {
-			return zero, status.Error(codes.Internal, "invalid singleflight result type")
-		}
-
-		return typed, nil
 	}
 }

--- a/scripts/compose/validate.sh
+++ b/scripts/compose/validate.sh
@@ -233,11 +233,19 @@ validate_auth_bundle() {
     echo "local Kubernetes issuer material must use only the isolated auth-certs PVC" >&2
     exit 1
   fi
-  # Makefile must inject per-issuer private key paths
-  if ! grep -q 'certs/issuers/users-service/auth.ed' "$root_dir/Makefile"; then
-    echo "Makefile does not inject per-issuer auth key paths" >&2
-    exit 1
-  fi
+  # Check expanded recipes so shared Make rules retain each binary's issuer.
+  for cmd_dir in "$root_dir"/cmd/*; do
+    svc=${cmd_dir##*/}
+    issuer=$svc
+    [ "$svc" != database-migration ] || issuer=server
+    recipe=$(make -s -n -C "$root_dir" -o dependencies "build/$svc")
+    for key in "authPrivateKeyPath=certs/issuers/$issuer/auth.ed'" "authPublicKeyPath=certs/issuers/$issuer/auth.ed.pub'"; do
+      if ! printf '%s\n' "$recipe" | grep -Fq "$key"; then
+        echo "Makefile does not inject $key for $svc" >&2
+        exit 1
+      fi
+    done
+  done
   # Auth package must expose kid-aware bundle
   if ! grep -q 'kidForKey' "$root_dir/internal/pkg/auth/bundle.go"; then
     echo "internal/pkg/auth/bundle.go missing kid handling" >&2


### PR DESCRIPTION
## Description

Consolidate repeated build recipes, Go helpers, and dashboard forms, and remove unused log-hook state and the EventSource polyfill. Preserve the existing app/service/repository layers. The work is grouped into five focused, signed commits.

- Replace 28 build/run recipes with Make static pattern rules; preserve binary names, linker flags, and database-migration's server certificate issuer.
- Share the five identical singleflight result handlers and accept the existing image-pull configuration type directly.
- Use native `EventSource`, remove its runtime/types packages, and remove unread connection state and hook controls.
- Share authentication inputs, workflow numeric/list fields, and destructive confirmation forms. Add accessible names to header, command, and environment inputs and their remove buttons; correctly associate confirmation labels with inputs. Remove a redundant submission wrapper already handled by React Hook Form.
- Replace nested analytics/log render branches with guarded content components, consolidate job timeline rows and failure defaults, and share URL-filter updates and inactive-query handling.

The React Doctor follow-up removes another net 304 lines, including 27 additional tests. Both React workspaces now score **100/100 with zero diagnostics** using `npx react-doctor@latest` (0.9.13), with a full uncached scan and no rule suppressions or configuration changes. The dashboard baseline was 81/100; the static site already scored 100/100.

## Rationale and risk

Repeated behavior now has one implementation without changing service boundaries, persistence, locking, or Go retry policies. The singleflight function body is unchanged; cancellation, deadlines, repository errors, and result-type errors have direct regression coverage. All 58 before/after build/run dry-run comparisons matched, including custom version settings.

Dashboard form validation, numeric empty-value handling, stable list IDs, and exact-name confirmation remain intact. Shared fields use consistent help text. Render checks preserve loading/error/data/empty-state priority, and hook checks preserve filtering and unavailable-log behavior. The render and hook tests also pass against the original pre-cleanup implementation. These are server-rendering and focused handler tests, not browser end-to-end coverage.

The dashboard relies on native SSE reconnection rather than the polyfill's transport/inactivity handling. Cookie credentials remain enabled; named log events, malformed-event handling, stream gating, and connection cleanup are covered with an EventTarget-based stream double. Native EventSource support is required; older browsers without it are not supported by this change.

## Validation

- `make dependencies`; generated protobuf files and `buf.lock` unchanged.
- `make -o dependencies test/short` — all Go unit tests pass with the race detector.
- `make -o dependencies test/integration` — all 40 top-level Docker integration tests pass with the race detector.
- `.bin/golangci-lint run` — zero issues.
- `make -o dependencies build/all` — all 14 binaries build.
- `make compose/validate` — passes, including expanded issuer-path checks.
- Dashboard: `npm ci --ignore-scripts`, `npm test` (**109 tests**), `npx tsc --noEmit`, `npm run lint`, and `npm run build` — pass.
- Static site: `npm run check` — docs/OpenAPI/LLM validation, lint, types, and static export pass.
- Both React workspaces: `npx react-doctor@latest --no-cache` — **100/100, zero warnings/errors**.
- Thirteen targeted behavioral mutations rejected: eight from the Go/SSE cleanup, plus list-ID removal, numeric empty values, exact-name confirmation, URL-filter clearing, and log-render priority. Sources restored and checks rerun green.
- `git diff --check`; commit signatures verified.

The Go checks cover the earlier commits; the follow-up changes only dashboard code, and dashboard/static checks were rerun. The `-o dependencies` runs reuse completed dependency/protobuf generation. Local validation used Go 1.26.5 and Node 25.2.1 on macOS; CI also checks Linux and Node 26. CI runs on the PR and is left for normal human review.

## Type of change

- [x] Chore (refactoring, accessibility fixes, and regression coverage)

## Checklist

- [x] Existing repository layering preserved
- [x] Self-review completed
- [x] New and existing tests pass locally
- [x] Relevant lint, type, build, and project checks pass locally
- [x] Commits signed and signatures verified
