### PR TITLE
fix(security): cap JSON nesting depth, require JSON content-type on decoders

### DIFF
--- a/internal/pkg/idempotency/json.go
+++ b/internal/pkg/idempotency/json.go
@@ -22,10 +22,15 @@ func DecodeUniqueJSON(reader io.Reader, destination any) error {
 	return json.Unmarshal(canonical, destination)
 }
 
+// maxJSONNestingDepth bounds recursion in decodeUniqueValue so a small
+// deeply-nested body cannot exhaust gateway memory. 100 is far beyond any
+// legitimate request or workflow payload shape.
+const maxJSONNestingDepth = 100
+
 func parseUniqueJSON(reader io.Reader) (any, error) {
 	decoder := json.NewDecoder(reader)
 	decoder.UseNumber()
-	value, err := decodeUniqueValue(decoder)
+	value, err := decodeUniqueValue(decoder, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +66,7 @@ func CanonicalJSONObject(raw string) ([]byte, error) {
 	return json.Marshal(value)
 }
 
-func decodeUniqueValue(decoder *json.Decoder) (any, error) {
+func decodeUniqueValue(decoder *json.Decoder, depth int) (any, error) {
 	token, err := decoder.Token()
 	if err != nil {
 		return nil, err
@@ -69,6 +74,9 @@ func decodeUniqueValue(decoder *json.Decoder) (any, error) {
 	delimiter, composite := token.(json.Delim)
 	if !composite {
 		return token, nil
+	}
+	if depth >= maxJSONNestingDepth {
+		return nil, fmt.Errorf("JSON nesting exceeds maximum depth of %d", maxJSONNestingDepth)
 	}
 
 	switch delimiter {
@@ -86,7 +94,7 @@ func decodeUniqueValue(decoder *json.Decoder) (any, error) {
 			if _, duplicate := object[key]; duplicate {
 				return nil, fmt.Errorf("duplicate JSON key %q", key)
 			}
-			value, valueErr := decodeUniqueValue(decoder)
+			value, valueErr := decodeUniqueValue(decoder, depth+1)
 			if valueErr != nil {
 				return nil, valueErr
 			}
@@ -99,7 +107,7 @@ func decodeUniqueValue(decoder *json.Decoder) (any, error) {
 	case '[':
 		array := make([]any, 0)
 		for decoder.More() {
-			value, valueErr := decodeUniqueValue(decoder)
+			value, valueErr := decodeUniqueValue(decoder, depth+1)
 			if valueErr != nil {
 				return nil, valueErr
 			}

--- a/internal/pkg/idempotency/json_test.go
+++ b/internal/pkg/idempotency/json_test.go
@@ -1,6 +1,7 @@
 package idempotency_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hitesh22rana/chronoverse/internal/pkg/idempotency"
@@ -34,5 +35,19 @@ func TestCanonicalJSONObject(t *testing.T) {
 		if _, err = idempotency.CanonicalJSONObject(payload); err == nil {
 			t.Fatalf("non-object payload %s was accepted", payload)
 		}
+	}
+}
+
+func TestCanonicalJSONRejectsDeepNesting(t *testing.T) {
+	t.Parallel()
+
+	deep := strings.Repeat("[", 1000) + strings.Repeat("]", 1000)
+	if _, err := idempotency.CanonicalJSON(deep); err == nil {
+		t.Fatal("deeply nested payload was accepted")
+	}
+
+	shallow := strings.Repeat("[", 10) + strings.Repeat("]", 10)
+	if _, err := idempotency.CanonicalJSON(shallow); err != nil {
+		t.Fatalf("shallow payload was rejected: %v", err)
 	}
 }

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -13,6 +13,7 @@ import (
 
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 	workflowsmodel "github.com/hitesh22rana/chronoverse/internal/model/workflows"
+	"github.com/hitesh22rana/chronoverse/internal/pkg/idempotency"
 	jobspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/jobs"
 )
 
@@ -66,6 +67,17 @@ type userIDKey struct{}
 func idempotencyKeyFromHeader(r *http.Request) (string, bool) {
 	key := r.Header.Get(idempotencyKeyHeader)
 	return key, key != ""
+}
+
+// decodeJSONRequest rejects non-JSON bodies before parsing. Requiring
+// application/json forces a CORS preflight on cross-site browser requests,
+// which the allowlist denies, blocking login CSRF via simple text/plain forms.
+func decodeJSONRequest(r *http.Request, destination any) error {
+	contentType := strings.ToLower(strings.TrimSpace(strings.Split(r.Header.Get("Content-Type"), ";")[0]))
+	if contentType != "application/json" {
+		return status.Error(codes.InvalidArgument, "content-type must be application/json")
+	}
+	return idempotency.DecodeUniqueJSON(r.Body, destination)
 }
 
 // sessionFromContext returns the session from the context.

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -31,6 +31,30 @@ func TestSetCookieDeletesExpiredCookie(t *testing.T) {
 	}
 }
 
+func TestDecodeJSONRequestRequiresJSONContentType(t *testing.T) {
+	newRequest := func(contentType, body string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/auth/login", strings.NewReader(body))
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+		return req
+	}
+
+	var req struct {
+		Email string `json:"email"`
+	}
+
+	if err := decodeJSONRequest(newRequest("text/plain", `{"email":"a@b.c"}`), &req); err == nil {
+		t.Fatal("text/plain body was accepted")
+	}
+	if err := decodeJSONRequest(newRequest("", `{"email":"a@b.c"}`), &req); err == nil {
+		t.Fatal("missing content-type was accepted")
+	}
+	if err := decodeJSONRequest(newRequest("application/json; charset=utf-8", `{"email":"a@b.c"}`), &req); err != nil {
+		t.Fatalf("json content-type was rejected: %v", err)
+	}
+}
+
 func TestSetCookieKeepsPositiveDuration(t *testing.T) {
 	recorder := httptest.NewRecorder()
 

--- a/internal/server/notifications_handlers.go
+++ b/internal/server/notifications_handlers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/hitesh22rana/chronoverse/internal/pkg/idempotency"
 	notificationspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/notifications"
 )
 
@@ -45,7 +44,7 @@ type markNotificationsReadRequest struct {
 
 func (s *Server) handleMarkNotificationsRead(w http.ResponseWriter, r *http.Request) {
 	var req markNotificationsReadRequest
-	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
+	if err := decodeJSONRequest(r, &req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}

--- a/internal/server/users_handlers.go
+++ b/internal/server/users_handlers.go
@@ -8,7 +8,6 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/hitesh22rana/chronoverse/internal/pkg/auth"
-	"github.com/hitesh22rana/chronoverse/internal/pkg/idempotency"
 	userspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/users"
 )
 
@@ -25,7 +24,7 @@ func (s *Server) handleRegisterUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req registerRequest
-	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
+	if err := decodeJSONRequest(r, &req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -77,7 +76,7 @@ type loginRequest struct {
 
 func (s *Server) handleLoginUser(w http.ResponseWriter, r *http.Request) {
 	var req loginRequest
-	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
+	if err := decodeJSONRequest(r, &req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -179,7 +178,7 @@ type updateUserRequest struct {
 
 func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
 	var req updateUserRequest
-	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
+	if err := decodeJSONRequest(r, &req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}

--- a/internal/server/workflows_handlers.go
+++ b/internal/server/workflows_handlers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/hitesh22rana/chronoverse/internal/pkg/idempotency"
 	workflowspb "github.com/hitesh22rana/chronoverse/pkg/proto/go/workflows"
 )
 
@@ -21,7 +20,7 @@ type createWorkflowRequest struct {
 
 func (s *Server) handleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
 	var req createWorkflowRequest
-	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
+	if err := decodeJSONRequest(r, &req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -80,7 +79,7 @@ type updateWorkflowRequest struct {
 
 func (s *Server) handleUpdateWorkflow(w http.ResponseWriter, r *http.Request) {
 	var req updateWorkflowRequest
-	if err := idempotency.DecodeUniqueJSON(r.Body, &req); err != nil {
+	if err := decodeJSONRequest(r, &req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
## Review verdict: agree on both confirmed findings, fixed

I verified and agree with VULN-001 and VULN-002. Both are fixed in this PR. The needs-verification items are intentionally not fixed (reasons below).

### Fixed (needs fix)

1. **VULN-001 Unauthenticated memory exhaustion — High (agree, fixed)**
   - Evidence: `decodeUniqueValue` in `internal/pkg/idempotency/json.go` recursed with no depth limit on every `{`/`[`, reachable pre-auth via `POST /auth/login`. A 1.5M-bracket / 1.5MB body fits the 4MB limit, and unbounded recursion plus per-level slice growth makes the reported 817 MiB peak (vs 512 MiB gateway limit) credible. Go stdlib caps nesting at 10,000; this parser had no cap at all.
   - Fix: `maxJSONNestingDepth = 100` enforced on both array and object recursion in the single shared parser, so all callers (gateway handlers, `CanonicalJSON`/`CanonicalJSONObject`) are covered. 100 is far beyond any legitimate request or workflow-payload shape. Added `TestCanonicalJSONRejectsDeepNesting` (1000-deep rejected, 10-deep accepted).

2. **VULN-002 Login CSRF account substitution — Medium (agree, fixed)**
   - Evidence: login accepted any Content-Type and CORS middleware never blocks disallowed origins (it only withholds CORS headers, which is normal — CORS is not a CSRF boundary). A cross-site `text/plain` simple request therefore reaches `LoginUser` and the response plants the attacker's session cookie in the victim's browser. `SameSite=Strict` does not stop this because no victim session needs to be sent.
   - Fix: new shared `decodeJSONRequest` helper requires `Content-Type: application/json` (charset suffix allowed) before parsing, applied to all 6 JSON-decoding handlers (register, login, update-user, create/update-workflow, mark-notifications-read). Requiring a non-simple content type forces a CORS preflight on cross-site browser requests, which the existing allowlist denies. No separate origin check added: it would duplicate that preflight protection while risking breakage for non-browser API clients.
   - No frontend breakage: dashboard `fetchWithCredentials` (`dashboard/src/lib/api/client.ts`) defaults every request to `application/json`, and login/signup go through it (`dashboard/src/features/auth/use-auth.ts`). Added `TestDecodeJSONRequestRequiresJSONContentType`.

### Not fixed (disagree / out of scope)

- **CSRF double-submit note**: `withVerifyCSRFMiddleware` compares two auto-sent HttpOnly cookies with no header-bound token, so on its own it is not a CSRF barrier — but under the default `SameSite=Strict` cross-site cookie sending is already blocked, and the report confirms no exploit under default config. Reworking CSRF (readable cookie + header check + frontend change) is a larger breaking change with no confirmed exploit; skipping per YAGNI.
- **Dependency advisories (9 Go + 4 npm per app)**: symbol-level matches only, several require absent features (e.g. Next.js Server Actions DoS needs a Server Action). Not confirmed application vulnerabilities; no action.

### Breaking changes

Accepted (no production users): bodies nested deeper than 100 levels are now rejected, and JSON endpoints return 400 unless Content-Type is `application/json`.

### Verification

- `gofmt` clean, `go vet` clean on touched packages.
- `go test ./internal/pkg/idempotency/ ./internal/server/ -count=1` — all pass.

### Follow-up review — agree, no changes needed, ready to merge

Re-verified every claim in the follow-up review against code and CI:

- VULN-001 gate sits in the shared parser (`json.go`) ahead of the `{`/`[` switch and both branches recurse with `depth+1`; `CanonicalJSON`/`CanonicalJSONObject`/`DecodeUniqueJSON` all route through it.
- `decodeJSONRequest` (`helpers.go`) is used by all 6 JSON handlers (register, login, update-user, create/update-workflow, mark-notifications-read); nothing still calls `DecodeUniqueJSON` directly in `internal/server`.
- Dashboard compatibility re-confirmed via `client.ts` + `use-auth.ts`.
- Local `go test` on both packages passes; full CI on this PR is green (build, lint, test, Docker integration, dashboard, static-site, protobuf checks); commit signature valid (`Good`, `G`); PR state `MERGEABLE`/`CLEAN`.

On the `400` vs `415` note: `415` would be more conventional, but the reviewer concedes it does not weaken the fix, and returning a distinct status would need error-kind branching across all 6 handlers for a cosmetic code on an unreleased API with no users. Keeping the uniform `400` — no fix needed.
