### PR TITLE
fix(k8s): make Redis bootstrap and Docker proxy production-safe

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -273,6 +273,12 @@ Kafka auto topic creation is disabled in compose. `init-kafka-topics` creates or
 expands the expected topics: `workflows`, `jobs`, `job_logs`, and `analytics`.
 The Kubernetes overlays include the same topic initializer.
 
+In the production overlay, KEDA scales Kafka consumers by current consumer-group
+lag. `execution-worker` keeps a minimum of four replicas (maximum twelve) so
+the default two-job-per-worker concurrency provides capacity for the Docker
+runtime nodes; the other Kafka consumers retain their overlay-specific floors
+and ceilings. These are lag targets, not time-window or arrival-rate metrics.
+
 ## Domain and Worker Settings
 
 ### Workflows Service

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -335,7 +335,7 @@ PostgreSQL, then heartbeats Docker endpoint health and capacity. In Compose
 there is one runtime named `local-docker` pointing at `tcp://docker-proxy:2376`.
 In Kubernetes, run one agent as a sidecar beside each node-local Docker proxy
 (`DaemonSet` on `chronoverse.io/docker-workloads=true` nodes) and register a
-node-stable endpoint on `NODE_IP:2376` via `hostPort: 2376` — not a pod IP or
+node-stable endpoint on `NODE_IP:2376` via `hostNetwork` — not a pod IP or
 load-balanced `tcp://docker-proxy:2376` `ClusterIP`. The DaemonSet is per-node by design;
 a `ClusterIP` would load-balance to a random backend and break the invariant
 that `ClaimJob` (`internal/repository/jobs/lease.go:254`) selects one `runtime_nodes`
@@ -344,7 +344,7 @@ row and workers later dial its stored `runtime_endpoint` (`internal/repository/e
 binds `:2376 ssl crt /certs/docker-proxy/server.pem ca-file /certs/docker-proxy/ca.crt verify required`
 plus the `X-Chronoverse-Docker-Proxy-Token` header allowlist and an exact
 Docker method/path allowlist before forwarding to the host socket. Runtime-agent
-health probes `tcp://127.0.0.1:2376` (loopback, no `hostPort` needed); the
+health probes `tcp://127.0.0.1:2376` (loopback); the
 advertised endpoint is constructed from
 `RUNTIME_AGENT_DOCKER_ADVERTISE_HOST`/`PORT` with IPv6-safe brackets. Workers
 and the agent use a bounded custom Docker HTTP transport with mTLS
@@ -386,8 +386,8 @@ a smaller blast radius. The workflow role cannot create containers, but its
 log/stop/delete cleanup calls are not tenant-scoped by HAProxy; a compromised
 workflow identity can affect a known container ID on any reachable runtime.
 Per-container authorization requires a purpose-built broker rather than direct
-Docker API access. `hostPort` bypasses `NetworkPolicy`, so restrict TCP `2376`
-at the infrastructure layer (node firewall / security group / CNI host policy).
+Docker API access. `hostNetwork` bypasses pod `NetworkPolicy`, so restrict TCP
+`2376` at the infrastructure layer (node firewall / security group / host policy).
 Multi-node kind and similar Docker-container-based Kubernetes emulators can
 make node host ports reachable only from pods on the same emulator node. In that
 specific topology, use a pod-IP endpoint override as an emulator workaround; do

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -353,6 +353,11 @@ plus the token second factor. The CA bundle and client keypair are reloaded on
 each new TLS handshake so staged certificate rotation does not leave cached
 clients pinned to old files.
 
+The proxy DaemonSet uses `hostNetwork` rather than CNI host-port DNAT. This
+makes the node endpoint reachable across nodes and remains valid when nodes are
+added or replaced; restrict node-to-node TCP 2376 at the infrastructure
+firewall layer.
+
 When mTLS is configured, the shared Docker client also normalizes a legacy
 `tcp://<same-host>:2375` endpoint to
 `tcp://<same-host>:2376`. The exact DNS name, IPv4 address, or bracketed IPv6

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -595,13 +595,15 @@ expected keys. Also verify the atomic Docker proxy set: `docker-proxy-ca`,
   or mismatched material fails closed and workers cannot ping `127.0.0.1:2376`
   or `$(NODE_IP):2376`).
 - Host-network runtime-agent connections to PgBouncer are allowed only from
-  the declared Docker-capable node CIDRs. In production, pass a stable node
-  pool range to setup (for example,
-  `scripts/k8s/setup.sh --mode production --runtime-node-cidrs 10.250.0.0/24`)
+  the declared source CIDRs. Depending on the CNI, host-network traffic may
+  reach pods with a node/WireGuard source or the node's pod CIDR; include both
+  stable ranges in production (for example,
+  `scripts/k8s/setup.sh --mode production --runtime-node-cidrs '10.250.0.0/24 10.42.0.0/16'`)
   so node replacement and scale-out remain covered. The setup script refuses
-  to guess a production range; local mode may snapshot current node addresses.
-  Update the range and rerun setup when the node pool moves to a different
-  network. Never replace this with `0.0.0.0/0`.
+  to guess a production range; local mode may snapshot current node addresses,
+  but pod CIDRs still need to be supplied when the CNI uses them. Update the
+  ranges and rerun setup when the node pool or CNI network changes. Never
+  replace this with `0.0.0.0/0`.
 - The base policy intentionally uses the reserved `192.0.2.1/32` placeholder
   and is fail-closed. If your platform applies Kustomize directly instead of
   using `setup.sh`, keep the CIDR in a private overlay under source control:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -594,6 +594,14 @@ expected keys. Also verify the atomic Docker proxy set: `docker-proxy-ca`,
   `DOCKER_PROXY_TOKEN` (mTLS `verify required` + token second factor — missing
   or mismatched material fails closed and workers cannot ping `127.0.0.1:2376`
   or `$(NODE_IP):2376`).
+- Host-network runtime-agent connections to PgBouncer are allowed only from
+  the declared Docker-capable node CIDRs. In production, pass a stable node
+  pool range to setup (for example,
+  `scripts/k8s/setup.sh --mode production --runtime-node-cidrs 10.250.0.0/24`)
+  so node replacement and scale-out remain covered. The setup script refuses
+  to guess a production range; local mode may snapshot current node addresses.
+  Update the range and rerun setup when the node pool moves to a different
+  network. Never replace this with `0.0.0.0/0`.
 - In kind, recreate the cluster with
   `infra/k8s/overlays/local/kind-cluster.yaml` if `docker-proxy` reports
   `/var/run/docker.sock is not a socket file`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -586,8 +586,10 @@ expected keys. Also verify the atomic Docker proxy set: `docker-proxy-ca`,
   generated or operator-provided Secrets match the target cluster.
 - Confirm Docker-capable nodes expose Docker Engine at `/var/run/docker.sock`
   and have the `chronoverse.io/docker-workloads=true` label.
-- Confirm workers can reach runtime node IPs on TCP `2376` (`hostPort` bypasses
-  `NetworkPolicy` — restrict `2376` at infra layer); the proxy requires
+- Confirm workers can reach runtime node IPs on TCP `2376`. The Docker proxy
+  uses `hostNetwork` so CNI host-port DNAT and pod NetworkPolicy do not break
+  cross-node access; restrict node-to-node TCP `2376` at the infrastructure
+  firewall layer. The proxy still requires
   `docker-proxy-ca`/`server`/`client-*` Secrets plus `docker-proxy-auth`
   `DOCKER_PROXY_TOKEN` (mTLS `verify required` + token second factor — missing
   or mismatched material fails closed and workers cannot ping `127.0.0.1:2376`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -602,6 +602,15 @@ expected keys. Also verify the atomic Docker proxy set: `docker-proxy-ca`,
   to guess a production range; local mode may snapshot current node addresses.
   Update the range and rerun setup when the node pool moves to a different
   network. Never replace this with `0.0.0.0/0`.
+- The base policy intentionally uses the reserved `192.0.2.1/32` placeholder
+  and is fail-closed. If your platform applies Kustomize directly instead of
+  using `setup.sh`, keep the CIDR in a private overlay under source control:
+  add a JSON6902 patch targeting
+  `NetworkPolicy/chronoverse-runtime-agent-postgres` that replaces
+  `/spec/ingress/0/from` with `podSelector: {}` plus one `ipBlock` per stable
+  Docker-node CIDR. Apply that same overlay on every run; do not edit the
+  generated base or run setup without the matching `--runtime-node-cidrs`, or
+  the generated patch will be replaced on the next apply.
 - In kind, recreate the cluster with
   `infra/k8s/overlays/local/kind-cluster.yaml` if `docker-proxy` reports
   `/var/run/docker.sock is not a socket file`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -103,19 +103,19 @@ for Docker-backed workers because its node does not expose Docker Engine at
 cluster whose nodes really provide that socket.
 
 The `docker-proxy` DaemonSet runs one `runtime-agent` sidecar per labeled
-Docker-capable node. Official overlays construct an IPv4/IPv6-safe node endpoint on `2376` via
-`hostPort:2376` so running job cleanup survives proxy pod restarts on the same
-node. Health probes use `tcp://127.0.0.1:2376` (loopback) while the advertised
+Docker-capable node. Official overlays use `hostNetwork` and construct an
+IPv4/IPv6-safe node endpoint on `2376`, so running job cleanup survives proxy
+pod restarts on the same node and cross-node workers avoid CNI host-port DNAT.
+Health probes use `tcp://127.0.0.1:2376` (loopback) while the advertised
 endpoint remains node-stable. The proxy binds
 `:2376 ssl crt /certs/docker-proxy/server.pem ca-file /certs/docker-proxy/ca.crt verify required`
 plus the `X-Chronoverse-Docker-Proxy-Token` and exact certificate-role and
 method/path ACLs. Runtime-agent receives health APIs only, workflow-worker gets
 image and cancellation-cleanup calls, and execution-worker gets the execution
 surface. The server and each role use separate private-key mounts; workload
-containers receive neither token nor certificate. Multi-node kind and other Docker-container-based Kubernetes emulators
-can have a specific hostPort routing limitation where pods on one emulator node
-cannot reach another emulator node's host port; if you choose that topology,
-use a pod-IP endpoint override as an emulator-only workaround.
+containers receive neither token nor certificate. Multi-node kind and other
+Docker-container-based Kubernetes emulators can have topology-specific routing
+limitations; use a pod-IP endpoint override only for emulator-only validation.
 `workflow-worker` and `execution-worker` do not need the Docker node label;
 they can schedule anywhere with network access to TCP `2376` on registered
 runtime endpoints.
@@ -150,7 +150,7 @@ This requires an existing deployment. The standalone
 `scripts/k8s/rotate-docker-proxy-certs.sh --context <context>` command skips the
 manifest apply. Both rotate the three clients before the server and remove the
 old CA only after all identities trust the replacement. Run in a maintenance
-window; a single-node hostPort DaemonSet briefly interrupts Docker calls while
+window; a single-node host-networked DaemonSet briefly interrupts Docker calls while
 its pod restarts.
 
 Compose rotation requires a stopped stack because it replaces the dedicated

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -611,6 +611,10 @@ expected keys. Also verify the atomic Docker proxy set: `docker-proxy-ca`,
   Docker-node CIDR. Apply that same overlay on every run; do not edit the
   generated base or run setup without the matching `--runtime-node-cidrs`, or
   the generated patch will be replaced on the next apply.
+- The same declared node CIDRs are applied to
+  `NetworkPolicy/chronoverse-runtime-agent-telemetry`, allowing only TCP 4317
+  into LGTM for runtime-agent OTLP telemetry. Direct overlays must patch both
+  policies; do not broaden LGTM ingress to all sources.
 - In kind, recreate the cluster with
   `infra/k8s/overlays/local/kind-cluster.yaml` if `docker-proxy` reports
   `/var/run/docker.sock is not a socket file`.

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -118,7 +118,7 @@ setup path is:
 
 ```sh
 scripts/k8s/setup.sh --mode production --context <context> \
-  --runtime-node-cidrs <stable-node-pool-cidr>
+  --runtime-node-cidrs '<stable-node-pool-cidr> <stable-pod-cidr>'
 ```
 
 ## gRPC Service Discovery

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -272,8 +272,9 @@ Docker-capable node runs one `docker-proxy` DaemonSet pod with a `runtime-agent`
 sidecar. Workers do not need the Docker node label and can schedule anywhere.
 
 Official overlays register an IPv4/IPv6-safe `NODE_IP:2376` endpoint through
-the Docker proxy `hostPort`, not a load-balanced ClusterIP. This keeps running job cleanup valid
-across proxy pod restarts on the same node. The DaemonSet's HAProxy binds
+the Docker proxy `hostNetwork`, not a load-balanced ClusterIP. This keeps
+running job cleanup valid across proxy pod restarts on the same node. The
+DaemonSet's HAProxy binds
 `:2376 ssl crt /certs/docker-proxy/server.pem ca-file /certs/docker-proxy/ca.crt verify required`
 plus the `X-Chronoverse-Docker-Proxy-Token` header and an exact Docker
 method/path allowlist; runtime-agent health probes `tcp://127.0.0.1:2376`
@@ -293,15 +294,14 @@ key readability or expose another role's private key. TLS clients reload the CA
 bundle and keypair on new handshakes, and endpoint clients are bounded to 256
 entries with idle/LRU eviction to avoid unbounded growth as runtime nodes churn.
 
-Multi-node kind and similar Docker-container-based Kubernetes emulators may not
-route one emulator node's hostPort from pods on another emulator node. If you
-choose that topology, use a pod-IP runtime endpoint override as an
-emulator-specific workaround. Real single-node and multi-node Kubernetes
-clusters should use node-stable runtime endpoints.
+Multi-node kind and similar Docker-container-based Kubernetes emulators may
+still have topology-specific routing limitations. Use a pod-IP runtime endpoint
+override only for emulator-specific validation. Real single-node and multi-node
+Kubernetes clusters should use node-stable runtime endpoints.
 
 Worker pods need egress to TCP `2376` on runtime node IPs. The base
-NetworkPolicy allows that port, but `hostPort` bypasses `NetworkPolicy` across
-CNI implementations — production must restrict `2376` at the infrastructure
+NetworkPolicy allows that port, but `hostNetwork` bypasses pod NetworkPolicy —
+production must restrict `2376` at the infrastructure
 layer (node firewall / security group / CNI host policy) in addition to the
 mTLS + token + allowlist. Do not expose `2376` publicly.
 
@@ -313,7 +313,7 @@ The supported runtime matrix is explicit:
 | Kubernetes single-node | Supported when the node exposes `/var/run/docker.sock` and carries the Docker workload label. |
 | Kubernetes multi-node | Supported when every labeled runtime node exposes Docker Engine and worker pods can route to every labeled node IP on `2376`. |
 | containerd-only Kubernetes or Docker Desktop's built-in Kubernetes | Not supported for Docker-backed workflows because the required Docker Engine socket is absent. |
-| Multi-node kind-like emulators | Conditional: some emulator networks cannot route cross-node hostPorts; validate first or use the documented pod-IP override only for that emulator. |
+| Multi-node kind-like emulators | Conditional: validate emulator routing first; use the documented pod-IP override only for that emulator. |
 
 The execution-worker role can create containers and is therefore
 node-root-equivalent if both that role key and token are compromised. mTLS
@@ -338,7 +338,7 @@ The rotation script installs an old+new CA bundle, rolls the DaemonSet, rotates
 the three client-role Secrets, rotates the server Secret, then removes the old
 CA and rolls all proxy clients again. This order works for single-node and
 multi-node clusters without a mixed-issuer authentication gap. A single-node
-DaemonSet still has a brief proxy interruption while its hostPort pod restarts.
+DaemonSet still has a brief proxy interruption while its host-networked pod restarts.
 Use `scripts/k8s/rotate-docker-proxy-certs.sh --context <context>` directly when
 the manifests do not need to be reapplied. Setup rejects rotation with
 `--dry-run`/`--skip-apply` and requires an existing proxy and worker deployment.

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -108,11 +108,13 @@ kubectl apply -k infra/k8s/overlays/production
 ```
 
 Because host-network runtime agents may reach PgBouncer as node IPs, direct
-production applies must also carry the private JSON6902 patch described in
-`docs/operations.md`, replacing the reserved TEST-NET entry in
-`NetworkPolicy/chronoverse-runtime-agent-postgres` with the stable Docker-node
-CIDR(s). Keep that patch in the operator overlay and apply it every time; the
-base placeholder is intentionally fail-closed. The supported setup path is:
+production applies must also carry the private JSON6902 patches described in
+`docs/operations.md`, replacing the reserved TEST-NET entry in both
+`NetworkPolicy/chronoverse-runtime-agent-postgres` and
+`NetworkPolicy/chronoverse-runtime-agent-telemetry` with the stable
+Docker-node CIDR(s). Keep those patches in the operator overlay and apply them
+every time; the base placeholders are intentionally fail-closed. The supported
+setup path is:
 
 ```sh
 scripts/k8s/setup.sh --mode production --context <context> \

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -107,6 +107,18 @@ kubectl apply -k infra/k8s/overlays/local
 kubectl apply -k infra/k8s/overlays/production
 ```
 
+Because host-network runtime agents may reach PgBouncer as node IPs, direct
+production applies must also carry the private JSON6902 patch described in
+`docs/operations.md`, replacing the reserved TEST-NET entry in
+`NetworkPolicy/chronoverse-runtime-agent-postgres` with the stable Docker-node
+CIDR(s). Keep that patch in the operator overlay and apply it every time; the
+base placeholder is intentionally fail-closed. The supported setup path is:
+
+```sh
+scripts/k8s/setup.sh --mode production --context <context> \
+  --runtime-node-cidrs <stable-node-pool-cidr>
+```
+
 ## gRPC Service Discovery
 
 The users, workflows, jobs, notifications, and analytics Services are headless.

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -138,6 +138,11 @@ Desktop's built-in `docker-desktop` Kubernetes context is not sufficient for the
 Docker-backed worker path because it does not expose a Docker Engine socket to
 pods.
 
+Workers reach node-local Docker proxies on TCP `2376`. The proxy DaemonSet uses
+`hostNetwork`, so newly labeled nodes work automatically without a node-CIDR
+snapshot or a generated NetworkPolicy. Restrict node-to-node TCP `2376` at the
+infrastructure firewall layer.
+
 For kind validation:
 
 ```sh

--- a/infra/k8s/base/docker-proxy.yaml
+++ b/infra/k8s/base/docker-proxy.yaml
@@ -120,6 +120,8 @@ spec:
               - key: chronoverse.io/docker-workloads
                 operator: In
                 values: ["true"]
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: docker-proxy
         image: haproxy:3.4-alpine
@@ -132,7 +134,6 @@ spec:
         ports:
         - name: docker
           containerPort: 2376
-          hostPort: 2376
           protocol: TCP
         env:
         - name: DOCKER_PROXY_TOKEN

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - configmaps.yaml
 - rbac.yaml
 - network-policy.yaml
+- runtime-agent-postgres-network-policy.yaml
 - docker-proxy.yaml
 - services.yaml
 - workloads.yaml

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - rbac.yaml
 - network-policy.yaml
 - runtime-agent-postgres-network-policy.yaml
+- runtime-agent-telemetry-network-policy.yaml
 - docker-proxy.yaml
 - services.yaml
 - workloads.yaml

--- a/infra/k8s/base/runtime-agent-postgres-network-policy.yaml
+++ b/infra/k8s/base/runtime-agent-postgres-network-policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: chronoverse-runtime-agent-postgres
+  labels:
+    app.kubernetes.io/name: chronoverse-runtime-agent-postgres
+    app.kubernetes.io/part-of: chronoverse
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: pgbouncer
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    # setup.sh replaces this with the cluster's node CIDRs. The reserved
+    # TEST-NET value keeps direct kustomize builds closed by default.
+    - ipBlock:
+        cidr: 192.0.2.1/32
+    ports:
+    - protocol: TCP
+      port: 5432

--- a/infra/k8s/base/runtime-agent-telemetry-network-policy.yaml
+++ b/infra/k8s/base/runtime-agent-telemetry-network-policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: chronoverse-runtime-agent-telemetry
+  labels:
+    app.kubernetes.io/name: chronoverse-runtime-agent-telemetry
+    app.kubernetes.io/part-of: chronoverse
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: lgtm
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    # setup.sh replaces this with the cluster's node CIDRs. The reserved
+    # TEST-NET value keeps direct kustomize builds closed by default.
+    - ipBlock:
+        cidr: 192.0.2.1/32
+    ports:
+    - protocol: TCP
+      port: 4317

--- a/infra/k8s/overlays/production/kustomization.yaml
+++ b/infra/k8s/overlays/production/kustomization.yaml
@@ -1266,7 +1266,7 @@ patches:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
-            add: ["CHOWN", "FOWNER"]
+            add: ["CHOWN", "FOWNER", "DAC_OVERRIDE"]
         resources:
           requests:
             cpu: 25m

--- a/infra/k8s/overlays/production/kustomization.yaml
+++ b/infra/k8s/overlays/production/kustomization.yaml
@@ -1249,10 +1249,17 @@ patches:
             echo waiting for redis certificates
             sleep 2
           done
-          cp -R /source-certs/. /certs/
+          # Copy only certificate files; never copy Kubernetes projected-volume symlinks.
+          rm -rf /certs/ca /certs/redis /certs/clients
+          mkdir -p /certs/ca /certs/redis /certs/clients
+          cp /source-certs/ca/ca.crt /certs/ca/ca.crt
+          cp /source-certs/redis/redis.crt /certs/redis/redis.crt
+          cp /source-certs/redis/redis.key /certs/redis/redis.key
+          cp /source-certs/clients/client.crt /certs/clients/client.crt
+          cp /source-certs/clients/client.key /certs/clients/client.key
           chown -R 999:999 /certs
-          find /certs -type d -exec chmod 0750 {} \;
-          find /certs -type f -exec chmod 0640 {} \;
+          find /certs -type d -exec chmod 0750 {} +
+          find /certs -type f -exec chmod 0640 {} +
         securityContext:
           runAsUser: 0
           runAsGroup: 0

--- a/infra/k8s/overlays/production/kustomization.yaml
+++ b/infra/k8s/overlays/production/kustomization.yaml
@@ -70,7 +70,7 @@ patches:
   patch: |-
     - op: replace
       path: /spec/minReplicaCount
-      value: 2
+      value: 4
     - op: replace
       path: /spec/maxReplicaCount
       value: 12

--- a/scripts/k8s/setup.sh
+++ b/scripts/k8s/setup.sh
@@ -10,6 +10,7 @@ SKIP_APPLY=false
 CREATE_KIND=false
 STORAGE_CLASS=""
 REALIP_CIDRS=""
+RUNTIME_NODE_CIDRS="${RUNTIME_NODE_CIDRS:-}"
 ALLOW_REALIP_SNAPSHOT=false
 ROTATE_DOCKER_PROXY_CERTS=false
 INGRESS_NGINX_AVAILABLE=false
@@ -33,6 +34,11 @@ Options:
                                  static clusters; scalable production should use
                                  --realip-cidrs with the cluster's pod range
                                  (e.g. --cluster-cidr) so new nodes remain trusted.
+  --runtime-node-cidrs <list>   Node CIDRs allowed to reach PgBouncer from the
+                                 host-network runtime-agent (comma/space separated).
+                                 Defaults to the current node InternalIPs as /32
+                                 (/128 for IPv6); pass a stable node CIDR for
+                                 production scale-out.
   --create-kind                 Create the local kind cluster before applying local.
   --rotate-docker-proxy-certs  After a successful apply, rotate the existing
                                 Docker proxy PKI with overlapping CA trust.
@@ -104,6 +110,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --realip-cidrs)
       REALIP_CIDRS="${2:-}"
+      shift 2
+      ;;
+    --runtime-node-cidrs)
+      RUNTIME_NODE_CIDRS="${2:-}"
       shift 2
       ;;
     --allow-realip-snapshot)
@@ -978,6 +988,41 @@ if [ "$MODE" = "production" ]; then
 fi
 create_docker_proxy_tls_secrets
 
+# Host-network runtime-agent traffic is seen as node traffic by some CNIs.
+# Keep PgBouncer closed to arbitrary sources and allow only the nodes that can
+# run the Docker proxy. Production requires a stable operator-supplied node
+# CIDR so node replacement/scale-out remains covered; local mode may use a
+# current-node snapshot for convenience.
+append_runtime_node_prefix() {
+  case "$1" in
+    *:*) echo "$1/128" ;;
+    *)   echo "$1/32" ;;
+  esac
+}
+if [ -z "$RUNTIME_NODE_CIDRS" ]; then
+  if [ "$MODE" = "production" ]; then
+    die "production requires --runtime-node-cidrs with the stable node-pool CIDR(s) used by host-network runtime-agent"
+  fi
+  if ! RUNTIME_NODE_IPS="$(kubectl_cmd get nodes -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | sort -u)"; then
+    RUNTIME_NODE_IPS=""
+  fi
+  if [ -z "$RUNTIME_NODE_IPS" ]; then
+    die "cannot determine node InternalIPs for host-network runtime-agent PostgreSQL access — pass --runtime-node-cidrs <list>"
+  fi
+  RUNTIME_NODE_CIDRS="$(for ip in $RUNTIME_NODE_IPS; do append_runtime_node_prefix "$ip"; done | tr '\n' ' ' | sed 's/ $//')"
+  warn "PgBouncer host-network access uses a current-node CIDR snapshot ($RUNTIME_NODE_CIDRS); pass --runtime-node-cidrs with a stable node range for scale-out"
+else
+  RUNTIME_NODE_CIDRS="$(echo "$RUNTIME_NODE_CIDRS" | tr ',' ' ' | tr -s ' ' | sed 's/^ //; s/ $//')"
+  for cidr in $RUNTIME_NODE_CIDRS; do
+    case "$cidr" in
+      *[!0-9A-Fa-f:./]*) die "invalid runtime node CIDR: $cidr" ;;
+      */*) ;;
+      *) die "runtime node entries must be CIDRs (for example 10.0.0.0/16): $cidr" ;;
+    esac
+  done
+  info "Using operator-provided runtime-agent node CIDRs: $RUNTIME_NODE_CIDRS"
+fi
+
 if [ "$SKIP_APPLY" = true ]; then
   info "Skipping manifest apply"
   exit 0
@@ -1106,7 +1151,7 @@ EOF
 fi
 
 USE_PATCH_DIR=false
-if [ -n "$STORAGE_CLASS" ] || [ -n "$REALIP_CIDRS" ]; then
+if [ -n "$STORAGE_CLASS" ] || [ -n "$REALIP_CIDRS" ] || [ -n "$RUNTIME_NODE_CIDRS" ]; then
   USE_PATCH_DIR=true
   PATCH_DIR="$(mktemp -d "$ROOT_DIR/.k8s-setup.XXXXXX")"
   mkdir -p "$PATCH_DIR"
@@ -1131,6 +1176,16 @@ EOF
     if [ -n "$REALIP_CIDRS" ]; then
       echo "- path: nginx-realip-patch.yaml"
     fi
+    if [ -n "$RUNTIME_NODE_CIDRS" ]; then
+      cat <<'EOF'
+- target:
+    group: networking.k8s.io
+    version: v1
+    kind: NetworkPolicy
+    name: chronoverse-runtime-agent-postgres
+  path: runtime-agent-postgres-network-policy-patch.yaml
+EOF
+    fi
   } > "$PATCH_DIR/kustomization.yaml"
   if [ -n "$REALIP_CIDRS" ]; then
     {
@@ -1147,6 +1202,20 @@ EOF
       echo "    real_ip_header X-Forwarded-For;"
       echo "    real_ip_recursive on;"
     } > "$PATCH_DIR/nginx-realip-patch.yaml"
+  fi
+  if [ -n "$RUNTIME_NODE_CIDRS" ]; then
+    {
+      cat <<'EOF'
+- op: replace
+  path: /spec/ingress/0/from
+  value:
+  - podSelector: {}
+EOF
+      for cidr in $RUNTIME_NODE_CIDRS; do
+        echo "  - ipBlock:"
+        echo "      cidr: $cidr"
+      done
+    } > "$PATCH_DIR/runtime-agent-postgres-network-policy-patch.yaml"
   fi
   KUSTOMIZE_DIR="$PATCH_DIR"
 fi

--- a/scripts/k8s/setup.sh
+++ b/scripts/k8s/setup.sh
@@ -1000,7 +1000,7 @@ append_runtime_node_prefix() {
   esac
 }
 validate_runtime_cidr() {
-  local cidr="$1" address prefix octet group compressed
+  local cidr="$1" address prefix octet group compressed nonempty
   case "$cidr" in
     */*) ;;
     *) die "runtime node entries must be CIDRs (for example 10.0.0.0/16): $cidr" ;;
@@ -1015,15 +1015,23 @@ validate_runtime_cidr() {
     *:*)
       [ "$prefix" -le 128 ] || die "invalid IPv6 runtime node CIDR: $cidr"
       case "$address" in *[!0-9A-Fa-f:]*|'') die "invalid IPv6 runtime node CIDR: $cidr" ;; esac
+      case "$address" in *:::*) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac
       compressed=false
       case "$address" in *::* ) compressed=true ;; esac
-      case "$address" in *::*::* ) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac
+      case "${address/::/}" in *::* ) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac
       IFS=: read -r -a group_array <<< "$address"
       local group_count="${#group_array[@]}"
       if [ "$compressed" = true ]; then
-        [ "$group_count" -lt 8 ] || die "invalid IPv6 runtime node CIDR: $cidr"
+        nonempty=0
+        for group in "${group_array[@]}"; do
+          [ -n "$group" ] && nonempty=$((nonempty + 1))
+        done
+        [ "$nonempty" -le 7 ] || die "invalid IPv6 runtime node CIDR: $cidr"
       else
         [ "$group_count" -eq 8 ] || die "invalid IPv6 runtime node CIDR: $cidr"
+        for group in "${group_array[@]}"; do
+          [ -n "$group" ] || die "invalid IPv6 runtime node CIDR: $cidr"
+        done
       fi
       for group in "${group_array[@]}"; do
         [ -z "$group" ] && continue
@@ -1032,6 +1040,7 @@ validate_runtime_cidr() {
       ;;
     *)
       [ "$prefix" -le 32 ] || die "invalid IPv4 runtime node CIDR: $cidr"
+      case "$address" in .*|*.|*..*) die "invalid IPv4 runtime node CIDR: $cidr" ;; esac
       local octets=()
       IFS=. read -r -a octets <<< "$address"
       [ "${#octets[@]}" -eq 4 ] || die "invalid IPv4 runtime node CIDR: $cidr"
@@ -1043,7 +1052,7 @@ validate_runtime_cidr() {
   esac
 }
 
-RUNTIME_NODE_CIDRS="$(echo "$RUNTIME_NODE_CIDRS" | tr ',' ' ' | tr -s ' ' | sed 's/^ //; s/ $//')"
+RUNTIME_NODE_CIDRS="$(echo "$RUNTIME_NODE_CIDRS" | tr ',[:space:]' ' ' | tr -s ' ' | sed 's/^ //; s/ $//')"
 if [ -z "$RUNTIME_NODE_CIDRS" ]; then
   if [ "$MODE" = "production" ]; then
     die "production requires --runtime-node-cidrs with the stable node-pool CIDR(s) used by host-network runtime-agent"

--- a/scripts/k8s/setup.sh
+++ b/scripts/k8s/setup.sh
@@ -34,11 +34,13 @@ Options:
                                  static clusters; scalable production should use
                                  --realip-cidrs with the cluster's pod range
                                  (e.g. --cluster-cidr) so new nodes remain trusted.
-  --runtime-node-cidrs <list>   Node CIDRs allowed to reach PgBouncer from the
-                                 host-network runtime-agent (comma/space separated).
-                                 Defaults to the current node InternalIPs as /32
-                                 (/128 for IPv6); pass a stable node CIDR for
-                                 production scale-out.
+  --runtime-node-cidrs <list>   Source CIDRs allowed to reach PgBouncer and LGTM
+                                 from host-network runtime-agent traffic
+                                 (comma/space separated). Include node and CNI
+                                 pod CIDRs; pass stable ranges for scale-out.
+                                 Local mode defaults to current node InternalIPs
+                                 as /32 (/128 for IPv6), but pod CIDRs still
+                                 need to be supplied when the CNI uses them.
   --create-kind                 Create the local kind cluster before applying local.
   --rotate-docker-proxy-certs  After a successful apply, rotate the existing
                                 Docker proxy PKI with overlapping CA trust.

--- a/scripts/k8s/setup.sh
+++ b/scripts/k8s/setup.sh
@@ -1018,6 +1018,8 @@ validate_runtime_cidr() {
       case "$address" in *:::*) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac
       case "$address" in
         :*) case "$address" in ::*) ;; *) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac ;;
+      esac
+      case "$address" in
         *:) case "$address" in *::) ;; *) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac ;;
       esac
       compressed=false

--- a/scripts/k8s/setup.sh
+++ b/scripts/k8s/setup.sh
@@ -1239,6 +1239,12 @@ EOF
     kind: NetworkPolicy
     name: chronoverse-runtime-agent-postgres
   path: runtime-agent-postgres-network-policy-patch.yaml
+- target:
+    group: networking.k8s.io
+    version: v1
+    kind: NetworkPolicy
+    name: chronoverse-runtime-agent-telemetry
+  path: runtime-agent-telemetry-network-policy-patch.yaml
 EOF
     fi
   } > "$PATCH_DIR/kustomization.yaml"
@@ -1271,6 +1277,8 @@ EOF
         echo "      cidr: $cidr"
       done
     } > "$PATCH_DIR/runtime-agent-postgres-network-policy-patch.yaml"
+    cp "$PATCH_DIR/runtime-agent-postgres-network-policy-patch.yaml" \
+      "$PATCH_DIR/runtime-agent-telemetry-network-policy-patch.yaml"
   fi
   KUSTOMIZE_DIR="$PATCH_DIR"
 fi

--- a/scripts/k8s/setup.sh
+++ b/scripts/k8s/setup.sh
@@ -988,6 +988,13 @@ if [ "$MODE" = "production" ]; then
 fi
 create_docker_proxy_tls_secrets
 
+# Prerequisite-only runs do not render or apply the runtime-agent policies, so
+# they must not require deployment-time node CIDR configuration.
+if [ "$SKIP_APPLY" = true ]; then
+  info "Skipping manifest apply"
+  exit 0
+fi
+
 # Host-network runtime-agent traffic is seen as node traffic by some CNIs.
 # Keep PgBouncer closed to arbitrary sources and allow only the nodes that can
 # run the Docker proxy. Production requires a stable operator-supplied node
@@ -1076,11 +1083,6 @@ else
     validate_runtime_cidr "$cidr"
   done
   info "Using operator-provided runtime-agent node CIDRs: $RUNTIME_NODE_CIDRS"
-fi
-
-if [ "$SKIP_APPLY" = true ]; then
-  info "Skipping manifest apply"
-  exit 0
 fi
 
 # Detect the cluster's node pod CIDRs so the nginx ingress can recover real

--- a/scripts/k8s/setup.sh
+++ b/scripts/k8s/setup.sh
@@ -999,6 +999,51 @@ append_runtime_node_prefix() {
     *)   echo "$1/32" ;;
   esac
 }
+validate_runtime_cidr() {
+  local cidr="$1" address prefix octet group compressed
+  case "$cidr" in
+    */*) ;;
+    *) die "runtime node entries must be CIDRs (for example 10.0.0.0/16): $cidr" ;;
+  esac
+  address="${cidr%/*}"
+  prefix="${cidr##*/}"
+  case "$prefix" in
+    ''|*[!0-9]*) die "invalid runtime node CIDR prefix: $cidr" ;;
+  esac
+  [ "$prefix" -gt 0 ] || die "runtime node CIDR must not be /0: $cidr"
+  case "$address" in
+    *:*)
+      [ "$prefix" -le 128 ] || die "invalid IPv6 runtime node CIDR: $cidr"
+      case "$address" in *[!0-9A-Fa-f:]*|'') die "invalid IPv6 runtime node CIDR: $cidr" ;; esac
+      compressed=false
+      case "$address" in *::* ) compressed=true ;; esac
+      case "$address" in *::*::* ) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac
+      IFS=: read -r -a group_array <<< "$address"
+      local group_count="${#group_array[@]}"
+      if [ "$compressed" = true ]; then
+        [ "$group_count" -lt 8 ] || die "invalid IPv6 runtime node CIDR: $cidr"
+      else
+        [ "$group_count" -eq 8 ] || die "invalid IPv6 runtime node CIDR: $cidr"
+      fi
+      for group in "${group_array[@]}"; do
+        [ -z "$group" ] && continue
+        [ "${#group}" -le 4 ] || die "invalid IPv6 runtime node CIDR: $cidr"
+      done
+      ;;
+    *)
+      [ "$prefix" -le 32 ] || die "invalid IPv4 runtime node CIDR: $cidr"
+      local octets=()
+      IFS=. read -r -a octets <<< "$address"
+      [ "${#octets[@]}" -eq 4 ] || die "invalid IPv4 runtime node CIDR: $cidr"
+      for octet in "${octets[@]}"; do
+        case "$octet" in ''|*[!0-9]*) die "invalid IPv4 runtime node CIDR: $cidr" ;; esac
+        [ "$octet" -le 255 ] || die "invalid IPv4 runtime node CIDR: $cidr"
+      done
+      ;;
+  esac
+}
+
+RUNTIME_NODE_CIDRS="$(echo "$RUNTIME_NODE_CIDRS" | tr ',' ' ' | tr -s ' ' | sed 's/^ //; s/ $//')"
 if [ -z "$RUNTIME_NODE_CIDRS" ]; then
   if [ "$MODE" = "production" ]; then
     die "production requires --runtime-node-cidrs with the stable node-pool CIDR(s) used by host-network runtime-agent"
@@ -1012,13 +1057,8 @@ if [ -z "$RUNTIME_NODE_CIDRS" ]; then
   RUNTIME_NODE_CIDRS="$(for ip in $RUNTIME_NODE_IPS; do append_runtime_node_prefix "$ip"; done | tr '\n' ' ' | sed 's/ $//')"
   warn "PgBouncer host-network access uses a current-node CIDR snapshot ($RUNTIME_NODE_CIDRS); pass --runtime-node-cidrs with a stable node range for scale-out"
 else
-  RUNTIME_NODE_CIDRS="$(echo "$RUNTIME_NODE_CIDRS" | tr ',' ' ' | tr -s ' ' | sed 's/^ //; s/ $//')"
   for cidr in $RUNTIME_NODE_CIDRS; do
-    case "$cidr" in
-      *[!0-9A-Fa-f:./]*) die "invalid runtime node CIDR: $cidr" ;;
-      */*) ;;
-      *) die "runtime node entries must be CIDRs (for example 10.0.0.0/16): $cidr" ;;
-    esac
+    validate_runtime_cidr "$cidr"
   done
   info "Using operator-provided runtime-agent node CIDRs: $RUNTIME_NODE_CIDRS"
 fi

--- a/scripts/k8s/setup.sh
+++ b/scripts/k8s/setup.sh
@@ -1016,6 +1016,10 @@ validate_runtime_cidr() {
       [ "$prefix" -le 128 ] || die "invalid IPv6 runtime node CIDR: $cidr"
       case "$address" in *[!0-9A-Fa-f:]*|'') die "invalid IPv6 runtime node CIDR: $cidr" ;; esac
       case "$address" in *:::*) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac
+      case "$address" in
+        :*) case "$address" in ::*) ;; *) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac ;;
+        *:) case "$address" in *::) ;; *) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac ;;
+      esac
       compressed=false
       case "$address" in *::* ) compressed=true ;; esac
       case "${address/::/}" in *::* ) die "invalid IPv6 runtime node CIDR: $cidr" ;; esac


### PR DESCRIPTION
## Summary
- make Redis certificate staging safe when the init container retries or a pod sandbox is recreated
- make the Docker proxy reachable across nodes without CNI host-port DNAT
- preserve runtime-agent PostgreSQL access when host-network traffic is classified as node traffic
- strictly validate runtime node CIDRs before applying the PgBouncer policy
- raise the production execution-worker KEDA floor from 2 to 4 replicas
- document node-firewall, runtime-agent node-CIDR, direct-apply, dynamic-node, and execution-worker capacity requirements

## Root causes and fixes
Redis bootstrap previously copied an entire projected Secret volume, including Kubernetes `..data` metadata and stale files. Retries could fail and files owned by Redis UID 999 could not be cleared. The init path now copies only the required certificate files and safely handles stale ownership.

Cross-node workers were reaching the Docker proxy through host-port DNAT, then `chronoverse-default` rejected the forwarded traffic. The proxy DaemonSet now uses `hostNetwork` and no `hostPort`, so each node advertises its own TCP 2376 endpoint directly. This automatically works when labeled nodes are added or replaced. mTLS, the token second factor, and HAProxy method/path ACLs remain fail-closed; infrastructure firewall rules must restrict node-to-node TCP 2376.

Because host-network runtime-agent traffic can be seen as node traffic by enforcing CNIs, the base includes a dedicated PgBouncer ingress policy. `setup.sh` replaces its closed TEST-NET placeholder with only the declared Docker-capable node CIDRs. Production requires a stable operator-supplied `--runtime-node-cidrs` range so node replacement and scale-out remain covered; local mode may snapshot current node addresses. Empty, whitespace-only, malformed IPv4/IPv6 (including boundary-colon errors), out-of-range, and `/0` CIDRs are rejected. Direct Kustomize users must keep the equivalent JSON6902 CIDR patch in their private overlay; the base remains fail-closed by design.

Production execution workers now keep four minimum replicas, matching the observed Docker execution capacity and the configured concurrency of two per worker. Kafka lag remains the scaling signal; time-window/rate-based scaling was intentionally deferred.

## Verification
- live rollout completed successfully on both nodes before this policy hardening
- workflow-worker and execution-worker reached both node endpoints on TCP 2376
- production and local Kustomize overlays render successfully
- base and generated CIDR-policy Kustomize renders validated
- validator regression cases: malformed boundary IPv6, valid compressed IPv6, malformed IPv4, invalid prefix, whitespace-only input, and `/0`
- `bash -n scripts/k8s/setup.sh`
- `git diff --check`
- signed commits pushed to this branch

No production users or workflows were active during the live validation.

Latest validator hardening: IPv6 leading and trailing boundary checks are evaluated independently, rejecting forms such as ::1:/64 and ::1:2:3:/64 while retaining valid ::-compressed addresses.

Latest networking hardening: host-network runtime-agent OTLP traffic now has a separate TCP 4317 ingress policy for LGTM, using the same validated node CIDRs as PgBouncer. Direct overlays must patch both policies.

Review disposition: the proposed local-overlay PostgreSQL selector change is not applicable. Rendered local configuration sets POSTGRES_HOST=postgres, and Service/postgres selects PgBouncer; postgres-primary is a separate direct backend used for bootstrap/migrations. The existing host-network exception therefore targets the correct endpoint. No manifest change was made, avoiding an unsafe PgBouncer bypass and extra direct PostgreSQL connections.

Clarification on the local-selector review: NetworkPolicy selectors authorize ingress to selected pods; they do not reroute Service traffic. Local Service/postgres selects PgBouncer for runtime-agent traffic, while Service/postgres-primary selects PostgreSQL for bootstrap/migrations. No selector change is required.

Latest setup fix: prerequisite-only production runs with --skip-apply now exit before deployment-time runtime-node CIDR validation. Normal apply and dry-run paths still require and render the validated CIDR policy.

Live lab verification found one deployment-specific source detail: the k8s-server host-network runtime-agent reached the remote LGTM pod with source 10.42.1.0 (the Flannel pod CIDR), not only 10.250.0.1. Supplying both stable node/WireGuard and CNI pod CIDRs fixed TCP 4317 telemetry. Setup and documentation now describe --runtime-node-cidrs as source CIDRs covering both ranges.