### PR TITLE
Refine and shorten comments across codebase

### DIFF
--- a/cmd/analytics-processor/main.go
+++ b/cmd/analytics-processor/main.go
@@ -23,9 +23,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -34,11 +32,9 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Handle OS signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
@@ -46,14 +42,12 @@ func run() int {
 		cancel()
 	}()
 
-	// Load the analyticsprocessor service configuration
 	cfg, err := config.InitAnalyticsProcessorConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the PostgreSQL database
 	pdb, err := postgres.New(ctx, &postgres.Config{
 		Host:        cfg.Postgres.Host,
 		Port:        cfg.Postgres.Port,
@@ -78,7 +72,6 @@ func run() int {
 	}
 	defer pdb.Close()
 
-	// Initialize the kafka client
 	kafkaLifecycle := kafka.NewPartitionLifecycle()
 	kfk, err := kafka.New(ctx,
 		kafka.WithBrokers(cfg.Kafka.Brokers...),
@@ -94,7 +87,6 @@ func run() int {
 	}
 	defer kfk.Close()
 
-	// Initialize the analyticsprocessor job components
 	repo := analyticsprocessorrepo.New(pdb, kfk, kafkaLifecycle)
 	svc := analyticsprocessorsvc.New(repo)
 	app := analyticsprocessor.New(ctx, &analyticsprocessor.Config{
@@ -104,7 +96,6 @@ func run() int {
 		ProcessedEventsRetention: cfg.AnalyticsProcessorConfig.ProcessedEventsRetention,
 	}, svc)
 
-	// Log the job information
 	loggerpkg.FromContext(ctx).Info(
 		"starting job",
 		zap.Any("ctx", ctx),
@@ -115,7 +106,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Run the analyticsprocessor job
 	if err := app.Run(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/analytics-service/main.go
+++ b/cmd/analytics-service/main.go
@@ -25,9 +25,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -36,25 +34,21 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Load the analytics service configuration
 	cfg, err := config.InitAnalyticsServiceConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the auth issuer
 	auth, err := auth.New()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the postgres store
 	pdb, err := postgres.New(ctx, &postgres.Config{
 		Host:        cfg.Postgres.Host,
 		Port:        cfg.Postgres.Port,
@@ -79,16 +73,12 @@ func run() int {
 	}
 	defer pdb.Close()
 
-	// Initialize the analytics repository
 	repo := analyticsrepo.New(auth, pdb)
 
-	// Initialize the validator utility
 	validator := validator.New()
 
-	// Initialize the analytics service
 	svc := analyticssvc.New(validator, repo)
 
-	// Initialize the analytics application
 	app := analytics.New(ctx, &analytics.Config{
 		Deadline:    cfg.Grpc.RequestTimeout,
 		Environment: cfg.Environment.Env,
@@ -100,7 +90,6 @@ func run() int {
 		},
 	}, auth, svc)
 
-	// Create a TCP listener
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Grpc.Port))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create listener: %v\n", err)
@@ -109,7 +98,6 @@ func run() int {
 
 	go grpcserverpkg.GracefulStop(ctx, app, 20*time.Second)
 
-	// Log the service information
 	loggerpkg.FromContext(ctx).Info(
 		"starting service",
 		zap.Any("ctx", ctx),
@@ -122,7 +110,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Start the gRPC server
 	if err := app.Serve(listener); err != nil {
 		if ctx.Err() != nil {
 			return ExitOk

--- a/cmd/database-migration/main.go
+++ b/cmd/database-migration/main.go
@@ -24,9 +24,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -35,11 +33,9 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Handle OS signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
@@ -47,14 +43,13 @@ func run() int {
 		cancel()
 	}()
 
-	// Load the database migration service configuration
 	cfg, err := config.InitDatabaseMigrationConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// DSN's for database connections
+	// DSNs for database connections
 	pgDSN := fmt.Sprintf(
 		"postgresql://%s:%s@%s:%d/%s",
 		url.QueryEscape(cfg.Postgres.User),
@@ -78,11 +73,9 @@ func run() int {
 			pgDSN += fmt.Sprintf("&sslkey=%s", url.QueryEscape(cfg.Postgres.TLS.KeyFile))
 		}
 	} else {
-		// Use a non-TLS DSN if TLS is not enabled
 		pgDSN += fmt.Sprintf("?sslmode=%s", "disable")
 	}
 
-	// Initialize the ClickHouse database client
 	clickhouseClient, err := clickhouse.New(ctx, &clickhouse.Config{
 		Hosts:           cfg.ClickHouse.Hosts,
 		Database:        cfg.ClickHouse.Database,
@@ -105,7 +98,6 @@ func run() int {
 	}
 	defer clickhouseClient.Close()
 
-	// Initialize the MeiliSearch client
 	meilisearchClient, err := meilisearch.New(
 		ctx,
 		meilisearch.WithURI(cfg.MeiliSearch.URI),
@@ -117,7 +109,6 @@ func run() int {
 		return ExitError
 	}
 
-	// Initialize the database migration components
 	repo := databasemigrationrepo.New(&databasemigrationrepo.Config{
 		PostgresDSN:       pgDSN,
 		ClickHouseClient:  clickhouseClient,
@@ -126,7 +117,6 @@ func run() int {
 	svc := databasemigrationsvc.New(repo)
 	app := databasemigration.New(ctx, svc)
 
-	// Log the job information
 	loggerpkg.FromContext(ctx).Info(
 		"starting job",
 		zap.Any("ctx", ctx),
@@ -137,7 +127,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Run the scheduling job
 	if err := app.Run(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/execution-worker/main.go
+++ b/cmd/execution-worker/main.go
@@ -35,9 +35,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -46,11 +44,9 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Handle OS signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
@@ -58,7 +54,6 @@ func run() int {
 		cancel()
 	}()
 
-	// Load the execution service configuration
 	cfg, err := config.InitExecutionJobConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -73,14 +68,12 @@ func run() int {
 		return ExitError
 	}
 
-	// Initialize the auth issuer
 	auth, err := auth.New()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the kafka client
 	kafkaLifecycle := kafka.NewPartitionLifecycle()
 	kfk, err := kafka.New(ctx,
 		kafka.WithBrokers(cfg.Kafka.Brokers...),
@@ -151,7 +144,6 @@ func run() int {
 		}
 	}()
 
-	// Connect to the workflows service
 	workflowsConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.WorkflowsService.Host,
@@ -172,7 +164,6 @@ func run() int {
 	}
 	defer workflowsConn.Close()
 
-	// Connect to the jobs service
 	jobsConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.JobsService.Host,
@@ -193,7 +184,6 @@ func run() int {
 	}
 	defer jobsConn.Close()
 
-	// Initialize the execution job components
 	repo, err := executorrepo.New(&executorrepo.Config{
 		WorkerID:                    cfg.ExecutionWorkerConfig.WorkerID,
 		Concurrency:                 cfg.ExecutionWorkerConfig.Concurrency,
@@ -233,7 +223,6 @@ func run() int {
 	svc := executorsvc.New(repo)
 	app := executor.New(ctx, svc)
 
-	// Log the job information
 	loggerpkg.FromContext(ctx).Info(
 		"starting job",
 		zap.Any("ctx", ctx),
@@ -244,7 +233,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Run the execution job
 	if err := app.Run(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/joblogs-processor/main.go
+++ b/cmd/joblogs-processor/main.go
@@ -26,9 +26,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -37,11 +35,9 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Handle OS signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
@@ -49,14 +45,12 @@ func run() int {
 		cancel()
 	}()
 
-	// Load the joblogs service configuration
 	cfg, err := config.InitJobLogsProcessorConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the redis store
 	rdb, err := redis.New(ctx, &redis.Config{
 		Host:                     cfg.Redis.Host,
 		Port:                     cfg.Redis.Port,
@@ -82,7 +76,6 @@ func run() int {
 	}
 	defer rdb.Close()
 
-	// Initialize the PostgreSQL database
 	pg, err := postgres.New(ctx, &postgres.Config{
 		Host:        cfg.Postgres.Host,
 		Port:        cfg.Postgres.Port,
@@ -107,7 +100,6 @@ func run() int {
 	}
 	defer pg.Close()
 
-	// Initialize the ClickHouse database
 	cdb, err := clickhouse.New(ctx, &clickhouse.Config{
 		Hosts:           cfg.ClickHouse.Hosts,
 		Database:        cfg.ClickHouse.Database,
@@ -130,7 +122,6 @@ func run() int {
 	}
 	defer cdb.Close()
 
-	// Initialize the MeiliSearch client
 	msdb, err := meilisearch.New(
 		ctx,
 		meilisearch.WithURI(cfg.MeiliSearch.URI),
@@ -143,7 +134,6 @@ func run() int {
 	}
 	defer msdb.Close()
 
-	// Initialize the kafka client
 	kafkaLifecycle := kafka.NewPartitionLifecycle()
 	kfk, err := kafka.New(ctx,
 		kafka.WithBrokers(cfg.Kafka.Brokers...),
@@ -159,7 +149,6 @@ func run() int {
 	}
 	defer kfk.Close()
 
-	// Initialize the joblogs job components
 	repo := joblogsrepo.New(&joblogsrepo.Config{
 		BatchJobLogsSizeLimit:    cfg.JobLogsProcessorConfig.BatchJobLogsSizeLimit,
 		BatchJobLogsTimeInterval: cfg.JobLogsProcessorConfig.BatchJobLogsTimeInterval,
@@ -167,7 +156,6 @@ func run() int {
 	svc := joblogssvc.New(repo)
 	app := joblogs.New(ctx, svc)
 
-	// Log the job information
 	loggerpkg.FromContext(ctx).Info(
 		"starting job",
 		zap.Any("ctx", ctx),
@@ -178,7 +166,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Run the joblogs job
 	if err := app.Run(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/jobs-service/main.go
+++ b/cmd/jobs-service/main.go
@@ -31,9 +31,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -42,25 +40,21 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Load the jobs service configuration
 	cfg, err := config.InitJobsServiceConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the auth issuer
 	auth, err := auth.New()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the PostgreSQL database
 	pdb, err := postgres.New(ctx, &postgres.Config{
 		Host:        cfg.Postgres.Host,
 		Port:        cfg.Postgres.Port,
@@ -85,7 +79,6 @@ func run() int {
 	}
 	defer pdb.Close()
 
-	// Initialize the redis store
 	rdb, err := redis.New(ctx, &redis.Config{
 		Host:                     cfg.Redis.Host,
 		Port:                     cfg.Redis.Port,
@@ -111,7 +104,6 @@ func run() int {
 	}
 	defer rdb.Close()
 
-	// Initialize the ClickHouse database
 	cdb, err := clickhouse.New(ctx, &clickhouse.Config{
 		Hosts:           cfg.ClickHouse.Hosts,
 		Database:        cfg.ClickHouse.Database,
@@ -134,7 +126,6 @@ func run() int {
 	}
 	defer cdb.Close()
 
-	// Initialize the MeiliSearch client
 	msdb, err := meilisearch.New(
 		ctx,
 		meilisearch.WithURI(cfg.MeiliSearch.URI),
@@ -147,7 +138,6 @@ func run() int {
 	}
 	defer msdb.Close()
 
-	// Connect to the workflows service
 	workflowsConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.WorkflowsService.Host,
@@ -168,7 +158,6 @@ func run() int {
 	}
 	defer workflowsConn.Close()
 
-	// Initialize the jobs repository
 	repo := jobsrepo.New(&jobsrepo.Config{
 		FetchLimit:            cfg.JobsServiceConfig.FetchLimit,
 		LogsFetchLimit:        cfg.JobsServiceConfig.LogsFetchLimit,
@@ -179,13 +168,10 @@ func run() int {
 		Workflows: workflowspb.NewWorkflowsServiceClient(workflowsConn),
 	})
 
-	// Initialize the validator utility
 	validator := validator.New()
 
-	// Initialize the jobs service
 	svc := jobssvc.New(validator, repo, rdb)
 
-	// Initialize the jobs application
 	app := jobs.New(ctx, &jobs.Config{
 		Deadline:    cfg.Grpc.RequestTimeout,
 		Environment: cfg.Environment.Env,
@@ -197,7 +183,6 @@ func run() int {
 		},
 	}, auth, svc)
 
-	// Create a TCP listener
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Grpc.Port))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create listener: %v\n", err)
@@ -206,7 +191,6 @@ func run() int {
 
 	go grpcserverpkg.GracefulStop(ctx, app, 20*time.Second)
 
-	// Log the service information
 	loggerpkg.FromContext(ctx).Info(
 		"starting service",
 		zap.Any("ctx", ctx),
@@ -219,7 +203,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Serve the gRPC service
 	if err := app.Serve(listener); err != nil {
 		if ctx.Err() != nil {
 			return ExitOk

--- a/cmd/notifications-service/main.go
+++ b/cmd/notifications-service/main.go
@@ -28,9 +28,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -39,25 +37,21 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Load the notifications service configuration
 	cfg, err := config.InitNotificationsServiceConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the auth issuer
 	auth, err := auth.New()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Connect to the users service
 	usersConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.UsersService.Host,
@@ -78,7 +72,6 @@ func run() int {
 	}
 	defer usersConn.Close()
 
-	// Initialize the PostgreSQL database
 	pdb, err := postgres.New(ctx, &postgres.Config{
 		Host:        cfg.Postgres.Host,
 		Port:        cfg.Postgres.Port,
@@ -103,7 +96,6 @@ func run() int {
 	}
 	defer pdb.Close()
 
-	// Initialize the notifications repository
 	repo := notificationsrepo.New(&notificationsrepo.Config{
 		FetchLimit:            cfg.NotificationsServiceConfig.FetchLimit,
 		EventCommandRetention: cfg.CommandIdempotency.EventRetention,
@@ -111,13 +103,10 @@ func run() int {
 		UsersService: userspb.NewUsersServiceClient(usersConn),
 	})
 
-	// Initialize the validator utility
 	validator := validator.New()
 
-	// Initialize the notifications service
 	svc := notificationssvc.New(validator, repo)
 
-	// Initialize the notifications application
 	app := notifications.New(ctx, &notifications.Config{
 		Deadline:    cfg.Grpc.RequestTimeout,
 		Environment: cfg.Environment.Env,
@@ -129,7 +118,6 @@ func run() int {
 		},
 	}, auth, svc)
 
-	// Create a TCP listener
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Grpc.Port))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create listener: %v\n", err)
@@ -138,7 +126,6 @@ func run() int {
 
 	go grpcserverpkg.GracefulStop(ctx, app, 20*time.Second)
 
-	// Log the service information
 	loggerpkg.FromContext(ctx).Info(
 		"starting service",
 		zap.Any("ctx", ctx),
@@ -151,7 +138,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Serve the gRPC service
 	if err := app.Serve(listener); err != nil {
 		if ctx.Err() != nil {
 			return ExitOk

--- a/cmd/runtime-agent/main.go
+++ b/cmd/runtime-agent/main.go
@@ -23,9 +23,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 

--- a/cmd/scheduling-worker/main.go
+++ b/cmd/scheduling-worker/main.go
@@ -22,9 +22,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -33,11 +31,9 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Handle OS signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
@@ -45,14 +41,12 @@ func run() int {
 		cancel()
 	}()
 
-	// Load the scheduling service configuration
 	cfg, err := config.InitSchedulingJobConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the PostgreSQL database
 	pdb, err := postgres.New(ctx, &postgres.Config{
 		Host:        cfg.Postgres.Host,
 		Port:        cfg.Postgres.Port,
@@ -77,7 +71,6 @@ func run() int {
 	}
 	defer pdb.Close()
 
-	// Initialize the scheduling job components
 	repo := schedulerrepo.New(&schedulerrepo.Config{
 		BatchSize: cfg.SchedulingWorkerConfig.BatchSize,
 	}, pdb)
@@ -87,7 +80,6 @@ func run() int {
 		ContextTimeout: cfg.SchedulingWorkerConfig.ContextTimeout,
 	}, svc)
 
-	// Log the job information
 	loggerpkg.FromContext(ctx).Info(
 		"starting job",
 		zap.Any("ctx", ctx),
@@ -98,7 +90,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Run the scheduling job
 	if err := app.Run(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,9 +27,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -38,32 +36,27 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Load the server configuration
 	cfg, err := config.InitServerConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the auth issuer
 	auth, err := authpkg.New()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the crypto module
 	crypto, err := crypto.New(cfg.Crypto.Secret)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Connect to the users service
 	usersConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.UsersService.Host,
@@ -84,7 +77,6 @@ func run() int {
 	}
 	defer usersConn.Close()
 
-	// Connect to the workflows service
 	workflowsConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.WorkflowsService.Host,
@@ -105,7 +97,6 @@ func run() int {
 	}
 	defer workflowsConn.Close()
 
-	// Connect to the jobs service
 	jobsConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.JobsService.Host,
@@ -126,7 +117,6 @@ func run() int {
 	}
 	defer jobsConn.Close()
 
-	// Connect to the notifications service
 	notificationsConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.NotificationsService.Host,
@@ -147,7 +137,6 @@ func run() int {
 	}
 	defer notificationsConn.Close()
 
-	// Connect to the analytics service
 	analyticsConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.AnalyticsService.Host,
@@ -168,7 +157,6 @@ func run() int {
 	}
 	defer analyticsConn.Close()
 
-	// Initialize the redis store
 	rdb, err := redis.New(ctx, &redis.Config{
 		Host:                     cfg.Redis.Host,
 		Port:                     cfg.Redis.Port,
@@ -223,7 +211,6 @@ func run() int {
 		analyticspb.NewAnalyticsServiceClient(analyticsConn),
 	)
 
-	// Log the server information
 	loggerpkg.FromContext(ctx).Info(
 		"starting server",
 		zap.Any("ctx", ctx),
@@ -236,7 +223,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Start the http server
 	if err := srv.Start(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/users-service/main.go
+++ b/cmd/users-service/main.go
@@ -26,9 +26,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -37,25 +35,21 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Load the users service configuration
 	cfg, err := config.InitUsersServiceConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the auth issuer
 	auth, err := auth.New()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the postgres store
 	pdb, err := postgres.New(ctx, &postgres.Config{
 		Host:        cfg.Postgres.Host,
 		Port:        cfg.Postgres.Port,
@@ -80,7 +74,6 @@ func run() int {
 	}
 	defer pdb.Close()
 
-	// Initialize the redis store
 	rdb, err := redis.New(ctx, &redis.Config{
 		Host:                     cfg.Redis.Host,
 		Port:                     cfg.Redis.Port,
@@ -106,16 +99,12 @@ func run() int {
 	}
 	defer rdb.Close()
 
-	// Initialize the users repository
 	repo := usersrepo.New(auth, pdb)
 
-	// Initialize the validator utility
 	validator := validator.New()
 
-	// Initialize the users service
 	svc := userssvc.New(validator, repo, rdb)
 
-	// Initialize the users application
 	app := users.New(ctx, &users.Config{
 		Deadline:    cfg.Grpc.RequestTimeout,
 		Environment: cfg.Environment.Env,
@@ -127,7 +116,6 @@ func run() int {
 		},
 	}, auth, svc)
 
-	// Create a TCP listener
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Grpc.Port))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create listener: %v\n", err)
@@ -136,7 +124,6 @@ func run() int {
 
 	go grpcserverpkg.GracefulStop(ctx, app, 20*time.Second)
 
-	// Log the service information
 	loggerpkg.FromContext(ctx).Info(
 		"starting service",
 		zap.Any("ctx", ctx),
@@ -149,7 +136,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Start the gRPC server
 	if err := app.Serve(listener); err != nil {
 		if ctx.Err() != nil {
 			return ExitOk

--- a/cmd/workflow-worker/main.go
+++ b/cmd/workflow-worker/main.go
@@ -33,9 +33,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -44,11 +42,9 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Handle OS signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
@@ -56,21 +52,18 @@ func run() int {
 		cancel()
 	}()
 
-	// Load the workflow service configuration
 	cfg, err := config.InitWorkflowWorkerConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the auth issuer
 	auth, err := auth.New()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the redis store
 	rdb, err := redis.New(ctx, &redis.Config{
 		Host:                     cfg.Redis.Host,
 		Port:                     cfg.Redis.Port,
@@ -96,7 +89,6 @@ func run() int {
 	}
 	defer rdb.Close()
 
-	// Initialize the ClickHouse database
 	cdb, err := clickhouse.New(ctx, &clickhouse.Config{
 		Hosts:           cfg.ClickHouse.Hosts,
 		Database:        cfg.ClickHouse.Database,
@@ -119,7 +111,6 @@ func run() int {
 	}
 	defer cdb.Close()
 
-	// Initialize the MeiliSearch client
 	msdb, err := meilisearch.New(
 		ctx,
 		meilisearch.WithURI(cfg.MeiliSearch.URI),
@@ -132,7 +123,6 @@ func run() int {
 	}
 	msdb.Close()
 
-	// Initialize the kafka client
 	kafkaLifecycle := kafka.NewPartitionLifecycle()
 	kfk, err := kafka.New(ctx,
 		kafka.WithBrokers(cfg.Kafka.Brokers...),
@@ -183,7 +173,6 @@ func run() int {
 		return workflowrepo.NewImagePullLockedContainerSvc(csvc, rdb, cfg), nil
 	}
 
-	// Connect to the workflows service
 	workflowsConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.WorkflowsService.Host,
@@ -204,7 +193,6 @@ func run() int {
 	}
 	defer workflowsConn.Close()
 
-	// Connect to the jobs service
 	jobsConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.JobsService.Host,
@@ -225,7 +213,6 @@ func run() int {
 	}
 	defer jobsConn.Close()
 
-	// Connect to the notifications service
 	notificationsConn, err := grpcclient.NewClient(
 		&grpcclient.ServiceConfig{
 			Host: cfg.NotificationsService.Host,
@@ -246,7 +233,6 @@ func run() int {
 	}
 	defer notificationsConn.Close()
 
-	// Initialize the workflow job components
 	repo := workflowrepo.New(auth, rdb, cdb, msdb, kfk, kafkaLifecycle, &workflowrepo.Services{
 		Workflows:       workflowspb.NewWorkflowsServiceClient(workflowsConn),
 		Jobs:            jobpb.NewJobsServiceClient(jobsConn),
@@ -256,7 +242,6 @@ func run() int {
 	svc := workflowsvc.New(repo)
 	app := workflow.New(ctx, svc)
 
-	// Log the job information
 	loggerpkg.FromContext(ctx).Info(
 		"starting job",
 		zap.Any("ctx", ctx),
@@ -267,7 +252,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Run the workflow job
 	if err := app.Run(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/workflows-service/main.go
+++ b/cmd/workflows-service/main.go
@@ -26,9 +26,7 @@ import (
 )
 
 const (
-	// ExitOk and ExitError are the exit codes.
 	ExitOk = iota
-	// ExitError is the exit code for errors.
 	ExitError
 )
 
@@ -37,25 +35,21 @@ func main() {
 }
 
 func run() int {
-	// Initialize the service with, all necessary components
 	ctx, cancel := svcpkg.Init()
 	defer cancel()
 
-	// Load the workflows service configuration
 	cfg, err := config.InitWorkflowsServiceConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the auth issuer
 	auth, err := auth.New()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 
-	// Initialize the PostgreSQL database
 	pdb, err := postgres.New(ctx, &postgres.Config{
 		Host:        cfg.Postgres.Host,
 		Port:        cfg.Postgres.Port,
@@ -80,7 +74,6 @@ func run() int {
 	}
 	defer pdb.Close()
 
-	// Initialize the redis store
 	rdb, err := redis.New(ctx, &redis.Config{
 		Host:                     cfg.Redis.Host,
 		Port:                     cfg.Redis.Port,
@@ -106,17 +99,13 @@ func run() int {
 	}
 	defer rdb.Close()
 
-	// Initialize the workflows repository
 	repo := workflowsrepo.New(&workflowsrepo.Config{
 		FetchLimit: cfg.WorkflowsServiceConfig.FetchLimit,
 	}, pdb)
 
-	// Initialize the validator utility
 	validator := validator.New()
 
-	// Initialize the workflows service
 	svc := workflowssvc.New(validator, repo, rdb)
-	// Initialize the workflows application
 	app := workflows.New(ctx, &workflows.Config{
 		Deadline:    cfg.Grpc.RequestTimeout,
 		Environment: cfg.Environment.Env,
@@ -128,7 +117,6 @@ func run() int {
 		},
 	}, auth, svc)
 
-	// Create a TCP listener
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Grpc.Port))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create listener: %v\n", err)
@@ -137,7 +125,6 @@ func run() int {
 
 	go grpcserverpkg.GracefulStop(ctx, app, 20*time.Second)
 
-	// Log the service information
 	loggerpkg.FromContext(ctx).Info(
 		"starting service",
 		zap.Any("ctx", ctx),
@@ -150,7 +137,6 @@ func run() int {
 		zap.Int64("gomemlimit", debug.SetMemoryLimit(0)),
 	)
 
-	// Serve the gRPC service
 	if err := app.Serve(listener); err != nil {
 		if ctx.Err() != nil {
 			return ExitOk

--- a/dashboard/src/components/ui/chart.tsx
+++ b/dashboard/src/components/ui/chart.tsx
@@ -316,7 +316,6 @@ function ChartLegendContent({
   )
 }
 
-// Helper to extract item config from a payload.
 function getPayloadConfigFromPayload(
   config: ChartConfig,
   payload: unknown,

--- a/dashboard/src/features/auth/use-auth.ts
+++ b/dashboard/src/features/auth/use-auth.ts
@@ -30,7 +30,6 @@ export function useAuth() {
   const queryClient = useQueryClient()
   const signupAttemptRef = useRef<SignupAttempt | null>(null)
 
-  // Login mutation
   const loginMutation = useMutation({
     mutationFn: async (credentials: LoginCredentials) => {
       await fetchApi(apiEndpoints.auth.login, "failed to login", {
@@ -47,7 +46,6 @@ export function useAuth() {
     },
   })
 
-  // Signup mutation
   const signupMutation = useMutation({
     mutationFn: async (command: SignupCommand) => {
       await fetchApi(apiEndpoints.auth.signup, "failed to signup", {
@@ -68,7 +66,6 @@ export function useAuth() {
     },
   })
 
-  // Logout mutation
   const logoutMutation = useMutation({
     mutationFn: async () => {
       await fetchApi(apiEndpoints.auth.logout, "failed to logout", {

--- a/dashboard/src/features/jobs/job-details-page.tsx
+++ b/dashboard/src/features/jobs/job-details-page.tsx
@@ -32,7 +32,6 @@ export default function JobDetailsAndLogsPage() {
     const { workflowId, jobId } = useParams() as { workflowId: string, jobId: string }
     const router = useRouter()
 
-    // Fetch job details and logs
     const {
         job,
         isLoading: isJobLoading,
@@ -40,7 +39,6 @@ export default function JobDetailsAndLogsPage() {
         refetch: refetchJob
     } = useJobDetails(workflowId, jobId)
 
-    // Handle manual refresh
     const handleRefresh = () => {
         refetchJob()
     }
@@ -169,7 +167,6 @@ export default function JobDetailsAndLogsPage() {
     )
 }
 
-// Helper function to format duration between two dates
 function formatDuration(start: Date, end: Date): string {
     const diffInSeconds = Math.floor((end.getTime() - start.getTime()) / 1000);
 

--- a/dashboard/src/features/jobs/job-status.ts
+++ b/dashboard/src/features/jobs/job-status.ts
@@ -28,13 +28,9 @@ export type StatusMeta = {
         workflow?: string
         job?: string
     }
-    // Tailwind classes for text & background of a badge/pill
     badgeClass: string
-    // Optional fancy shadow/border class used by some cards
     glowClass?: string
-    // Optional icon animation class (e.g. spinning)
     iconClass?: string
-    // Optional dot color used by some cards
     dotColor?: string
 }
 

--- a/dashboard/src/features/jobs/use-workflow-jobs.ts
+++ b/dashboard/src/features/jobs/use-workflow-jobs.ts
@@ -24,7 +24,6 @@ export function useWorkflowJobs(
 
     const isNotWorkflowPath = path !== `/workflows/${workflowId}`
 
-    // Get URL parameters
     let currentCursor = ""
     let statusFilter = ""
     let triggerFilter = ""
@@ -40,7 +39,6 @@ export function useWorkflowJobs(
         triggerFilter = searchParams.get("trigger") || ""
     }
 
-    // Build query parameters for the get jobs request
     const getJobQueryParams = (() => {
         const params = new URLSearchParams()
 
@@ -75,7 +73,6 @@ export function useWorkflowJobs(
         staleTime: queryStaleTimes.workflowJobs,
     })
 
-    // Pagination functions
     const goToNextPage = () => {
         const nextCursor = getJobQuery.data?.cursor
         if (!nextCursor) return false
@@ -97,7 +94,6 @@ export function useWorkflowJobs(
         router.push(`?${params.toString()}`)
     }
 
-    // Apply all filters to the jobs
     const applyAllFilters = (filters: unknown) => {
         const params = new URLSearchParams(searchParams.toString())
         params.delete("cursor") // Reset pagination when applying filters
@@ -119,7 +115,6 @@ export function useWorkflowJobs(
         router.push(`?${params.toString()}`)
     }
 
-    // Clear all filters
     const clearAllFilters = () => {
         const oldParams = new URLSearchParams(searchParams.toString())
         const tab = oldParams.get("tab")

--- a/dashboard/src/features/logs/logs-viewer.tsx
+++ b/dashboard/src/features/logs/logs-viewer.tsx
@@ -500,7 +500,6 @@ export function LogsViewer({
         />
     )
 
-    // Trigger pagination only when user reaches bottom of the Virtuoso viewport
     const handleEndReached = () => {
         if (hasNextPage && !isFetchingNextPage) {
             fetchNextPage()

--- a/dashboard/src/features/logs/use-job-logs.ts
+++ b/dashboard/src/features/logs/use-job-logs.ts
@@ -63,7 +63,6 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
 
     const canFetch = shouldFetch && Boolean(workflowId) && Boolean(jobId)
 
-    // Download raw logs from backend and trigger browser file download
     const downloadLogsMutation = useMutation({
         mutationFn: async ({ filename, format }: DownloadLogsOptions) => {
             const params = new URLSearchParams(getSearchQueryParams)
@@ -122,7 +121,6 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         enabled: canFetch && !getSearchQueryParams,
     })
 
-    // Search job logs query
     const jobLogsSearchInfiniteQuery = useInfiniteQuery<JobLogsResponse, Error>({
         queryKey: queryKeys.job.logSearch(workflowId, jobId, searchQuery, streamFilter),
         queryFn: async ({ pageParam }) => {
@@ -152,7 +150,6 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         enabled: canFetch && Boolean(getSearchQueryParams),
     });
 
-    // Handle SSE connection for running jobs
     useEffect(() => {
         if (!shouldFetch || !isRunning || Boolean(getSearchQueryParams) || !workflowId || !jobId) {
             return
@@ -178,7 +175,7 @@ export function useJobLogs(workflowId: string, jobId: string, jobStatus: string)
         eventSource.addEventListener('error', handleError)
 
         eventSource.onerror = () => {
-            // No error toast for normal disconnections
+            // Silent on normal disconnects.
             if (eventSource.readyState !== EventSource.CLOSED) {
                 toast.error('Lost connection to log stream')
             }

--- a/dashboard/src/features/notifications/notifications-drawer.tsx
+++ b/dashboard/src/features/notifications/notifications-drawer.tsx
@@ -112,7 +112,6 @@ export function NotificationsDrawer({ open, onClose }: NotificationsDrawerProps)
         hasNextPage,
     } = useNotifications()
 
-    // Group notifications by date and flatten with headings
     const flat: FlatRow[] = (() => {
         if (notifications.length === 0) return []
         const groups = new Map<string, Notification[]>()
@@ -132,7 +131,6 @@ export function NotificationsDrawer({ open, onClose }: NotificationsDrawerProps)
         return result
     })()
 
-    // Bulk selection
     const [selected, setSelected] = useState<Set<string>>(new Set())
     const notificationIds = new Set(notifications.map((notification) => notification.id))
     const visibleSelected = new Set([...selected].filter((id) => notificationIds.has(id)))
@@ -192,7 +190,6 @@ export function NotificationsDrawer({ open, onClose }: NotificationsDrawerProps)
         onClose()
     }
 
-    // Item renderer
     const renderRow = (index: number) => {
         const d = flat[index]
         if (!d) return null

--- a/dashboard/src/features/users/profile-drawer.tsx
+++ b/dashboard/src/features/users/profile-drawer.tsx
@@ -63,7 +63,6 @@ export function ProfileDrawer({ open, onClose }: ProfileDrawerProps) {
     const { logout, isLogoutLoading } = useAuth()
     const { refetch: refetchNotifications } = useNotifications()
 
-    // State for password confirmation dialog
     const [confirmDialogOpen, setConfirmDialogOpen] = useState(false)
     const [newPreference, setNewPreference] = useState("")
 
@@ -77,7 +76,6 @@ export function ProfileDrawer({ open, onClose }: ProfileDrawerProps) {
             .slice(0, 2)
         : "U"
 
-    // Handler for notification preference change
     const handlePreferenceChange = (value: string) => {
         if (value === user?.notification_preference) return
 
@@ -85,7 +83,6 @@ export function ProfileDrawer({ open, onClose }: ProfileDrawerProps) {
         setConfirmDialogOpen(true)
     }
 
-    // Handler for password confirmation and update
     const handleConfirmUpdate = () => {
         updateUser({
             notification_preference: newPreference
@@ -97,7 +94,6 @@ export function ProfileDrawer({ open, onClose }: ProfileDrawerProps) {
         })
     }
 
-    // Handler for sign out
     const handleSignOut = () => {
         logout()
     }

--- a/dashboard/src/features/workflows/create-workflow-dialog.tsx
+++ b/dashboard/src/features/workflows/create-workflow-dialog.tsx
@@ -51,7 +51,6 @@ import {
 
 import { useWorkflows } from "@/features/workflows/use-workflows"
 
-// Base schema for common fields
 const baseCreateWorkflowSchema = z.object({
     name: z.string().trim().min(3, "Name must be at least 3 characters").max(50, "Name must be at most 50 characters"),
     interval: z.union([
@@ -68,7 +67,6 @@ const baseCreateWorkflowSchema = z.object({
     retainLogs: z.boolean().default(true)
 })
 
-// Heartbeat payload schema
 const heartbeatPayloadSchema = z.object({
     endpoint: z.url().trim().refine(val => val !== "", {
         message: "Please enter a valid URL"
@@ -94,7 +92,6 @@ const heartbeatPayloadSchema = z.object({
         }, "Timeout must be a valid duration (e.g., '30s', '1m') max up to 5 minutes")
 })
 
-// Container payload schema
 const containerPayloadSchema = z.object({
     image: z.string().trim().min(1, "Container image is required"),
     cmd: z.array(z.string().trim())
@@ -117,7 +114,6 @@ const containerPayloadSchema = z.object({
         }, "Timeout must be a valid duration (e.g., '30s', '5m') max up to 1 hour")
 })
 
-// Complete workflow schemas with discriminated union
 const heartbeatWorkflowSchema = baseCreateWorkflowSchema.extend({
     kind: z.literal("HEARTBEAT"),
     heartbeatPayload: heartbeatPayloadSchema,
@@ -131,7 +127,6 @@ const containerWorkflowSchema = baseCreateWorkflowSchema.extend({
     containerPayload: containerPayloadSchema,
 })
 
-// Union the schemas to handle different kinds
 const workflowSchema = z.discriminatedUnion("kind", [
     heartbeatWorkflowSchema,
     containerWorkflowSchema
@@ -253,7 +248,6 @@ export function CreateWorkflowDialog({ open, onOpenChange }: CreateWorkflowDialo
                 env: [],
                 timeout: "",
             }
-            // parse env in key=value format and map to object
             const envObject = env.reduce((acc, item) => {
                 const [key, value] = item.split("=")
                 if (key) {
@@ -270,7 +264,6 @@ export function CreateWorkflowDialog({ open, onOpenChange }: CreateWorkflowDialo
             })
         }
 
-        // Submit the workflow with the constructed payload
         createWorkflow({
             name: data.name,
             kind: data.kind,
@@ -283,7 +276,6 @@ export function CreateWorkflowDialog({ open, onOpenChange }: CreateWorkflowDialo
         onOpenChange(false)
     }
 
-    // Get current field values based on selected kind
     const watchedHeaders = useWatch({ control: form.control, name: "heartbeatPayload.headers" })
     const watchedCmd = useWatch({ control: form.control, name: "containerPayload.cmd" })
     const watchedCmdIds = useWatch({ control: form.control, name: "containerPayload.cmdIds" })
@@ -331,7 +323,6 @@ function renderCreateWorkflowDialogView(model: any) {
         <Dialog
             open={open}
             onOpenChange={(newOpen) => {
-                // Prevent closing if creating
                 if (isCreating && !newOpen) return;
                 onOpenChange(newOpen)
             }}

--- a/dashboard/src/features/workflows/update-workflow-dialog.tsx
+++ b/dashboard/src/features/workflows/update-workflow-dialog.tsx
@@ -41,7 +41,6 @@ import {
 
 import { useWorkflowDetails } from "@/features/workflows/use-workflow-details"
 
-// Base schema for update workflow
 const baseUpdateWorkflowSchema = z.object({
     name: z.string().trim().min(3, "Name must be at least 3 characters").max(50, "Name must be at most 50 characters"),
     interval: z.union([
@@ -59,7 +58,6 @@ const baseUpdateWorkflowSchema = z.object({
     })
 })
 
-// Heartbeat payload schema
 const heartbeatPayloadSchema = z.object({
     endpoint: z.url().trim().refine(val => val !== "", {
         message: "Please enter a valid URL"
@@ -85,7 +83,6 @@ const heartbeatPayloadSchema = z.object({
         }, "Timeout must be a valid duration (e.g., '30s', '1m') max up to 5 minutes")
 })
 
-// Container payload schema
 const containerPayloadSchema = z.object({
     image: z.string().trim().min(1, "Container image is required"),
     cmd: z.array(z.string().trim())
@@ -177,14 +174,12 @@ export function UpdateWorkflowDialog({
         mode: "onBlur",
     });
 
-    // Initialize payload when workflow data is loaded
     useEffect(() => {
         if (!workflow) return;
 
         const parsedPayload = workflow.payload ? JSON.parse(workflow.payload) as WorkflowPayload : {};
 
         if (workflow.kind === "HEARTBEAT") {
-            // Prepare headers array from object
             const headers = parsedPayload.headers ?
                 Object.entries(parsedPayload.headers).map(([key, value]) => ({ id: crypto.randomUUID(), key, value })) :
                 [];
@@ -228,10 +223,8 @@ export function UpdateWorkflowDialog({
     }, [workflow, form]);
 
     const handleSubmit = (data: UpdateWorkflowFormValues) => {
-        // Don't proceed if no workflow data
         if (!workflow) return;
 
-        // Prepare the payload based on workflow kind
         let payload = "{}";
 
         if (workflow.kind === "HEARTBEAT") {
@@ -261,7 +254,6 @@ export function UpdateWorkflowDialog({
                 env: [],
                 timeout: "",
             };
-            // parse env in key=value format and map to object
             const envObject = env.reduce((acc, item) => {
                 const [key, value] = item.split("=")
                 if (key) {
@@ -278,7 +270,6 @@ export function UpdateWorkflowDialog({
             });
         }
 
-        // Call update API with the constructed payload
         updateWorkflow({
             name: data.name,
             payload: payload,
@@ -289,7 +280,6 @@ export function UpdateWorkflowDialog({
         onOpenChange(false);
     };
 
-    // Get current field values based on kind
     const watchedHeaders = useWatch({ control: form.control, name: "heartbeatPayload.headers" })
     const watchedCmd = useWatch({ control: form.control, name: "containerPayload.cmd" })
     const watchedCmdIds = useWatch({ control: form.control, name: "containerPayload.cmdIds" })

--- a/dashboard/src/features/workflows/use-workflows.ts
+++ b/dashboard/src/features/workflows/use-workflows.ts
@@ -47,7 +47,6 @@ export function useWorkflows({ poll = false }: UseWorkflowsOptions = {}) {
         intervalMax = normalizeIntervalFilter(searchParams.get("interval_max"))
     }
 
-    // Build query parameters for the get workflows request
     const getWorkflowQueryParams = (() => {
         const params = new URLSearchParams()
 
@@ -134,7 +133,6 @@ export function useWorkflows({ poll = false }: UseWorkflowsOptions = {}) {
         router.push(`?${params.toString()}`)
     }
 
-    // Update search query in URL params
     const updateSearchQuery = (newSearchQuery: string) => {
         const params = new URLSearchParams(searchParams.toString())
         params.delete("cursor") // Reset pagination when searching
@@ -148,7 +146,6 @@ export function useWorkflows({ poll = false }: UseWorkflowsOptions = {}) {
         router.push(`?${params.toString()}`)
     }
 
-    // Apply all filters and search query
     const applyAllFilters = (filters: unknown) => {
         const params = new URLSearchParams(searchParams.toString())
         params.delete("cursor") // Reset pagination when applying filters
@@ -194,9 +191,7 @@ export function useWorkflows({ poll = false }: UseWorkflowsOptions = {}) {
         router.push(`?${params.toString()}`)
     }
 
-    // Clear all filters
     const clearAllFilters = () => {
-        // Get the search query if it exists
         const oldParams = new URLSearchParams(searchParams.toString())
         const query = oldParams.get("query")
 
@@ -243,7 +238,6 @@ export function useWorkflows({ poll = false }: UseWorkflowsOptions = {}) {
         isCreating: createWorkflowMutation.isPending,
         refetch: getWorkflowQuery.refetch,
         refetchLoading: getWorkflowQuery.isRefetching,
-        // Search and filter functions
         searchQuery,
         statusFilter,
         kindFilter,

--- a/dashboard/src/features/workflows/workflow-card.tsx
+++ b/dashboard/src/features/workflows/workflow-card.tsx
@@ -26,16 +26,13 @@ export function WorkflowCard({ workflow }: WorkflowCardProps) {
     const failureCount = workflow.consecutive_job_failures_count ?? 0
     const failureLimit = workflow.max_consecutive_job_failures_allowed ?? 1
 
-    // Determine status
     const status = workflow.terminated_at ? "TERMINATED" : workflow.build_status
 
-    // Format dates
     const updatedAt = formatDistanceToNow(new Date(workflow.updated_at), { addSuffix: true })
     const statusMeta = getStatusMeta(status)
 
     const StatusIcon = statusMeta.icon
 
-    // Format interval for display
     const interval = workflow.interval === 1440
         ? "daily"
         : workflow.interval % 60 === 0 && workflow.interval >= 60

--- a/dashboard/src/features/workflows/workflow-details-page.tsx
+++ b/dashboard/src/features/workflows/workflow-details-page.tsx
@@ -81,7 +81,7 @@ export default function WorkflowDetailsAndJobsPage() {
     const router = useRouter()
     const searchParams = useSearchParams()
 
-    // Local state for filter inputs (to be applied when "Apply Filters" is clicked)
+    // Pending filter inputs; applied on Apply.
     const [filterState, setFilterState] = useState({
         status: "",
         trigger: "",
@@ -120,13 +120,10 @@ export default function WorkflowDetailsAndJobsPage() {
     const [showTerminateWorkflowDialog, setShowTerminateWorkflowDialog] = useState(false)
     const [showDeleteWorkflowDialog, setShowDeleteWorkflowDialog] = useState(false)
 
-    // Determine status
     const status = workflow?.terminated_at ? "TERMINATED" : workflow?.build_status
 
-    // Get status meta (unified)
     const statusMeta = getStatusMeta(status)
 
-    // Format interval for display
     const interval = workflow?.interval
         ? workflow.interval === 1440
             ? "daily"
@@ -154,7 +151,6 @@ export default function WorkflowDetailsAndJobsPage() {
         setIsFiltersOpen(nextOpen)
     }
 
-    // Handle tab change
     const handleTabsChange = (value: string) => {
         const params = new URLSearchParams(searchParams.toString())
         if (value === "details") {
@@ -185,7 +181,6 @@ export default function WorkflowDetailsAndJobsPage() {
         setIsFiltersOpen(false)
     }
 
-    // Count active filters
     const activeFiltersCount = [
         statusFilter,
         triggerFilter,
@@ -559,7 +554,6 @@ function renderWorkflowDetailsAndJobsView(model: any) {
                 {urlTabFilter === "details" && isWorkflowLoading ? (
                     <WorkflowDetailsSkeleton />
                 ) : (urlTabFilter === "details" && !isWorkflowLoading && !workflowError) && (
-                    // Details Tab
                     <TabsContent value="details" className="h-full w-full">
                         {/* UpdateWorkflow Dialog */}
                         <UpdateWorkflowDialog

--- a/dashboard/src/features/workflows/workflows.tsx
+++ b/dashboard/src/features/workflows/workflows.tsx
@@ -54,7 +54,7 @@ export function Workflows() {
     const [isFiltersOpen, setIsFiltersOpen] = useState(false)
     const [isSearchFocused, setIsSearchFocused] = useState(false)
 
-    // Local state for filter inputs (to be applied when "Apply Filters" is clicked)
+    // Pending filter inputs; applied on Apply.
     const [filterState, setFilterState] = useState({
         status: "",
         kind: "",
@@ -80,7 +80,6 @@ export function Workflows() {
 
     const [searchInput, setSearchInput] = useState(searchQuery)
 
-    // Debounced search update
     useEffect(() => {
         const timer = setTimeout(() => {
             if (searchInput !== searchQuery) {
@@ -93,7 +92,6 @@ export function Workflows() {
         return () => clearTimeout(timer)
     }, [searchInput, searchQuery, updateSearchQuery])
 
-    // Keyboard shortcuts
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             if ((e.ctrlKey || e.metaKey) && e.key === "f") {
@@ -142,7 +140,6 @@ export function Workflows() {
         setIsFiltersOpen(false)
     }
 
-    // Count active filters
     const activeFiltersCount = [
         statusFilter,
         kindFilter,

--- a/dashboard/src/proxy.ts
+++ b/dashboard/src/proxy.ts
@@ -6,35 +6,25 @@ const publicRoutes = ["/login", "/signup"]
 export async function proxy(request: NextRequest) {
     const { pathname } = request.nextUrl
 
-    // Check if the requested path is a public route
     const isPublicRoute = publicRoutes.some((route) => pathname.startsWith(route))
 
     const session = request.cookies.get("session")?.value
     const csrf = request.cookies.get("csrf")?.value
     const validUser = Boolean(session && csrf)
 
-    // If user is not authenticated and trying to access a protected route
-    // Redirect unauthenticated users to login
     if (!validUser && !isPublicRoute) {
-        // Redirect to login page
         return NextResponse.redirect(new URL("/login", request.url))
     }
 
-    // Since user is authenticated and trying to access a public route
-    // Redirect authenticated users away from login
     if (validUser && isPublicRoute) {
-        // Redirect to dashboard (root)
         return NextResponse.redirect(new URL("/", request.url))
     }
 
-    // For protected routes, we only check cookie existence
-    // Actual validation happens in the page or API route
+    // Cookie presence only; validated in page/API route.
     return NextResponse.next()
 }
 
-// Configure which paths should be processed by the middleware
 export const config = {
-    // Apply to all routes except for static files, api routes, etc.
     matcher: [
         /*
          * Match all request paths except for the ones starting with:

--- a/internal/app/analytics/analytics.go
+++ b/internal/app/analytics/analytics.go
@@ -68,7 +68,6 @@ func (a *Analytics) authTokenInterceptor(logger *zap.Logger) grpc.UnaryServerInt
 			return handler(ctx, req)
 		}
 
-		// Extract the authToken from metadata.
 		authToken, err := auth.ExtractAuthorizationTokenFromMetadata(ctx)
 		if err != nil {
 			grpcmiddlewares.LogAuthenticationFailure(ctx, logger, err)

--- a/internal/app/jobs/jobs.go
+++ b/internal/app/jobs/jobs.go
@@ -103,7 +103,6 @@ func (j *Jobs) unaryAuthTokenInterceptor(logger *zap.Logger) grpc.UnaryServerInt
 			return handler(ctx, req)
 		}
 
-		// Extract the authToken from metadata.
 		authToken, err := authpkg.ExtractAuthorizationTokenFromMetadata(ctx)
 		if err != nil {
 			grpcmiddlewares.LogAuthenticationFailure(ctx, logger, err)
@@ -128,7 +127,6 @@ func (j *Jobs) streamAuthTokenInterceptor(logger *zap.Logger) grpc.StreamServerI
 			return handler(srv, stream)
 		}
 
-		// Extract the authToken from metadata.
 		authToken, err := authpkg.ExtractAuthorizationTokenFromMetadata(stream.Context())
 		if err != nil {
 			grpcmiddlewares.LogAuthenticationFailure(stream.Context(), logger, err)
@@ -564,7 +562,7 @@ func (j *Jobs) GetJob(ctx context.Context, req *jobspb.GetJobRequest) (res *jobs
 }
 
 // GetJobByID returns the job details by ID.
-// This is an internal method used by internal services, and it should not be exposed to the public.
+// Internal only; not public API.
 func (j *Jobs) GetJobByID(ctx context.Context, req *jobspb.GetJobByIDRequest) (res *jobspb.GetJobByIDResponse, err error) {
 	ctx, span := j.tp.Start(
 		ctx,

--- a/internal/app/notifications/notifications.go
+++ b/internal/app/notifications/notifications.go
@@ -77,7 +77,6 @@ func (n *Notifications) authTokenInterceptor(logger *zap.Logger) grpc.UnaryServe
 			return handler(ctx, req)
 		}
 
-		// Extract the authToken from metadata.
 		authToken, err := authpkg.ExtractAuthorizationTokenFromMetadata(ctx)
 		if err != nil {
 			grpcmiddlewares.LogAuthenticationFailure(ctx, logger, err)
@@ -205,7 +204,7 @@ func New(ctx context.Context, cfg *Config, auth authpkg.IAuth, svc Service) *grp
 }
 
 // CreateNotification creates a new notification.
-// This is an internal method used by internal services, and it should not be exposed to the public.
+// Internal only; not public API.
 func (n *Notifications) CreateNotification(
 	ctx context.Context,
 	req *notificationspb.CreateNotificationRequest,

--- a/internal/app/users/users.go
+++ b/internal/app/users/users.go
@@ -242,7 +242,6 @@ func (u *Users) RegisterUser(ctx context.Context, req *userpb.RegisterUserReques
 		return nil, err
 	}
 
-	// Append the authToken in the headers.
 	if err = grpc.SendHeader(ctx, auth.WithSetAuthorizationTokenInHeaders(authToken)); err != nil {
 		return nil, err
 	}
@@ -275,7 +274,6 @@ func (u *Users) LoginUser(ctx context.Context, req *userpb.LoginUserRequest) (re
 		return nil, err
 	}
 
-	// Append the authToken in the headers.
 	if err = grpc.SendHeader(ctx, auth.WithSetAuthorizationTokenInHeaders(authToken)); err != nil {
 		return nil, err
 	}

--- a/internal/app/workflows/workflows.go
+++ b/internal/app/workflows/workflows.go
@@ -90,7 +90,6 @@ func (w *Workflows) authTokenInterceptor(logger *zap.Logger) grpc.UnaryServerInt
 			return handler(ctx, req)
 		}
 
-		// Extract the authToken from metadata.
 		authToken, err := authpkg.ExtractAuthorizationTokenFromMetadata(ctx)
 		if err != nil {
 			grpcmiddlewares.LogAuthenticationFailure(ctx, logger, err)
@@ -286,7 +285,7 @@ func (w *Workflows) UpdateWorkflow(ctx context.Context, req *workflowspb.UpdateW
 }
 
 // UpdateWorkflowBuildStatus updates the job build status.
-// This is an internal method used by internal services, and it should not be exposed to the public.
+// Internal only; not public API.
 func (w *Workflows) UpdateWorkflowBuildStatus(
 	ctx context.Context,
 	req *workflowspb.UpdateWorkflowBuildStatusRequest,
@@ -349,7 +348,7 @@ func (w *Workflows) GetWorkflow(ctx context.Context, req *workflowspb.GetWorkflo
 }
 
 // GetWorkflowByID returns the job details by ID.
-// This is an internal method used by internal services, and it should not be exposed to the public.
+// Internal only; not public API.
 func (w *Workflows) GetWorkflowByID(ctx context.Context, req *workflowspb.GetWorkflowByIDRequest) (res *workflowspb.GetWorkflowByIDResponse, err error) {
 	ctx, span := w.tp.Start(
 		ctx,
@@ -378,7 +377,7 @@ func (w *Workflows) GetWorkflowByID(ctx context.Context, req *workflowspb.GetWor
 }
 
 // IncrementWorkflowConsecutiveJobFailuresCount increments the consecutive job failures count.
-// This is an internal method used by internal services, and it should not be exposed to the public.
+// Internal only; not public API.
 func (w *Workflows) IncrementWorkflowConsecutiveJobFailuresCount(
 	ctx context.Context,
 	req *workflowspb.IncrementWorkflowConsecutiveJobFailuresCountRequest,
@@ -413,7 +412,7 @@ func (w *Workflows) IncrementWorkflowConsecutiveJobFailuresCount(
 }
 
 // ResetWorkflowConsecutiveJobFailuresCount resets the consecutive job failures count.
-// This is an internal method used by internal services, and it should not be exposed to the public.
+// Internal only; not public API.
 func (w *Workflows) ResetWorkflowConsecutiveJobFailuresCount(
 	ctx context.Context,
 	req *workflowspb.ResetWorkflowConsecutiveJobFailuresCountRequest,

--- a/internal/pkg/clickhouse/migrate.go
+++ b/internal/pkg/clickhouse/migrate.go
@@ -51,7 +51,7 @@ func Migrate(ctx context.Context, client *Client) error {
 	return nil
 }
 
-// createSchemaMigrationsTable creates the schema_migrations table if it does not exist.
+// Ensures the schema_migrations table exists.
 func createSchemaMigrationsTable(ctx context.Context, client *Client) error {
 	query := `
 		CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -92,11 +92,11 @@ func getAppliedMigrations(ctx context.Context, client *Client) (map[int]bool, er
 	return applied, rows.Err()
 }
 
-// getPendingMigrations returns the embedded migrations that have not been applied yet.
+// Returns unapplied embedded migrations.
 func getPendingMigrations(applied map[int]bool) ([]migration, error) {
 	var migrations []migration
 
-	// Read migration files from the embedded filesystem.
+	// Walk embedded migration files.
 	err := fs.WalkDir(migrationsFS, "migrations", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/internal/pkg/grpc/client/interceptors.go
+++ b/internal/pkg/grpc/client/interceptors.go
@@ -48,24 +48,20 @@ func circuitBreakerStreamInterceptor(cb *breaker.Breaker) grpc.StreamClientInter
 		})
 
 		if cbErr != nil {
-			// If the underlying RPC returned an error that we treat as a circuit-breaker error,
-			// return that error (breaker counted it). If cbErr is non-nil but the RPC error
-			// was nil, it's likely the breaker is open - return the breaker error.
+			// Prefer the RPC error when counted; otherwise the breaker is open.
 			if streamErr != nil {
 				return stream, streamErr
 			}
 			return stream, cbErr
 		}
 
-		// cbErr == nil. If the RPC returned a non-circuit-breaker error, return it to caller
-		// but it won't be counted by the breaker.
+		// Uncounted RPC error; return as-is.
 		return stream, streamErr
 	}
 }
 
-// isCircuitBreakerError determines whether an error should be counted against the circuit
-// breaker. Only treat internal server errors, deadline/timeouts and network timeouts as
-// circuit-breaker errors.
+// isCircuitBreakerError reports whether err should count against the circuit.
+// Only internal, deadline/timeout, and network-timeout failures count.
 func isCircuitBreakerError(err error) bool {
 	if err == nil {
 		return false

--- a/internal/pkg/kafka/partition_runner.go
+++ b/internal/pkg/kafka/partition_runner.go
@@ -22,7 +22,7 @@ const (
 	defaultPartitionRunnerChannelBuffer = 1024
 )
 
-// RecordProcessor processes one Kafka record. Retruning a retryable gRPC status
+// RecordProcessor processes one Kafka record. Returning a retryable gRPC status
 // keeps the record uncommitted and retries it in the same partition lane.
 type RecordProcessor func(context.Context, *kgo.Record) error
 
@@ -282,7 +282,7 @@ func NewPartitionRunner(
 	return runner
 }
 
-// NewPartitionBatchRunner creates a partition-aware runner for partition-local bacthes.
+// NewPartitionBatchRunner creates a partition-aware runner for partition-local batches.
 func NewPartitionBatchRunner(
 	client partitionClient,
 	processBatch RecordBatchProcessor,

--- a/internal/pkg/kind/container/docker.go
+++ b/internal/pkg/kind/container/docker.go
@@ -670,7 +670,6 @@ func (w *DockerWorkflow) streamContainerLogs(ctx context.Context, containerID st
 			if msg != "" {
 				select {
 				case logMessages <- &jobsmodel.JobLog{Timestamp: time.Now(), Message: msg, SequenceNum: atomic.LoadUint32(&sequenceNum), Stream: "stdout"}:
-					// Atomic increment the sequence number for each log entry
 					atomic.AddUint32(&sequenceNum, 1)
 				case <-ctx.Done():
 					return
@@ -689,7 +688,6 @@ func (w *DockerWorkflow) streamContainerLogs(ctx context.Context, containerID st
 			if msg != "" {
 				select {
 				case logMessages <- &jobsmodel.JobLog{Timestamp: time.Now(), Message: msg, SequenceNum: atomic.LoadUint32(&sequenceNum), Stream: "stderr"}:
-					// Atomic increment the sequence number for each log entry
 					atomic.AddUint32(&sequenceNum, 1)
 				case <-ctx.Done():
 					return

--- a/internal/pkg/kind/heartbeat/validator.go
+++ b/internal/pkg/kind/heartbeat/validator.go
@@ -13,9 +13,7 @@ const (
 	heartbeatWorkflowMaxRequestTimeout     = 5 * time.Minute
 )
 
-// Details encapsulates the configuration required to perform a heartbeat check
-// against a specified endpoint. It includes the request timeout, target endpoint URL,
-// the expected HTTP status code for a successful heartbeat, and any custom headers
+// Details configures a heartbeat check: timeout, endpoint URL, expected status, and headers.
 // to be included in the request.
 type Details struct {
 	TimeOut            time.Duration       // Maximum duration to wait for the heartbeat request to complete

--- a/internal/pkg/meilisearch/index.go
+++ b/internal/pkg/meilisearch/index.go
@@ -1,7 +1,6 @@
 package meilisearch
 
-// Index represents the configuration for a MeiliSearch index, including its name, primary key,
-// and lists of searchable, filterable, and sortable attributes.
+// Index configures a MeiliSearch index: name, primary key, and searchable/filterable/sortable attributes.
 type Index struct {
 	// Name is the unique name of the MeiliSearch index.
 	Name string

--- a/internal/pkg/meilisearch/meilisearch.go
+++ b/internal/pkg/meilisearch/meilisearch.go
@@ -25,7 +25,7 @@ type Config struct {
 	TLS       *tls.Config
 }
 
-// Option is a functional option type that allows to configure the MeiliSearch client.
+// Option configures the MeiliSearch client.
 type Option func(*Config)
 
 // New creates a new MeiliSearch client.

--- a/internal/pkg/svc/svc.go
+++ b/internal/pkg/svc/svc.go
@@ -13,31 +13,23 @@ import (
 )
 
 var (
-	// version is the service version.
 	version string
 
-	// name is the name of the service.
 	name string
 
-	// authPrivateKeyPath is the path to the private key.
 	authPrivateKeyPath string
 
-	// authPublicKeyPath is the path to the public key.
 	authPublicKeyPath string
 )
 
 // Svc contains the service information.
 type Svc struct {
-	// version is the service version.
 	version string
 
-	// name is the name of the service.
 	name string
 
-	// authPrivateKeyPath is the path to the private key.
 	authPrivateKeyPath string
 
-	// authPublicKeyPath is the path to the public key.
 	authPublicKeyPath string
 }
 

--- a/internal/repository/jobs/jobs.go
+++ b/internal/repository/jobs/jobs.go
@@ -642,7 +642,6 @@ func (r *Repository) GetJobLogs(
 		span.End()
 	}()
 
-	// Issue necessary headers and tokens for authorization
 	ctx, ctxErr := r.withAuthorization(ctx)
 	if ctxErr != nil {
 		err = ctxErr
@@ -765,7 +764,6 @@ func (r *Repository) GetJobLogs(
 			return status.Errorf(codes.Internal, "rows error: %v", rowsErr)
 		}
 
-		// Check if there are more logs
 		if len(tmp) > r.cfg.LogsFetchLimit {
 			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
 			tmp = tmp[:r.cfg.LogsFetchLimit]
@@ -800,9 +798,7 @@ func (r *Repository) GetJobLogs(
 		return nil, "", err
 	}
 
-	// Buffer-based status override:
-	// If the job just completed within the buffer window, we may not have all logs yet.
-	// Treat it as "RUNNING" temporarily.
+	// Logs may lag a just-completed job; report RUNNING within the buffer window.
 	if completedAt.Valid && time.Since(completedAt.Time) <= jobStatusUpdateBuffer {
 		fetchedStatus = jobsmodel.JobStatusRunning.ToString()
 	}
@@ -826,7 +822,6 @@ func (r *Repository) StreamJobLogs(ctx context.Context, jobID, workflowID, userI
 		span.End()
 	}()
 
-	// Issue necessary headers and tokens for authorization
 	ctx, ctxErr := r.withAuthorization(ctx)
 	if ctxErr != nil {
 		err = ctxErr
@@ -936,7 +931,6 @@ func (r *Repository) SearchJobLogs(
 		span.End()
 	}()
 
-	// Issue necessary headers and tokens for authorization
 	ctx, ctxErr := r.withAuthorization(ctx)
 	if ctxErr != nil {
 		err = ctxErr
@@ -1078,7 +1072,6 @@ func (r *Repository) SearchJobLogs(
 			})
 		}
 
-		// Check if there are more logs
 		if len(tmp) > r.cfg.LogsFetchLimit {
 			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
 			tmp = tmp[:r.cfg.LogsFetchLimit]
@@ -1113,9 +1106,7 @@ func (r *Repository) SearchJobLogs(
 		return nil, "", err
 	}
 
-	// Buffer-based status override:
-	// If the job just completed within the buffer window, we may not have all logs yet.
-	// Treat it as "RUNNING" temporarily.
+	// Logs may lag a just-completed job; report RUNNING within the buffer window.
 	if completedAt.Valid && time.Since(completedAt.Time) <= jobStatusUpdateBuffer {
 		fetchedStatus = jobsmodel.JobStatusRunning.ToString()
 	}

--- a/internal/repository/notifications/notifications.go
+++ b/internal/repository/notifications/notifications.go
@@ -347,7 +347,6 @@ func (r *Repository) ListNotifications(ctx context.Context, userID, cursor strin
 		span.End()
 	}()
 
-	// Issue necessary headers and tokens for authorization
 	ctx, ctxErr := r.withAuthorization(ctx)
 	if ctxErr != nil {
 		err = ctxErr

--- a/internal/repository/scheduler/scheduler.go
+++ b/internal/repository/scheduler/scheduler.go
@@ -67,7 +67,6 @@ func (r *Repository) Run(ctx context.Context) (total int, err error) {
 		span.End()
 	}()
 
-	// Start transaction
 	tx, err := r.pg.BeginTx(ctx)
 	if err != nil {
 		err = status.Errorf(codes.Internal, "failed to start transaction: %v", err)
@@ -250,7 +249,6 @@ func (r *Repository) Run(ctx context.Context) (total int, err error) {
 		return 0, nil
 	}
 
-	// Commit transaction
 	if err = tx.Commit(ctx); err != nil {
 		err = status.Errorf(codes.Internal, "failed to commit transaction: %v", err)
 		return 0, err

--- a/internal/repository/workflow/build_workflow.go
+++ b/internal/repository/workflow/build_workflow.go
@@ -44,14 +44,12 @@ func (r *Repository) buildWorkflow(parentCtx context.Context, workflowEvent *wor
 	occurrenceKey := workflowOccurrenceKey(workflowEvent)
 	scheduleIdempotencyKey := idempotency.AutomaticScheduleEventKey(occurrenceKey)
 
-	// Issue necessary headers and tokens for authorization
 	ctx, err := r.withAuthorization(parentCtx)
 	if err != nil {
 		return err
 	}
 
-	// This context is used for sending notifications, as we don't want to propagate the cancellation
-	// This context does not use the parent context
+	// Detached context for notifications; ignores cancellation.
 	//nolint:errcheck // Ignore the error as we don't want to block the workflow build process
 	notificationCtx, _ := r.withAuthorization(context.Background())
 
@@ -166,7 +164,7 @@ func (r *Repository) buildWorkflow(parentCtx context.Context, workflowEvent *wor
 		}
 
 		// Send notification for the workflow build skipped event
-		// This is a fire-and-forget operation, so we don't need to wait for it to complete
+		// Fire-and-forget; do not wait.
 		//nolint:errcheck,contextcheck // Ignore the error as we don't want to block the workflow execution
 		go r.sendNotification(
 			notificationCtx,
@@ -207,7 +205,7 @@ func (r *Repository) buildWorkflow(parentCtx context.Context, workflowEvent *wor
 	}
 
 	// Send notification for the workflow build start event
-	// This is a fire-and-forget operation, so we don't need to wait for it to complete
+	// Fire-and-forget; do not wait.
 	//nolint:errcheck,contextcheck // Ignore the error as we don't want to block the workflow execution
 	go r.sendNotification(
 		notificationCtx,
@@ -250,8 +248,7 @@ func (r *Repository) buildWorkflow(parentCtx context.Context, workflowEvent *wor
 	//nolint:errcheck // Ignore the error as we don't want to block the workflow build process
 	ctx, _ = r.withAuthorization(ctx)
 
-	// This context is used for sending notifications, as we don't want to propagate the cancellation
-	// This context does not use the parent context
+	// Detached context for notifications; ignores cancellation.
 	//nolint:errcheck // Ignore the error as we don't want to block the workflow build process
 	notificationCtx, _ = r.withAuthorization(context.Background())
 
@@ -278,7 +275,7 @@ func (r *Repository) buildWorkflow(parentCtx context.Context, workflowEvent *wor
 		}
 
 		// Send notification for the workflow build failed event
-		// This is a fire-and-forget operation, so we don't need to wait for it to complete
+		// Fire-and-forget; do not wait.
 		//nolint:errcheck,contextcheck // Ignore the error as we don't want to block the workflow execution
 		go r.sendNotification(
 			notificationCtx,
@@ -313,7 +310,7 @@ func (r *Repository) buildWorkflow(parentCtx context.Context, workflowEvent *wor
 	}
 
 	// Send notification for the workflow build completed event
-	// This is a fire-and-forget operation, so we don't need to wait for it to complete
+	// Fire-and-forget; do not wait.
 	//nolint:errcheck,contextcheck // Ignore the error as we don't want to block the workflow build process
 	go r.sendNotification(
 		notificationCtx,

--- a/internal/repository/workflow/terminate_workflow.go
+++ b/internal/repository/workflow/terminate_workflow.go
@@ -102,14 +102,14 @@ func (r *Repository) sendJobCanceledNotification(
 	workflow *workflowspb.GetWorkflowByIDResponse,
 	job *jobspb.JobsResponse,
 ) {
-	// This context is used for sending notifications, as we don't want to propagate the cancellation.
+	// Detached context for notifications; ignores cancellation.
 	notificationCtx, err := r.withAuthorization(context.WithoutCancel(parentCtx))
 	if err != nil {
 		return
 	}
 
 	// Send notification for the job termination.
-	// This is a fire-and-forget operation, so we don't need to wait for it to complete.
+	// Fire-and-forget; do not wait.
 	//nolint:errcheck // Ignore the error as we don't want to block the job execution.
 	go r.sendNotification(
 		notificationCtx,
@@ -130,14 +130,14 @@ func (r *Repository) sendWorkflowTerminatedNotification(
 	workflow *workflowspb.GetWorkflowByIDResponse,
 	workflowEvent *workflowsmodel.WorkflowEvent,
 ) {
-	// This context is used for sending notifications, as we don't want to propagate the cancellation.
+	// Detached context for notifications; ignores cancellation.
 	notificationCtx, err := r.withAuthorization(context.WithoutCancel(parentCtx))
 	if err != nil {
 		return
 	}
 
 	// Send notification for the workflow termination.
-	// This is a fire-and-forget operation, so we don't need to wait for it to complete.
+	// Fire-and-forget; do not wait.
 	//nolint:errcheck // Ignore the error as we don't want to block the workflow execution.
 	go r.sendNotification(
 		notificationCtx,
@@ -502,7 +502,6 @@ func (r *Repository) terminateWorkflow(parentCtx context.Context, workflowEvent 
 	workflowID := workflowEvent.ID
 	userID := workflowEvent.UserID
 
-	// Issue necessary headers and tokens for authorization
 	ctx, err := r.withAuthorization(parentCtx)
 	if err != nil {
 		return err

--- a/internal/repository/workflows/workflows.go
+++ b/internal/repository/workflows/workflows.go
@@ -73,7 +73,6 @@ func (r *Repository) CreateWorkflow(
 		return nil, err
 	}
 
-	// Start transaction
 	tx, err := r.pg.BeginTx(ctx)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -177,7 +176,6 @@ func (r *Repository) CreateWorkflow(
 		return nil, completeErr
 	}
 
-	// Commit transaction
 	if err = tx.Commit(ctx); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			err = status.Error(codes.DeadlineExceeded, err.Error())
@@ -253,7 +251,6 @@ func (r *Repository) UpdateWorkflow(
 		return err
 	}
 
-	// Start transaction
 	tx, err := r.pg.BeginTx(ctx)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -470,7 +467,6 @@ func (r *Repository) UpdateWorkflow(
 		return completeErr
 	}
 
-	// Commit transaction
 	if err = tx.Commit(ctx); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			err = status.Error(codes.DeadlineExceeded, err.Error())
@@ -931,7 +927,6 @@ func (r *Repository) TerminateWorkflow(ctx context.Context, workflowID, userID s
 		span.End()
 	}()
 
-	// Start transaction
 	tx, err := r.pg.BeginTx(ctx)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -1011,7 +1006,6 @@ func (r *Repository) TerminateWorkflow(ctx context.Context, workflowID, userID s
 		return insertErr
 	}
 
-	// Commit transaction
 	if err = tx.Commit(ctx); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			err = status.Error(codes.DeadlineExceeded, err.Error())
@@ -1041,7 +1035,6 @@ func (r *Repository) DeleteWorkflow(ctx context.Context, workflowID, userID stri
 		span.End()
 	}()
 
-	// Start transaction
 	tx, err := r.pg.BeginTx(ctx)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -1173,7 +1166,6 @@ func (r *Repository) DeleteWorkflow(ctx context.Context, workflowID, userID stri
 		return insertErr
 	}
 
-	// Commit transaction
 	if err = tx.Commit(ctx); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			err = status.Error(codes.DeadlineExceeded, err.Error())

--- a/internal/server/analytics_handlers.go
+++ b/internal/server/analytics_handlers.go
@@ -7,9 +7,7 @@ import (
 	analyticspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/analytics"
 )
 
-// handleGetUserAnalytics handles the get user analytics request.
 func (s *Server) handleGetUserAnalytics(w http.ResponseWriter, r *http.Request) {
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -36,7 +34,6 @@ func (s *Server) handleGetUserAnalytics(w http.ResponseWriter, r *http.Request) 
 	json.NewEncoder(w).Encode(newUserAnalyticsHTTPResponse(res))
 }
 
-// handleGetWorkflowAnalytics handles the get workflow analytics request.
 func (s *Server) handleGetWorkflowAnalytics(w http.ResponseWriter, r *http.Request) {
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
@@ -44,7 +41,6 @@ func (s *Server) handleGetWorkflowAnalytics(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)

--- a/internal/server/jobs_handlers.go
+++ b/internal/server/jobs_handlers.go
@@ -31,16 +31,13 @@ type jobLogsDownloadRequest struct {
 	SearchQuery string
 }
 
-// handleListJobs handles the list jobs by job ID request.
 func (s *Server) handleListJobs(w http.ResponseWriter, r *http.Request) {
-	// Get the job ID from the path	parameters
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
 		http.Error(w, "job ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -53,10 +50,8 @@ func (s *Server) handleListJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get cursor from the query parameters
 	cursor := r.URL.Query().Get("cursor")
 
-	// Get status from the query parameters
 	status := r.URL.Query().Get("status")
 	if status != "" {
 		// Validate the job status
@@ -91,23 +86,19 @@ func (s *Server) handleListJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Write the response
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	//nolint:errcheck // The error is always nil
 	json.NewEncoder(w).Encode(res)
 }
 
-// handleManualScheduleJob handles the manual schedule job request.
 func (s *Server) handleManualScheduleJob(w http.ResponseWriter, r *http.Request) {
-	// Get the job ID from the path	parameters
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
 		http.Error(w, "job ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -139,30 +130,25 @@ func (s *Server) handleManualScheduleJob(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Write the response
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	//nolint:errcheck // The error is always nil
 	json.NewEncoder(w).Encode(res)
 }
 
-// handleGetJob handles the get job by job ID request.
 func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
-	// Get the job ID from the path	parameters
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
 		http.Error(w, "job ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the job ID from the path parameters
 	jobID := r.PathValue("job_id")
 	if jobID == "" {
 		http.Error(w, "job ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -186,7 +172,6 @@ func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Write the response
 	w.Header().Set("Content-Type", "application/json")
 	if isTerminalJobStatus(res.GetStatus()) {
 		w.Header().Set("Cache-Control", "public, max-age=7200") // Cache for 2 hrs
@@ -197,23 +182,19 @@ func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(res)
 }
 
-// handleGetJobLogs handles the get job logs by job ID request.
 func (s *Server) handleGetJobLogs(w http.ResponseWriter, r *http.Request) {
-	// Get the job ID from the path	parameters
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
 		http.Error(w, "job ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the job ID from the path parameters
 	jobID := r.PathValue("job_id")
 	if jobID == "" {
 		http.Error(w, "job ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -226,7 +207,6 @@ func (s *Server) handleGetJobLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get cursor from the query parameters
 	cursor := r.URL.Query().Get("cursor")
 
 	// GetJobLogs gets the job logs by job ID.
@@ -244,7 +224,6 @@ func (s *Server) handleGetJobLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Write the response
 	w.Header().Set("Content-Type", "application/json")
 	setJobLogsCacheControl(w, cursor, res.GetCursor())
 
@@ -253,23 +232,19 @@ func (s *Server) handleGetJobLogs(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(res)
 }
 
-// handleSearchJobLogs handles the search job logs by job ID and filters request.
 func (s *Server) handleSearchJobLogs(w http.ResponseWriter, r *http.Request) {
-	// Get the job ID from the path	parameters
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
 		http.Error(w, "job ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the job ID from the path parameters
 	jobID := r.PathValue("job_id")
 	if jobID == "" {
 		http.Error(w, "job ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -282,10 +257,8 @@ func (s *Server) handleSearchJobLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get cursor from the query parameters
 	cursor := r.URL.Query().Get("cursor")
 
-	// Get status from the query parameters
 	stream, err := getJobLogsStreamType(r.URL.Query().Get("stream"))
 	if err != nil {
 		http.Error(w, "invalid log stream type", http.StatusBadRequest)
@@ -327,7 +300,6 @@ func (s *Server) handleSearchJobLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Write the response
 	w.Header().Set("Content-Type", "application/json")
 	setJobLogsCacheControl(w, cursor, res.GetCursor())
 
@@ -644,23 +616,19 @@ func writeJobLogsDownloadError(w io.Writer, format, message string, err error) {
 	}
 }
 
-// handleJobEvents handles the job events by job ID request.
 func (s *Server) handleJobEvents(w http.ResponseWriter, r *http.Request) {
-	// Get the workflow ID from the path parameters
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
 		http.Error(w, "workflow ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the job ID from the path parameters
 	jobID := r.PathValue("job_id")
 	if jobID == "" {
 		http.Error(w, "job ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)

--- a/internal/server/notifications_handlers.go
+++ b/internal/server/notifications_handlers.go
@@ -8,9 +8,7 @@ import (
 	notificationspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/notifications"
 )
 
-// handleListNotifications handles the list notifications request.
 func (s *Server) handleListNotifications(w http.ResponseWriter, r *http.Request) {
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -23,7 +21,6 @@ func (s *Server) handleListNotifications(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Get cursor from the query parameters
 	cursor := r.URL.Query().Get("cursor")
 
 	// ListNotifications lists the notifications.
@@ -36,7 +33,6 @@ func (s *Server) handleListNotifications(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Write the response
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	//nolint:errcheck // The error is always nil
@@ -47,7 +43,6 @@ type markNotificationsReadRequest struct {
 	IDs []string `json:"ids"`
 }
 
-// handleMarkNotificationsRead handles the mark notifications read request.
 func (s *Server) handleMarkNotificationsRead(w http.ResponseWriter, r *http.Request) {
 	var req markNotificationsReadRequest
 	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
@@ -55,7 +50,6 @@ func (s *Server) handleMarkNotificationsRead(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -78,6 +72,5 @@ func (s *Server) handleMarkNotificationsRead(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Write the response
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/server/users_handlers.go
+++ b/internal/server/users_handlers.go
@@ -17,7 +17,6 @@ type registerRequest struct {
 	Password string `json:"password"`
 }
 
-// handleRegisterUser handles the register request.
 func (s *Server) handleRegisterUser(w http.ResponseWriter, r *http.Request) {
 	idempotencyKey, ok := idempotencyKeyFromHeader(r)
 	if !ok {
@@ -76,7 +75,6 @@ type loginRequest struct {
 	Password string `json:"password"`
 }
 
-// handleLoginUser handles the login request.
 func (s *Server) handleLoginUser(w http.ResponseWriter, r *http.Request) {
 	var req loginRequest
 	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
@@ -123,13 +121,11 @@ func (s *Server) handleLoginUser(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 }
 
-// handleLogout handles the logout request.
 func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	// Delete the csrf and session cookies
 	setCookie(w, csrfCookieName, "", s.hostConfig.Host, s.hostConfig.Secure, -1, s.hostConfig.SameSite)
 	setCookie(w, sessionCookieName, "", s.hostConfig.Host, s.hostConfig.Secure, -1, s.hostConfig.SameSite)
 
-	// Get the session from the context
 	session, err := sessionFromContext(r.Context())
 	if err != nil {
 		http.Error(w, "session not found in context", http.StatusUnauthorized)
@@ -145,14 +141,11 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// handleValidate handles the validate request.
 func (s *Server) handleValidate(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleGetUser handles the get user request.
 func (s *Server) handleGetUser(w http.ResponseWriter, r *http.Request) {
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -184,7 +177,6 @@ type updateUserRequest struct {
 	NotificationPreference string `json:"notification_preference"`
 }
 
-// handleUpdateUser handles the update user request.
 func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
 	var req updateUserRequest
 	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
@@ -192,7 +184,6 @@ func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)

--- a/internal/server/workflows_handlers.go
+++ b/internal/server/workflows_handlers.go
@@ -19,7 +19,6 @@ type createWorkflowRequest struct {
 	LogRetention                     *bool  `json:"log_retention"`
 }
 
-// handleCreateWorkflow handles the create workflow request.
 func (s *Server) handleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
 	var req createWorkflowRequest
 	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
@@ -27,7 +26,6 @@ func (s *Server) handleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -56,12 +54,11 @@ func (s *Server) handleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
 		IdempotencyKey:                   idempotencyKey,
 	}
 
-	// If log retention is provided, set it in the proto request, otherwise it will be set to the default value in the service layer.
+	// Forward log retention only when set; service applies default otherwise.
 	if req.LogRetention != nil {
 		protoReq.LogRetention = req.LogRetention
 	}
 
-	// CreateWorkflow creates a new workflow.
 	res, err := s.workflowsClient.CreateWorkflow(r.Context(), protoReq)
 	if err != nil {
 		handleError(w, err, "failed to create workflow")
@@ -81,7 +78,6 @@ type updateWorkflowRequest struct {
 	MaxConsecutiveJobFailuresAllowed int32  `json:"max_consecutive_job_failures_allowed"`
 }
 
-// handleUpdateWorkflow handles the update workflow request.
 func (s *Server) handleUpdateWorkflow(w http.ResponseWriter, r *http.Request) {
 	var req updateWorkflowRequest
 	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
@@ -89,14 +85,12 @@ func (s *Server) handleUpdateWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get the workflow ID from the path parameters
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
 		http.Error(w, "workflow ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -115,7 +109,6 @@ func (s *Server) handleUpdateWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// UpdateWorkflow updates the workflow details.
 	_, err := s.workflowsClient.UpdateWorkflow(r.Context(), &workflowspb.UpdateWorkflowRequest{
 		Id:                               workflowID,
 		UserId:                           userID,
@@ -133,16 +126,13 @@ func (s *Server) handleUpdateWorkflow(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// handleGetWorkflow handles the get workflow by ID and user ID request.
 func (s *Server) handleGetWorkflow(w http.ResponseWriter, r *http.Request) {
-	// Get the workflow ID from the path	parameters
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
 		http.Error(w, "workflow ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -155,7 +145,6 @@ func (s *Server) handleGetWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// GetWorkflow gets the workflow by ID.
 	res, err := s.workflowsClient.GetWorkflow(r.Context(), &workflowspb.GetWorkflowRequest{
 		Id:     workflowID,
 		UserId: userID,
@@ -171,16 +160,13 @@ func (s *Server) handleGetWorkflow(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(res)
 }
 
-// handleTerminateWorkflow handles the terminate workflow by ID and user ID request.
 func (s *Server) handleTerminateWorkflow(w http.ResponseWriter, r *http.Request) {
-	// Get the workflow ID from the path	parameters
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
 		http.Error(w, "workflow ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -193,7 +179,6 @@ func (s *Server) handleTerminateWorkflow(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// TerminateWorkflow terminates the workflow by ID.
 	_, err := s.workflowsClient.TerminateWorkflow(r.Context(), &workflowspb.TerminateWorkflowRequest{
 		Id:     workflowID,
 		UserId: userID,
@@ -206,16 +191,13 @@ func (s *Server) handleTerminateWorkflow(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// handleDeleteWorkflow handles the delete workflow by ID and user ID request.
 func (s *Server) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
-	// Get the workflow ID from the path parameters
 	workflowID := r.PathValue("workflow_id")
 	if workflowID == "" {
 		http.Error(w, "workflow ID not found", http.StatusBadRequest)
 		return
 	}
 
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -228,7 +210,6 @@ func (s *Server) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// DeleteWorkflow deletes the workflow by ID.
 	_, err := s.workflowsClient.DeleteWorkflow(r.Context(), &workflowspb.DeleteWorkflowRequest{
 		Id:     workflowID,
 		UserId: userID,
@@ -241,11 +222,9 @@ func (s *Server) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// handleListWorkflows handles the list workflows by user ID request.
 //
 //nolint:gocyclo // This function is complex and can be simplified further.
 func (s *Server) handleListWorkflows(w http.ResponseWriter, r *http.Request) {
-	// Get the user ID from the context
 	value := r.Context().Value(userIDKey{})
 	if value == nil {
 		http.Error(w, "user ID not found", http.StatusBadRequest)
@@ -258,7 +237,6 @@ func (s *Server) handleListWorkflows(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get cursor from the query parameters
 	cursor := r.URL.Query().Get("cursor")
 
 	// 1. query
@@ -267,7 +245,6 @@ func (s *Server) handleListWorkflows(w http.ResponseWriter, r *http.Request) {
 	// 2. kind
 	kind := r.URL.Query().Get("kind")
 	if kind != "" {
-		// Validate kind
 		if !isValidKind(kind) {
 			http.Error(w, "invalid kind", http.StatusBadRequest)
 			return
@@ -277,7 +254,6 @@ func (s *Server) handleListWorkflows(w http.ResponseWriter, r *http.Request) {
 	// 3. build_status
 	buildStatus := r.URL.Query().Get("build_status")
 	if buildStatus != "" {
-		// Validate build status
 		if !isValidBuildStatus(buildStatus) {
 			http.Error(w, "invalid build status", http.StatusBadRequest)
 			return
@@ -315,7 +291,6 @@ func (s *Server) handleListWorkflows(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ListWorkflows lists the workflows by user ID.
 	res, err := s.workflowsClient.ListWorkflows(r.Context(), &workflowspb.ListWorkflowsRequest{
 		UserId: userID,
 		Cursor: cursor,

--- a/internal/service/analytics/analytics_test.go
+++ b/internal/service/analytics/analytics_test.go
@@ -22,10 +22,8 @@ import (
 func TestGetUserAnalytics(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := analyticsmock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := analytics.New(validator.New(), repo)
 
 	var (
@@ -33,7 +31,6 @@ func TestGetUserAnalytics(t *testing.T) {
 		singleflightReleaseChan chan struct{}
 	)
 
-	// Test cases
 	tests := []struct {
 		name    string
 		req     *analyticspb.GetUserAnalyticsRequest
@@ -195,13 +192,10 @@ func TestGetUserAnalytics(t *testing.T) {
 func TestGetWorkflowAnalytics(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := analyticsmock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := analytics.New(validator.New(), repo)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *analyticspb.GetWorkflowAnalyticsRequest

--- a/internal/service/analyticsprocessor/analyticsprocessor_test.go
+++ b/internal/service/analyticsprocessor/analyticsprocessor_test.go
@@ -16,10 +16,8 @@ import (
 func TestRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	mockRepo := analyticsprocessormock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := analyticsprocessor.New(mockRepo)
 
 	type want struct {

--- a/internal/service/databasemigration/databasemigration_test.go
+++ b/internal/service/databasemigration/databasemigration_test.go
@@ -15,10 +15,8 @@ import (
 func TestRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	mockRepo := databasemigrationmock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := databasemigration.New(mockRepo)
 
 	type want struct {

--- a/internal/service/executor/executor_test.go
+++ b/internal/service/executor/executor_test.go
@@ -15,10 +15,8 @@ import (
 func TestRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	mockRepo := executormock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := executor.New(mockRepo)
 
 	type want struct {

--- a/internal/service/joblogs/joblogs_test.go
+++ b/internal/service/joblogs/joblogs_test.go
@@ -15,10 +15,8 @@ import (
 func TestRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	mockRepo := joblogsmock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := joblogs.New(mockRepo)
 
 	type want struct {

--- a/internal/service/jobs/jobs.go
+++ b/internal/service/jobs/jobs.go
@@ -130,7 +130,6 @@ func (s *Service) ScheduleJob(ctx context.Context, req *jobspb.ScheduleJobReques
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&ScheduleJobRequest{
 		WorkflowID:         req.GetWorkflowId(),
 		UserID:             req.GetUserId(),
@@ -511,7 +510,6 @@ func (s *Service) GetJob(ctx context.Context, req *jobspb.GetJobRequest) (res *j
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&GetJobRequest{
 		ID:         req.GetId(),
 		WorkflowID: req.GetWorkflowId(),
@@ -547,7 +545,6 @@ func (s *Service) GetJobByID(ctx context.Context, req *jobspb.GetJobByIDRequest)
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&GetJobByIDRequest{
 		ID: req.GetId(),
 	})
@@ -601,7 +598,6 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 		filters = &jobsmodel.GetJobLogsFilters{}
 	}
 
-	// Validate the request
 	err = s.validator.Struct(&GetJobLogsRequest{
 		ID:         req.GetId(),
 		WorkflowID: req.GetWorkflowId(),
@@ -617,7 +613,6 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 
 	sortOrder := normalizeJobLogsSortOrder(jobsmodel.JobLogsSortOrder(req.GetSortOrder()))
 
-	// Check if the job logs are cached
 	cacheKey := fmt.Sprintf(
 		"job_logs:%s:%s:%s:%s:%d",
 		req.GetUserId(),
@@ -635,7 +630,6 @@ func (s *Service) GetJobLogs(ctx context.Context, req *jobspb.GetJobLogsRequest)
 				return nil, err
 			}
 		} else {
-			// Cache hit, return cached response
 			//nolint:errcheck,forcetypeassert // Ignore error as we are just reading from cache
 			return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 		}
@@ -708,7 +702,6 @@ func (s *Service) StreamJobLogs(ctx context.Context, req *jobspb.StreamJobLogsRe
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&StreamJobLogsRequest{
 		ID:         req.GetId(),
 		WorkflowID: req.GetWorkflowId(),
@@ -822,7 +815,6 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 	sortOrder := normalizeJobLogsSortOrder(jobsmodel.JobLogsSortOrder(req.GetSortOrder()))
 	disableHighlight := req.GetDisableHighlight()
 
-	// Check if the job logs are cached
 	cacheKey := fmt.Sprintf(
 		"job_logs:search:%s:%s:%s:%s:%s:%d:%t",
 		req.GetUserId(),
@@ -842,7 +834,6 @@ func (s *Service) SearchJobLogs(ctx context.Context, req *jobspb.SearchJobLogsRe
 				return nil, err
 			}
 		} else {
-			// Cache hit, return cached response
 			//nolint:errcheck,forcetypeassert // Ignore error as we are just reading from cache
 			return cacheRes.(*jobsmodel.GetJobLogsResponse), nil
 		}
@@ -927,7 +918,6 @@ func (s *Service) ListJobs(ctx context.Context, req *jobspb.ListJobsRequest) (re
 		filters = &jobsmodel.ListJobsFilters{}
 	}
 
-	// Validate the request
 	err = s.validator.Struct(&ListJobsRequest{
 		WorkflowID: req.GetWorkflowId(),
 		UserID:     req.GetUserId(),

--- a/internal/service/jobs/jobs_test.go
+++ b/internal/service/jobs/jobs_test.go
@@ -26,18 +26,15 @@ import (
 func TestScheduleJob(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
 
 	type want struct {
 		jobID string
 	}
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *jobspb.ScheduleJobRequest
@@ -406,11 +403,9 @@ func TestTerminalReasonValidation(t *testing.T) {
 func TestGetJob(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -431,7 +426,6 @@ func TestGetJob(t *testing.T) {
 		}
 	)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *jobspb.GetJobRequest
@@ -590,11 +584,9 @@ func TestGetJob(t *testing.T) {
 func TestGetJobByID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -615,7 +607,6 @@ func TestGetJobByID(t *testing.T) {
 		}
 	)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *jobspb.GetJobByIDRequest
@@ -724,11 +715,9 @@ func TestGetJobByID(t *testing.T) {
 func TestGetJobLogs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -741,7 +730,6 @@ func TestGetJobLogs(t *testing.T) {
 		singleflightReleaseChan chan struct{}
 	)
 
-	// Test cases
 	tests := []struct {
 		name    string
 		req     *jobspb.GetJobLogsRequest
@@ -1332,18 +1320,15 @@ func TestGetJobLogsAscendingSortOrder(t *testing.T) {
 func TestStreamJobLogs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
 
 	type want struct {
 		channelType string
 	}
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *jobspb.StreamJobLogsRequest
@@ -1369,7 +1354,6 @@ func TestStreamJobLogs(t *testing.T) {
 					req.GetUserId(),
 				).Return(sub, nil)
 
-				// Simulate sending logs to the channel
 				go func() {
 					redisMock.Publish(t.Context(), "job_logs", &jobsmodel.JobLog{
 						Timestamp:   time.Now(),
@@ -1517,11 +1501,9 @@ func searchJobLogsOptionsForTest(req *jobspb.SearchJobLogsRequest) jobsmodel.Sea
 func TestSearchJobLogs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -1530,7 +1512,6 @@ func TestSearchJobLogs(t *testing.T) {
 
 	timestamp := time.Now()
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *jobspb.SearchJobLogsRequest
@@ -2006,11 +1987,9 @@ func TestSearchJobLogs(t *testing.T) {
 func TestListJobs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := jobsmock.NewMockRepository(ctrl)
 	cache := jobsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := jobs.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -2031,7 +2010,6 @@ func TestListJobs(t *testing.T) {
 		}
 	)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *jobspb.ListJobsRequest

--- a/internal/service/notifications/notifications.go
+++ b/internal/service/notifications/notifications.go
@@ -65,7 +65,6 @@ func (s *Service) CreateNotification(ctx context.Context, req *notificationspb.C
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&CreateNotificationRequest{
 		UserID:         req.GetUserId(),
 		Kind:           req.GetKind(),
@@ -115,7 +114,6 @@ func (s *Service) MarkNotificationsRead(ctx context.Context, req *notificationsp
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&MarkNotificationsRead{
 		IDs:    req.GetIds(),
 		UserID: req.GetUserId(),
@@ -150,7 +148,6 @@ func (s *Service) ListNotifications(
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&ListNotificationsRequest{
 		UserID: req.GetUserId(),
 		Cursor: req.GetCursor(),

--- a/internal/service/notifications/notifications_test.go
+++ b/internal/service/notifications/notifications_test.go
@@ -22,17 +22,14 @@ import (
 func TestService_CreateNotification(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := notificationsmock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := notifications.New(validator.New(), repo)
 
 	type want struct {
 		notificationID string
 	}
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *notificationspb.CreateNotificationRequest
@@ -173,17 +170,14 @@ func TestService_CreateNotificationRejectsNonObjectPayload(t *testing.T) {
 func TestService_MarkNotificationsRead(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := notificationsmock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := notifications.New(validator.New(), repo)
 
 	type want struct {
 		err error
 	}
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *notificationspb.MarkNotificationsReadRequest
@@ -277,10 +271,8 @@ func TestService_MarkNotificationsRead(t *testing.T) {
 func TestService_ListNotifications(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := notificationsmock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := notifications.New(validator.New(), repo)
 
 	type want struct {
@@ -295,7 +287,6 @@ func TestService_ListNotifications(t *testing.T) {
 		singleflightReleaseChan chan struct{}
 	)
 
-	// Test cases
 	tests := []struct {
 		name    string
 		req     *notificationspb.ListNotificationsRequest

--- a/internal/service/scheduler/scheduler_test.go
+++ b/internal/service/scheduler/scheduler_test.go
@@ -15,10 +15,8 @@ import (
 func TestRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	mockRepo := schedulermock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := scheduler.New(mockRepo)
 
 	type want struct {

--- a/internal/service/users/users.go
+++ b/internal/service/users/users.go
@@ -86,7 +86,6 @@ func (s *Service) RegisterUser(ctx context.Context, req *userpb.RegisterUserRequ
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&RegisterUserRequest{
 		Email:          req.GetEmail(),
 		Password:       req.GetPassword(),
@@ -102,13 +101,11 @@ func (s *Service) RegisterUser(ctx context.Context, req *userpb.RegisterUserRequ
 		return "", "", err
 	}
 
-	// Cache the response in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
+	// Fire-and-forget; do not wait.
 	go func() {
 		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 		defer cancel()
 
-		// Cache the LoginUser response
 		// The key is in the format "user:{user_id}"
 		cacheKey := fmt.Sprintf("user:%s", res.ID)
 		if setErr := s.cache.Set(bgCtx, cacheKey, res, cachepkg.AddJitter(defaultExpirationTTL, cacheExpirationJitter)); setErr != nil {
@@ -148,7 +145,6 @@ func (s *Service) LoginUser(ctx context.Context, req *userpb.LoginUserRequest) (
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&LoginUserRequest{
 		Email:    req.GetEmail(),
 		Password: req.GetPassword(),
@@ -163,13 +159,11 @@ func (s *Service) LoginUser(ctx context.Context, req *userpb.LoginUserRequest) (
 		return "", "", normalizeLoginError(err)
 	}
 
-	// Cache the response in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
+	// Fire-and-forget; do not wait.
 	go func() {
 		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 		defer cancel()
 
-		// Cache the LoginUser response
 		// The key is in the format "user:{user_id}"
 		cacheKey := fmt.Sprintf("user:%s", res.ID)
 		if setErr := s.cache.Set(bgCtx, cacheKey, res, cachepkg.AddJitter(defaultExpirationTTL, cacheExpirationJitter)); setErr != nil {
@@ -208,7 +202,6 @@ func (s *Service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (res 
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&GetUserRequest{
 		ID: req.GetId(),
 	})
@@ -226,7 +219,6 @@ func (s *Service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (res 
 			return nil, err
 		}
 	} else {
-		// Cache hit, return cached response
 		//nolint:errcheck,forcetypeassert // Ignore error as we are just reading from cache
 		return cacheRes.(*usersmodel.GetUserResponse), nil
 	}
@@ -287,7 +279,6 @@ func (s *Service) UpdateUser(ctx context.Context, req *userpb.UpdateUserRequest)
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&UpdateUserRequest{
 		ID:                     req.GetId(),
 		NotificationPreference: req.GetNotificationPreference(),

--- a/internal/service/users/users_test.go
+++ b/internal/service/users/users_test.go
@@ -21,11 +21,9 @@ import (
 func TestRegisterUser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := usersmock.NewMockRepository(ctrl)
 	cache := usersmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := users.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -33,7 +31,6 @@ func TestRegisterUser(t *testing.T) {
 		pat    string
 	}
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *userspb.RegisterUserRequest
@@ -62,7 +59,6 @@ func TestRegisterUser(t *testing.T) {
 					UpdatedAt:              time.Now(),
 				}, "token", nil)
 
-				// Simulate cache set
 				cache.EXPECT().Set(
 					gomock.Any(),
 					gomock.Any(),
@@ -154,11 +150,9 @@ func TestRegisterUser(t *testing.T) {
 func TestLoginUser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := usersmock.NewMockRepository(ctrl)
 	cache := usersmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := users.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -167,7 +161,6 @@ func TestLoginUser(t *testing.T) {
 		code   codes.Code
 	}
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *userspb.LoginUserRequest
@@ -194,7 +187,6 @@ func TestLoginUser(t *testing.T) {
 					UpdatedAt:              time.Now(),
 				}, "token", nil)
 
-				// Simulate cache set
 				cache.EXPECT().Set(
 					gomock.Any(),
 					gomock.Any(),
@@ -301,11 +293,9 @@ func TestLoginUser(t *testing.T) {
 func TestGetUser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := usersmock.NewMockRepository(ctrl)
 	cache := usersmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := users.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -319,7 +309,6 @@ func TestGetUser(t *testing.T) {
 		singleflightReleaseChan chan struct{}
 	)
 
-	// Test cases
 	tests := []struct {
 		name    string
 		req     *userspb.GetUserRequest
@@ -334,7 +323,6 @@ func TestGetUser(t *testing.T) {
 				Id: "userID",
 			},
 			mock: func(req *userspb.GetUserRequest) {
-				// Simulate cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -352,7 +340,6 @@ func TestGetUser(t *testing.T) {
 					UpdatedAt:              updatedAt,
 				}, nil)
 
-				// Simulate cache set
 				cache.EXPECT().Set(
 					gomock.Any(),
 					gomock.Any(),
@@ -377,7 +364,6 @@ func TestGetUser(t *testing.T) {
 				Id: "userID",
 			},
 			mock: func(_ *userspb.GetUserRequest) {
-				// Simulate cache hit
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -492,7 +478,6 @@ func TestGetUser(t *testing.T) {
 				Id: "invalid_user_id",
 			},
 			mock: func(req *userspb.GetUserRequest) {
-				// Simulate cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -513,7 +498,6 @@ func TestGetUser(t *testing.T) {
 				Id: "invalid_user_id",
 			},
 			mock: func(req *userspb.GetUserRequest) {
-				// Simulate cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -534,7 +518,6 @@ func TestGetUser(t *testing.T) {
 				Id: "user_id",
 			},
 			mock: func(req *userspb.GetUserRequest) {
-				// Simulate cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -582,11 +565,9 @@ func TestGetUser(t *testing.T) {
 func TestUpdateUser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := usersmock.NewMockRepository(ctrl)
 	cache := usersmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := users.New(validator.New(), repo, cache)
 
 	tests := []struct {
@@ -608,7 +589,6 @@ func TestUpdateUser(t *testing.T) {
 					req.GetNotificationPreference(),
 				).Return(nil)
 
-				// Simulate cache invalidation
 				cache.EXPECT().Delete(
 					gomock.Any(),
 					gomock.Any(),

--- a/internal/service/workflow/workflow_test.go
+++ b/internal/service/workflow/workflow_test.go
@@ -15,10 +15,8 @@ import (
 func TestRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	mockRepo := workflowmock.NewMockRepository(ctrl)
 
-	// Create a new service
 	s := workflow.New(mockRepo)
 
 	type want struct {

--- a/internal/service/workflows/workflows.go
+++ b/internal/service/workflows/workflows.go
@@ -113,7 +113,6 @@ func (s *Service) CreateWorkflow(ctx context.Context, req *workflowspb.CreateWor
 		logRetentionEnabled = req.GetLogRetention()
 	}
 
-	// Validate the request
 	err = s.validator.Struct(&CreateWorkflowRequest{
 		UserID:                           req.GetUserId(),
 		Name:                             req.GetName(),
@@ -167,13 +166,11 @@ func (s *Service) CreateWorkflow(ctx context.Context, req *workflowspb.CreateWor
 		return "", err
 	}
 
-	// Cache the response in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
+	// Fire-and-forget; do not wait.
 	go func() {
 		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 		defer cancel()
 
-		// Invalidate all list entries for the user
 		s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
 
 		if res.IdempotencyReplay {
@@ -226,7 +223,6 @@ func (s *Service) UpdateWorkflow(ctx context.Context, req *workflowspb.UpdateWor
 		span.End()
 	}()
 
-	// Validate the request
 	if err = s.validator.Struct(&UpdateWorkflowRequest{
 		ID:                               req.GetId(),
 		UserID:                           req.GetUserId(),
@@ -264,17 +260,13 @@ func (s *Service) UpdateWorkflow(ctx context.Context, req *workflowspb.UpdateWor
 		return err
 	}
 
-	// Invalidate the cache in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
+	// Fire-and-forget; do not wait.
 	go func() {
-		// Cache invalidation for the following:
 		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 		defer cancel()
 
-		// Invalidate specific workflow cache
 		s.invalidateWorkflowCache(bgCtx, req.GetId(), req.GetUserId(), logger)
 
-		// Invalidate all list entries for the user
 		s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
 	}()
 
@@ -305,7 +297,6 @@ func (s *Service) UpdateWorkflowBuildStatus(ctx context.Context, req *workflowsp
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&UpdateWorkflowBuildStatusRequest{
 		ID:          req.GetId(),
 		UserID:      req.GetUserId(),
@@ -337,17 +328,13 @@ func (s *Service) UpdateWorkflowBuildStatus(ctx context.Context, req *workflowsp
 		return err
 	}
 
-	// Invalidate the cache in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
+	// Fire-and-forget; do not wait.
 	go func() {
-		// Cache invalidation for the following:
 		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 		defer cancel()
 
-		// Invalidate specific workflow cache
 		s.invalidateWorkflowCache(bgCtx, req.GetId(), req.GetUserId(), logger)
 
-		// Invalidate all list entries for the user
 		s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
 	}()
 
@@ -374,7 +361,6 @@ func (s *Service) GetWorkflow(ctx context.Context, req *workflowspb.GetWorkflowR
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&GetWorkflowRequest{
 		ID:     req.GetId(),
 		UserID: req.GetUserId(),
@@ -393,7 +379,6 @@ func (s *Service) GetWorkflow(ctx context.Context, req *workflowspb.GetWorkflowR
 			return nil, err
 		}
 	} else {
-		// Cache hit, return cached response
 		//nolint:errcheck,forcetypeassert // Ignore error as we are just reading from cache
 		return cacheRes.(*workflowsmodel.GetWorkflowResponse), nil
 	}
@@ -453,7 +438,6 @@ func (s *Service) GetWorkflowByID(ctx context.Context, req *workflowspb.GetWorkf
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&GetWorkflowByIDRequest{
 		ID: req.GetId(),
 	})
@@ -498,7 +482,6 @@ func (s *Service) IncrementWorkflowConsecutiveJobFailuresCount(
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&IncrementWorkflowConsecutiveJobFailuresCountRequest{
 		ID:     req.GetId(),
 		UserID: req.GetUserId(),
@@ -515,17 +498,13 @@ func (s *Service) IncrementWorkflowConsecutiveJobFailuresCount(
 		return false, err
 	}
 
-	// Invalidate the cache in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
+	// Fire-and-forget; do not wait.
 	go func() {
-		// Cache invalidation for the following:
 		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 		defer cancel()
 
-		// Invalidate specific workflow cache
 		s.invalidateWorkflowCache(bgCtx, req.GetId(), req.GetUserId(), logger)
 
-		// Invalidate all list entries for the user
 		s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
 	}()
 
@@ -553,7 +532,6 @@ func (s *Service) ResetWorkflowConsecutiveJobFailuresCount(ctx context.Context, 
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&ResetWorkflowConsecutiveJobFailuresCountRequest{
 		ID:     req.GetId(),
 		UserID: req.GetUserId(),
@@ -570,17 +548,13 @@ func (s *Service) ResetWorkflowConsecutiveJobFailuresCount(ctx context.Context, 
 		return err
 	}
 
-	// Invalidate the cache in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
+	// Fire-and-forget; do not wait.
 	go func() {
-		// Cache invalidation for the following:
 		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 		defer cancel()
 
-		// Invalidate specific workflow cache
 		s.invalidateWorkflowCache(bgCtx, req.GetId(), req.GetUserId(), logger)
 
-		// Invalidate all list entries for the user
 		s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
 	}()
 
@@ -609,7 +583,6 @@ func (s *Service) TerminateWorkflow(ctx context.Context, req *workflowspb.Termin
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&TerminateWorkflowRequest{
 		ID:     req.GetId(),
 		UserID: req.GetUserId(),
@@ -625,17 +598,13 @@ func (s *Service) TerminateWorkflow(ctx context.Context, req *workflowspb.Termin
 		return err
 	}
 
-	// Invalidate the cache in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
+	// Fire-and-forget; do not wait.
 	go func() {
-		// Cache invalidation for the following:
 		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 		defer cancel()
 
-		// Invalidate specific workflow cache
 		s.invalidateWorkflowCache(bgCtx, req.GetId(), req.GetUserId(), logger)
 
-		// Invalidate all list entries for the user
 		s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
 	}()
 
@@ -664,7 +633,6 @@ func (s *Service) DeleteWorkflow(ctx context.Context, req *workflowspb.DeleteWor
 		span.End()
 	}()
 
-	// Validate the request
 	err = s.validator.Struct(&DeleteWorkflowRequest{
 		ID:     req.GetId(),
 		UserID: req.GetUserId(),
@@ -680,17 +648,13 @@ func (s *Service) DeleteWorkflow(ctx context.Context, req *workflowspb.DeleteWor
 		return err
 	}
 
-	// Invalidate the cache in the background
-	// This is a fire-and-forget operation, so we don't wait for it to complete.
+	// Fire-and-forget; do not wait.
 	go func() {
-		// Cache invalidation for the following:
 		bgCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheTimeout)
 		defer cancel()
 
-		// Invalidate specific workflow cache
 		s.invalidateWorkflowCache(bgCtx, req.GetId(), req.GetUserId(), logger)
 
-		// Invalidate all list entries for the user
 		s.invalidateWorkflowsCache(bgCtx, req.GetUserId(), logger)
 	}()
 
@@ -732,7 +696,6 @@ func (s *Service) ListWorkflows(ctx context.Context, req *workflowspb.ListWorkfl
 		filters = &workflowsmodel.ListWorkflowsFilters{}
 	}
 
-	// Validate the request
 	err = s.validator.Struct(&ListWorkflowsRequest{
 		UserID:  req.GetUserId(),
 		Cursor:  req.GetCursor(),
@@ -769,7 +732,6 @@ func (s *Service) ListWorkflows(ctx context.Context, req *workflowspb.ListWorkfl
 			return nil, err
 		}
 	} else {
-		// Cache hit, return cached response
 		//nolint:errcheck,forcetypeassert // Ignore error as we are just reading from cache
 		return cacheRes.(*workflowsmodel.ListWorkflowsResponse), nil
 	}
@@ -888,7 +850,6 @@ func generateListWorkflowsCacheKey(userID, cursor string, filters *workflowsmode
 
 // invalidateWorkflowCache handles cache invalidation for a specific workflow for a user.
 func (s *Service) invalidateWorkflowCache(ctx context.Context, workflowID, userID string, logger *zap.Logger) {
-	// Invalidate specific workflow cache
 	// The key is in the format "workflow:{user_id}:{job_id}".
 	cacheKey := fmt.Sprintf("workflow:%s:%s", userID, workflowID)
 	if err := s.cache.Delete(ctx, cacheKey); err != nil &&
@@ -906,7 +867,6 @@ func (s *Service) invalidateWorkflowCache(ctx context.Context, workflowID, userI
 
 // invalidateWorkflowsCache handles cache invalidation for all workflows for a user.
 func (s *Service) invalidateWorkflowsCache(ctx context.Context, userID string, logger *zap.Logger) {
-	// Invalidate all list entries for the user
 	// We use the user ID as the key, and '*' as the pattern.
 	cacheKey := fmt.Sprintf("workflows:%s:*", userID)
 	count, err := s.cache.DeleteByPattern(ctx, cacheKey)

--- a/internal/service/workflows/workflows_test.go
+++ b/internal/service/workflows/workflows_test.go
@@ -26,18 +26,15 @@ func boolPtr(b bool) *bool {
 func TestCreateWorkflow(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := workflowsmock.NewMockRepository(ctrl)
 	cache := workflowsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := workflows.New(validator.New(), repo, cache)
 
 	type want struct {
 		workflowID string
 	}
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *workflowspb.CreateWorkflowRequest
@@ -86,13 +83,11 @@ func TestCreateWorkflow(t *testing.T) {
 					LogRetention: false,
 				}, nil)
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(int64(0), nil).AnyTimes()
 
-				// Simulate a cache set
 				cache.EXPECT().Set(
 					gomock.Any(),
 					gomock.Any(),
@@ -145,13 +140,11 @@ func TestCreateWorkflow(t *testing.T) {
 					LogRetention: true,
 				}, nil)
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(int64(0), nil).AnyTimes()
 
-				// Simulate a cache set
 				cache.EXPECT().Set(
 					gomock.Any(),
 					gomock.Any(),
@@ -205,13 +198,11 @@ func TestCreateWorkflow(t *testing.T) {
 					LogRetention: false,
 				}, nil)
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(int64(0), nil).AnyTimes()
 
-				// Simulate a cache set
 				cache.EXPECT().Set(
 					gomock.Any(),
 					gomock.Any(),
@@ -265,13 +256,11 @@ func TestCreateWorkflow(t *testing.T) {
 					LogRetention: true,
 				}, nil)
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(int64(0), nil).AnyTimes()
 
-				// Simulate a cache set
 				cache.EXPECT().Set(
 					gomock.Any(),
 					gomock.Any(),
@@ -325,13 +314,11 @@ func TestCreateWorkflow(t *testing.T) {
 					LogRetention: false,
 				}, nil)
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(int64(0), nil).AnyTimes()
 
-				// Simulate a cache set
 				cache.EXPECT().Set(
 					gomock.Any(),
 					gomock.Any(),
@@ -462,14 +449,11 @@ func TestCreateWorkflow(t *testing.T) {
 func TestUpdateWorkflow(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := workflowsmock.NewMockRepository(ctrl)
 	cache := workflowsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := workflows.New(validator.New(), repo, cache)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *workflowspb.UpdateWorkflowRequest
@@ -499,13 +483,11 @@ func TestUpdateWorkflow(t *testing.T) {
 					req.GetIdempotencyKey(),
 				).Return(nil)
 
-				// Simulate a cache delete
 				cache.EXPECT().Delete(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(nil).AnyTimes()
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
@@ -625,14 +607,11 @@ func TestUpdateWorkflow(t *testing.T) {
 func TestUpdateWorkflowBuildStatus(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := workflowsmock.NewMockRepository(ctrl)
 	cache := workflowsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := workflows.New(validator.New(), repo, cache)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *workflowspb.UpdateWorkflowBuildStatusRequest
@@ -660,13 +639,11 @@ func TestUpdateWorkflowBuildStatus(t *testing.T) {
 					req.GetResolvedImageDigest(),
 				).Return(nil)
 
-				// Simulate a cache delete
 				cache.EXPECT().Delete(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(nil).AnyTimes()
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
@@ -776,11 +753,9 @@ func TestUpdateWorkflowBuildStatus(t *testing.T) {
 func TestGetWorkflow(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := workflowsmock.NewMockRepository(ctrl)
 	cache := workflowsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := workflows.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -798,7 +773,6 @@ func TestGetWorkflow(t *testing.T) {
 		}
 	)
 
-	// Test cases
 	tests := []struct {
 		name    string
 		req     *workflowspb.GetWorkflowRequest
@@ -814,7 +788,6 @@ func TestGetWorkflow(t *testing.T) {
 				UserId: "user_id",
 			},
 			mock: func(req *workflowspb.GetWorkflowRequest) {
-				// Simulate a cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -840,13 +813,11 @@ func TestGetWorkflow(t *testing.T) {
 					LogRetention:                     true,
 				}, nil)
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(int64(0), nil).AnyTimes()
 
-				// Simulate a cache set
 				cache.EXPECT().Set(
 					gomock.Any(),
 					gomock.Any(),
@@ -879,7 +850,6 @@ func TestGetWorkflow(t *testing.T) {
 				UserId: "user_id",
 			},
 			mock: func(_ *workflowspb.GetWorkflowRequest) {
-				// Simulate a cache hit
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -1031,7 +1001,6 @@ func TestGetWorkflow(t *testing.T) {
 				UserId: "invalid_user_id",
 			},
 			mock: func(req *workflowspb.GetWorkflowRequest) {
-				// Simulate a cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -1054,7 +1023,6 @@ func TestGetWorkflow(t *testing.T) {
 				UserId: "user_id",
 			},
 			mock: func(req *workflowspb.GetWorkflowRequest) {
-				// Simulate a cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -1077,7 +1045,6 @@ func TestGetWorkflow(t *testing.T) {
 				UserId: "user_id",
 			},
 			mock: func(req *workflowspb.GetWorkflowRequest) {
-				// Simulate a cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -1126,11 +1093,9 @@ func TestGetWorkflow(t *testing.T) {
 func TestGetWorkflowByID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := workflowsmock.NewMockRepository(ctrl)
 	cache := workflowsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := workflows.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -1146,7 +1111,6 @@ func TestGetWorkflowByID(t *testing.T) {
 		}
 	)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *workflowspb.GetWorkflowByIDRequest
@@ -1263,18 +1227,15 @@ func TestGetWorkflowByID(t *testing.T) {
 func TestIncrementWorkflowConsecutiveJobFailuresCount(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := workflowsmock.NewMockRepository(ctrl)
 	cache := workflowsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := workflows.New(validator.New(), repo, cache)
 
 	type want struct {
 		thresholdReached bool
 	}
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *workflowspb.IncrementWorkflowConsecutiveJobFailuresCountRequest
@@ -1297,13 +1258,11 @@ func TestIncrementWorkflowConsecutiveJobFailuresCount(t *testing.T) {
 					req.GetJobId(),
 				).Return(false, nil)
 
-				// Simulate a cache delete
 				cache.EXPECT().Delete(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(nil).AnyTimes()
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
@@ -1413,14 +1372,11 @@ func TestIncrementWorkflowConsecutiveJobFailuresCount(t *testing.T) {
 func TestResetWorkflowConsecutiveJobFailuresCount(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := workflowsmock.NewMockRepository(ctrl)
 	cache := workflowsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := workflows.New(validator.New(), repo, cache)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *workflowspb.ResetWorkflowConsecutiveJobFailuresCountRequest
@@ -1442,13 +1398,11 @@ func TestResetWorkflowConsecutiveJobFailuresCount(t *testing.T) {
 					req.GetJobId(),
 				).Return(nil)
 
-				// Simulate a cache delete
 				cache.EXPECT().Delete(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(nil).AnyTimes()
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
@@ -1526,14 +1480,11 @@ func TestResetWorkflowConsecutiveJobFailuresCount(t *testing.T) {
 func TestTerminateWorkflow(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := workflowsmock.NewMockRepository(ctrl)
 	cache := workflowsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := workflows.New(validator.New(), repo, cache)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *workflowspb.TerminateWorkflowRequest
@@ -1553,13 +1504,11 @@ func TestTerminateWorkflow(t *testing.T) {
 					req.GetUserId(),
 				).Return(nil)
 
-				// Simulate a cache delete
 				cache.EXPECT().Delete(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(nil).AnyTimes()
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
@@ -1641,14 +1590,11 @@ func TestTerminateWorkflow(t *testing.T) {
 func TestDeleteWorkflow(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := workflowsmock.NewMockRepository(ctrl)
 	cache := workflowsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := workflows.New(validator.New(), repo, cache)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *workflowspb.DeleteWorkflowRequest
@@ -1668,13 +1614,11 @@ func TestDeleteWorkflow(t *testing.T) {
 					req.GetUserId(),
 				).Return(nil)
 
-				// Simulate a cache delete
 				cache.EXPECT().Delete(
 					gomock.Any(),
 					gomock.Any(),
 				).Return(nil).AnyTimes()
 
-				// Simulate a cache delete by pattern
 				cache.EXPECT().DeleteByPattern(
 					gomock.Any(),
 					gomock.Any(),
@@ -1757,11 +1701,9 @@ func TestDeleteWorkflow(t *testing.T) {
 func TestListWorkflows(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	// Create a mock repository
 	repo := workflowsmock.NewMockRepository(ctrl)
 	cache := workflowsmock.NewMockCache(ctrl)
 
-	// Create a new service
 	s := workflows.New(validator.New(), repo, cache)
 
 	type want struct {
@@ -1777,7 +1719,6 @@ func TestListWorkflows(t *testing.T) {
 		}
 	)
 
-	// Test cases
 	tests := []struct {
 		name  string
 		req   *workflowspb.ListWorkflowsRequest
@@ -1792,7 +1733,6 @@ func TestListWorkflows(t *testing.T) {
 				Cursor: "",
 			},
 			mock: func(req *workflowspb.ListWorkflowsRequest) {
-				// Simulate a cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -1824,7 +1764,6 @@ func TestListWorkflows(t *testing.T) {
 					Cursor: "",
 				}, nil)
 
-				// Simulate a cache set
 				cache.EXPECT().Set(
 					gomock.Any(),
 					gomock.Any(),
@@ -1862,7 +1801,6 @@ func TestListWorkflows(t *testing.T) {
 				Cursor: "",
 			},
 			mock: func(_ *workflowspb.ListWorkflowsRequest) {
-				// Simulate a cache hit using a pre-defined response
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
@@ -1927,14 +1865,12 @@ func TestListWorkflows(t *testing.T) {
 				Cursor: "",
 			},
 			mock: func(req *workflowspb.ListWorkflowsRequest) {
-				// Simulate a cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(nil, status.Error(codes.NotFound, "cache miss"))
 
-				// Simulate a repository call
 				// This should return an error
 				repo.EXPECT().ListWorkflows(
 					gomock.Any(),
@@ -1953,7 +1889,6 @@ func TestListWorkflows(t *testing.T) {
 				Cursor: "",
 			},
 			mock: func(req *workflowspb.ListWorkflowsRequest) {
-				// Simulate a cache miss
 				cache.EXPECT().Get(
 					gomock.Any(),
 					gomock.Any(),


### PR DESCRIPTION
## Summary
Global comment cleanup: removed redundant restatements and shortened verbose notes across Go backend (cmd, internal/server, internal/service, internal/repository, internal/app, internal/pkg, internal/config, internal/model, pkg) and dashboard TS. No behavior changes: full-branch diff is comment-only (verified via git diff filter), go build clean, go test -short green for server/service/pkg.

## Approach
- Deleted comments that restate the next line (Initialize/Load/Connect/listener/log/serve in cmd; user/path/query/write-response in handlers; validate-request/cache-hit/Simulate scaffolding in services; transaction bounds, atomic/auth echoes in repos; formatting/filter/mutation/schema labels in dashboard).
- Shortened repeated why-notes to one line (fire-and-forget, detached notification context, internal-only, log-retention forwarding, buffer-override, circuit-breaker, index/validator docs) preserving semantics.
- Fixed typos/grammar: DSNs, Retruning->Returning, bacthes->batches, stray comma, copy-paste workflow-vs-job ID label (resolved by deletion), proxy auth-boundary note.
- Preserved all directives (go:generate, nolint, nosec, go:build), generated code (*.pb.go, mock/*, next-env.d.ts), exported API docs, and genuine why-comments (TLS verify-full, runtime identity, NAT64, retention policy, log ordering).

## Reviewer notes
- Per-commit review recommended (one scope each). Spot-check: cmd/database-migration/main.go (kept TLS why-comments), internal/pkg/grpc/client/interceptors.go (condensed breaker logic), internal/repository/jobs/jobs.go (buffer override), dashboard/src/proxy.ts (auth boundary).
- Deliberately left standard exported getter docs and domain terms (idempotency, singleflight, outbox) untouched.