### PR TITLE
fix(security): close VERIFY-01/02/06 residuals from AI security review

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,3 +1,7 @@
+# Local-development profile only. Every host-published port binds 127.0.0.1 and
+# services use well-known default credentials — never expose this profile past
+# localhost / your firewall. Production uses compose.prod.yaml with
+# operator-provided secrets (${VAR:?} enforced).
 name: chronoverse
 services:
   postgres:
@@ -8,7 +12,7 @@ services:
       POSTGRES_PASSWORD: chronoverse
       POSTGRES_DB: chronoverse
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     restart: on-failure
     volumes:
       - postgres:/var/lib/postgresql
@@ -43,7 +47,7 @@ services:
       CLICKHOUSE_USER: chronoverse-client
       CLICKHOUSE_PASSWORD: chronoverse
     ports:
-      - "9440:9440"
+      - "127.0.0.1:9440:9440"
     restart: on-failure
     volumes:
       - clickhouse:/var/lib/clickhouse
@@ -71,7 +75,7 @@ services:
     image: redis:8.2.1-alpine
     container_name: redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     restart: on-failure
     volumes:
       - redis:/data
@@ -107,7 +111,7 @@ services:
     image: getmeili/meilisearch:v1.45.2
     container_name: meilisearch
     ports:
-      - "7700:7700"
+      - "127.0.0.1:7700:7700"
     restart: on-failure
     environment:
       MEILI_MASTER_KEY: 35b09c3c7b1001ed1fbed7db29a155d0201ab22d527b41bfba9003da7bb3b404
@@ -144,8 +148,8 @@ services:
     hostname: kafka
     container_name: kafka
     ports:
-      - "9094:9094"
-      - "9093:9093"
+      - "127.0.0.1:9094:9094"
+      - "127.0.0.1:9093:9093"
     restart: on-failure
     environment:
       KAFKA_KRAFT_MODE: "true"
@@ -322,7 +326,7 @@ services:
     volumes:
       - lgtm:/data
     ports:
-      - "4317:4317"
+      - "127.0.0.1:4317:4317"
     networks:
       - chronoverse
 
@@ -844,7 +848,7 @@ services:
         - PRIVATE_KEY_PATH=certs/issuers/users-service/auth.ed
         - PUBLIC_KEY_PATH=certs/issuers/users-service/auth.ed.pub
     ports:
-      - "50051:50051"
+      - "127.0.0.1:50051:50051"
     restart: on-failure
     volumes:
       - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
@@ -933,7 +937,7 @@ services:
         - PRIVATE_KEY_PATH=certs/issuers/workflows-service/auth.ed
         - PUBLIC_KEY_PATH=certs/issuers/workflows-service/auth.ed.pub
     ports:
-      - "50052:50052"
+      - "127.0.0.1:50052:50052"
     restart: on-failure
     volumes:
       - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
@@ -1042,7 +1046,7 @@ services:
         - PRIVATE_KEY_PATH=certs/issuers/jobs-service/auth.ed
         - PUBLIC_KEY_PATH=certs/issuers/jobs-service/auth.ed.pub
     ports:
-      - "50053:50053"
+      - "127.0.0.1:50053:50053"
     restart: on-failure
     volumes:
       - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
@@ -1139,7 +1143,7 @@ services:
         - PRIVATE_KEY_PATH=certs/issuers/notifications-service/auth.ed
         - PUBLIC_KEY_PATH=certs/issuers/notifications-service/auth.ed.pub
     ports:
-      - "50054:50054"
+      - "127.0.0.1:50054:50054"
     restart: on-failure
     volumes:
       - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
@@ -1223,7 +1227,7 @@ services:
         - PRIVATE_KEY_PATH=certs/issuers/analytics-service/auth.ed
         - PUBLIC_KEY_PATH=certs/issuers/analytics-service/auth.ed.pub
     ports:
-      - "50055:50055"
+      - "127.0.0.1:50055:50055"
     restart: on-failure
     volumes:
       - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
@@ -1872,7 +1876,7 @@ services:
         - PRIVATE_KEY_PATH=certs/issuers/server/auth.ed
         - PUBLIC_KEY_PATH=certs/issuers/server/auth.ed.pub
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     restart: on-failure
     volumes:
       - ./certs/ca/ca.crt:/certs/ca/ca.crt:ro
@@ -1929,7 +1933,7 @@ services:
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8080
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3001:3000"
     restart: on-failure
     depends_on:
       server:

--- a/infra/k8s/base/rbac.yaml
+++ b/infra/k8s/base/rbac.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/component: role
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "configmaps", "secrets"]
+  resources: ["pods", "services", "configmaps"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources: ["deployments", "replicasets", "daemonsets"]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,7 @@ type Postgres struct {
 	Host        string        `envconfig:"POSTGRES_HOST" default:"localhost"`
 	Port        int           `envconfig:"POSTGRES_PORT" default:"5432"`
 	User        string        `envconfig:"POSTGRES_USER" default:"postgres"`
-	Password    string        `envconfig:"POSTGRES_PASSWORD" default:"postgres"`
+	Password    string        `envconfig:"POSTGRES_PASSWORD" default:""`
 	Database    string        `envconfig:"POSTGRES_DB" default:"chronoverse"`
 	MaxConns    int32         `envconfig:"POSTGRES_MAX_CONNS" default:"10"`
 	MinConns    int32         `envconfig:"POSTGRES_MIN_CONNS" default:"0"`

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -61,6 +61,12 @@ func validateServerSecrets(cfg *ServerConfig) error {
 	if cfg.Secret == cfg.CSRFHMACSecret {
 		return errors.New("CRYPTO_SECRET and SERVER_CSRF_HMAC_SECRET must be different")
 	}
+	if len(cfg.Secret) != 32 {
+		return errors.New("CRYPTO_SECRET must be 32 bytes long")
+	}
+	if len(cfg.CSRFHMACSecret) < 32 {
+		return errors.New("SERVER_CSRF_HMAC_SECRET must be at least 32 bytes long")
+	}
 
 	return nil
 }

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -33,6 +33,18 @@ func TestValidateServerSecrets(t *testing.T) {
 			crypto: "0123456789abcdef0123456789abcdef",
 			csrf:   "abcdef0123456789abcdef0123456789",
 		},
+		{
+			name:    "crypto secret wrong length",
+			crypto:  "short",
+			csrf:    "abcdef0123456789abcdef0123456789",
+			wantErr: true,
+		},
+		{
+			name:    "csrf secret too short",
+			crypto:  "0123456789abcdef0123456789abcdef",
+			csrf:    "x",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes the actionable residuals from the AI security review (10/11 claims confirmed fixed, 1 partial). Breaking changes acceptable pre-production; each fix is fail-closed and minimal.

## Fixed

- **VERIFY-01 — CSRF HMAC accepted any length (Low).** `validateServerSecrets` (`internal/config/server.go`) only rejected empty/reused secrets, so a 1-char `SERVER_CSRF_HMAC_SECRET` passed. Now fail-fast: `CRYPTO_SECRET` must be exactly 32B (previously only caught later in `crypto.New`), `SERVER_CSRF_HMAC_SECRET` must be ≥32B. Matches `init-env.sh` defaults (32/64 hex chars) and existing fixtures, so nothing valid breaks. Coverage: 2 new table cases in `server_test.go`.
- **VERIFY-02 — `POSTGRES_PASSWORD` defaulted to `"postgres"` (Low).** Direct-binary runs without env silently used a predictable password (`internal/config/config.go`). Default is now `""` (fail-closed); compose prod forces `${VAR:?}` and dev sets it explicitly, verified no Go code/tests depend on the old default.
- **VERIFY-06 (RBAC) — dead `secrets` read on readonly Role.** `infra/k8s/base/rbac.yaml` granted `get/list/watch` on `secrets` to `chronoverse-sa`, which is unmounted (no `serviceAccountName` in `workloads.yaml`) and nothing in-tree uses the k8s API (no client-go). Removed `secrets` from the resource list (pods/services/configmaps only).
- **VERIFY-04 — dev ports were LAN-reachable with default creds (follow-up review).** `compose.dev.yaml` published postgres/redis/clickhouse/meili/kafka/gRPC/API/dashboard on `0.0.0.0` with well-known passwords — not loopback-only as first assumed. All 14 host ports now bind `127.0.0.1` (same pattern as `compose.grafana.yaml`), plus an in-file header documenting the dev-only / never-expose-past-localhost rule. Dev `${VAR:?}` correctly rejected — it would only add run friction; binding is the fix.

## Explicitly deferred (with evidence)

- **VERIFY-03 (ID-only `CancelJob`/`GetJobByID`):** gateway-safe — `internal/server` only calls user-scoped `GetJob`; ID-only methods sit behind the admin-role interceptor (`internal/app/jobs/jobs.go:39-52,191-193`). Adding `user_id` predicates to internal worker paths is speculative; revisit if a gateway route ever exposes them.
- **VERIFY-05 (PENDING→CANCELED):** intended behavior — `terminateWorkflow` explicitly cancels PENDING jobs and `CancelJob` accepts PENDING/QUEUED/RUNNING. No attacker-input trace; nothing to fix.
- **VERIFY-06 (image pins, nginx CIDR):** first-party `:latest` tracks local builds pre-prod — pin digests at first prod deploy. Nginx `10.244.0.0/16` is already flagged DEPLOYMENT-CRITICAL in-file; CIDR is unknowable at commit time.
- **setup.sh short-CSRF reuse gap (follow-up review note):** no action — existing-secret re-validation checks crypto length only, but Go startup now rejects a short CSRF fail-closed, so it cannot run.

## Verification

- `go test -count=1 ./internal/config/...` — pass
- `go build ./internal/config/... ./internal/server/...` + `go vet` — clean
- `sh scripts/compose/validate.sh` — valid (covers loopback edit)
- `gofmt -l internal/config/` — clean