### PR TITLE
fix(grpc): re-resolve DNS so scaled backends join rotation

### DIFF
--- a/internal/pkg/grpc/client/client.go
+++ b/internal/pkg/grpc/client/client.go
@@ -153,8 +153,6 @@ func NewClient(svcCfg *ServiceConfig, cbCfg *CircuitBreakerConfig, retryCfg *Ret
 		grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)),
 	)
 
-	ensureDNSPollRegistered()
-
 	// Connect to the service
 	conn, err := grpc.NewClient(
 		buildDialTarget(svcCfg.Host, svcCfg.Port),

--- a/internal/pkg/grpc/client/client.go
+++ b/internal/pkg/grpc/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"os"
 	"time"
 
@@ -154,9 +153,11 @@ func NewClient(svcCfg *ServiceConfig, cbCfg *CircuitBreakerConfig, retryCfg *Ret
 		grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)),
 	)
 
+	ensureDNSPollRegistered()
+
 	// Connect to the service
 	conn, err := grpc.NewClient(
-		fmt.Sprintf("%s:%d", svcCfg.Host, svcCfg.Port),
+		buildDialTarget(svcCfg.Host, svcCfg.Port),
 		opts...,
 	)
 	if err != nil {

--- a/internal/pkg/grpc/client/client_test.go
+++ b/internal/pkg/grpc/client/client_test.go
@@ -1,0 +1,158 @@
+package client_test
+
+import (
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+
+	grpcclient "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/client"
+)
+
+func TestNewClient_NormalizesDialTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{"k8s fully-qualified", "dns:///users-service.chronoverse.svc", "dns-poll:///users-service.chronoverse.svc:50051"},
+		{"short dns scheme", "dns://users-service", "dns-poll:///users-service:50051"},
+		{"bare compose hostname", "users-service", "dns-poll:///users-service:50051"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			conn, err := grpcclient.NewClient(
+				&grpcclient.ServiceConfig{Host: tt.host, Port: 50051, TLS: &grpcclient.TLSConfig{}},
+				nil,
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+			defer conn.Close()
+
+			if got := conn.Target(); got != tt.want {
+				t.Errorf("conn.Target() = %q, want %q", got, tt.want)
+			}
+			if resolver.Get("dns-poll") == nil {
+				t.Error(`resolver.Get("dns-poll") = nil, want registered builder`)
+			}
+		})
+	}
+}
+
+// stubClientConn records resolver updates without opening connections.
+type stubClientConn struct {
+	mu     sync.Mutex
+	states []resolver.State
+}
+
+func (s *stubClientConn) UpdateState(st resolver.State) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.states = append(s.states, st)
+	return nil
+}
+
+func (s *stubClientConn) ReportError(error) {}
+
+func (s *stubClientConn) NewAddress([]resolver.Address) {}
+
+func (s *stubClientConn) ParseServiceConfig(string) *serviceconfig.ParseResult { return nil }
+
+func (s *stubClientConn) addressCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, st := range s.states {
+		n += len(st.Addresses)
+	}
+	return n
+}
+
+// TestDNSPollBuilder_ResolvesAddresses guards the dial-target shape: the host
+// must land in the URL path slot, otherwise gRPC resolves an empty endpoint
+// and the channel ends up with zero addresses (every RPC fails fast).
+func TestDNSPollBuilder_ResolvesAddresses(t *testing.T) {
+	t.Parallel()
+
+	conn, err := grpcclient.NewClient(
+		&grpcclient.ServiceConfig{Host: "localhost", Port: 50051, TLS: &grpcclient.TLSConfig{}},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer conn.Close()
+
+	b := resolver.Get("dns-poll")
+	if b == nil {
+		t.Fatal(`resolver.Get("dns-poll") = nil, want registered builder`)
+	}
+
+	targetURL, err := url.Parse("dns-poll:///localhost:50051")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	cc := &stubClientConn{}
+	r, err := b.Build(resolver.Target{URL: *targetURL}, cc, resolver.BuildOptions{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	defer r.Close()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for cc.addressCount() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for resolver addresses, want at least one for localhost")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestDNSPollBuilder_AuthoritySlotYieldsNoAddresses(t *testing.T) {
+	t.Parallel()
+
+	conn, err := grpcclient.NewClient(
+		&grpcclient.ServiceConfig{Host: "localhost", Port: 50051, TLS: &grpcclient.TLSConfig{}},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer conn.Close()
+
+	b := resolver.Get("dns-poll")
+	if b == nil {
+		t.Fatal(`resolver.Get("dns-poll") = nil, want registered builder`)
+	}
+
+	// Host in the authority slot leaves the endpoint empty, which can never
+	// resolve. Accept either a build error or zero addresses: both mean the
+	// channel would serve every RPC from an empty picker.
+	badURL, err := url.Parse("dns-poll://localhost:50051")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	cc := &stubClientConn{}
+	r, err := b.Build(resolver.Target{URL: *badURL}, cc, resolver.BuildOptions{})
+	if err != nil {
+		return
+	}
+	defer r.Close()
+
+	time.Sleep(time.Second)
+	if n := cc.addressCount(); n != 0 {
+		t.Errorf("addressCount() = %d, want 0 for authority-slot target", n)
+	}
+}

--- a/internal/pkg/grpc/client/client_test.go
+++ b/internal/pkg/grpc/client/client_test.go
@@ -15,6 +15,10 @@ import (
 func TestNewClient_NormalizesDialTarget(t *testing.T) {
 	t.Parallel()
 
+	if resolver.Get("dns-poll") == nil {
+		t.Fatal(`resolver.Get("dns-poll") = nil, want registered builder`)
+	}
+
 	tests := []struct {
 		name string
 		host string
@@ -42,23 +46,20 @@ func TestNewClient_NormalizesDialTarget(t *testing.T) {
 			if got := conn.Target(); got != tt.want {
 				t.Errorf("conn.Target() = %q, want %q", got, tt.want)
 			}
-			if resolver.Get("dns-poll") == nil {
-				t.Error(`resolver.Get("dns-poll") = nil, want registered builder`)
-			}
 		})
 	}
 }
 
 // stubClientConn records resolver updates without opening connections.
 type stubClientConn struct {
-	mu     sync.Mutex
-	states []resolver.State
+	mu    sync.Mutex
+	addrs int
 }
 
 func (s *stubClientConn) UpdateState(st resolver.State) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.states = append(s.states, st)
+	s.addrs += len(st.Addresses)
 	return nil
 }
 
@@ -71,11 +72,30 @@ func (s *stubClientConn) ParseServiceConfig(string) *serviceconfig.ParseResult {
 func (s *stubClientConn) addressCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	n := 0
-	for _, st := range s.states {
-		n += len(st.Addresses)
+	return s.addrs
+}
+
+// buildTestResolver builds a dns-poll resolver for rawurl against a stub.
+// Registration needs no client: init() runs on package import.
+func buildTestResolver(t *testing.T, rawurl string) (*stubClientConn, error) {
+	t.Helper()
+
+	b := resolver.Get("dns-poll")
+	if b == nil {
+		t.Fatal(`resolver.Get("dns-poll") = nil, want registered builder`)
 	}
-	return n
+
+	targetURL, err := url.Parse(rawurl)
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	cc := &stubClientConn{}
+	r, err := b.Build(resolver.Target{URL: *targetURL}, cc, resolver.BuildOptions{})
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(r.Close)
+	return cc, nil
 }
 
 // TestDNSPollBuilder_ResolvesAddresses guards the dial-target shape: the host
@@ -84,31 +104,10 @@ func (s *stubClientConn) addressCount() int {
 func TestDNSPollBuilder_ResolvesAddresses(t *testing.T) {
 	t.Parallel()
 
-	conn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{Host: "localhost", Port: 50051, TLS: &grpcclient.TLSConfig{}},
-		nil,
-		nil,
-	)
-	if err != nil {
-		t.Fatalf("NewClient() error = %v", err)
-	}
-	defer conn.Close()
-
-	b := resolver.Get("dns-poll")
-	if b == nil {
-		t.Fatal(`resolver.Get("dns-poll") = nil, want registered builder`)
-	}
-
-	targetURL, err := url.Parse("dns-poll:///localhost:50051")
-	if err != nil {
-		t.Fatalf("url.Parse() error = %v", err)
-	}
-	cc := &stubClientConn{}
-	r, err := b.Build(resolver.Target{URL: *targetURL}, cc, resolver.BuildOptions{})
+	cc, err := buildTestResolver(t, "dns-poll:///localhost:50051")
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
 	}
-	defer r.Close()
 
 	deadline := time.Now().Add(10 * time.Second)
 	for cc.addressCount() == 0 {
@@ -122,34 +121,13 @@ func TestDNSPollBuilder_ResolvesAddresses(t *testing.T) {
 func TestDNSPollBuilder_AuthoritySlotYieldsNoAddresses(t *testing.T) {
 	t.Parallel()
 
-	conn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{Host: "localhost", Port: 50051, TLS: &grpcclient.TLSConfig{}},
-		nil,
-		nil,
-	)
-	if err != nil {
-		t.Fatalf("NewClient() error = %v", err)
-	}
-	defer conn.Close()
-
-	b := resolver.Get("dns-poll")
-	if b == nil {
-		t.Fatal(`resolver.Get("dns-poll") = nil, want registered builder`)
-	}
-
 	// Host in the authority slot leaves the endpoint empty, which can never
 	// resolve. Accept either a build error or zero addresses: both mean the
 	// channel would serve every RPC from an empty picker.
-	badURL, err := url.Parse("dns-poll://localhost:50051")
-	if err != nil {
-		t.Fatalf("url.Parse() error = %v", err)
-	}
-	cc := &stubClientConn{}
-	r, err := b.Build(resolver.Target{URL: *badURL}, cc, resolver.BuildOptions{})
+	cc, err := buildTestResolver(t, "dns-poll://localhost:50051")
 	if err != nil {
 		return
 	}
-	defer r.Close()
 
 	time.Sleep(time.Second)
 	if n := cc.addressCount(); n != 0 {

--- a/internal/pkg/grpc/client/dns.go
+++ b/internal/pkg/grpc/client/dns.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/resolver"
+	grpcDNS "google.golang.org/grpc/resolver/dns"
+)
+
+// dnsPollScheme is a drop-in wrapper around the stock "dns" resolver that
+// re-resolves on a timer. Stock dns only re-resolves on ResolveNow, which
+// fires on connection failures, so with healthy long-lived connections a
+// client keeps its dial-time membership forever and scaled-up pods stay
+// invisible (and idle) until a restart. The timer bounds that skew to one
+// interval.
+const dnsPollScheme = "dns-poll"
+
+const (
+	dnsPollInterval          = 15 * time.Second
+	dnsMinResolutionInterval = 10 * time.Second
+)
+
+var registerDNSPollOnce sync.Once
+
+// ensureDNSPollRegistered registers the polling DNS resolver once: the
+// registry panics on duplicates and every process dials several services.
+// It also lowers the re-resolution floor, otherwise the 15s tick is
+// throttled by the 30s stock default.
+func ensureDNSPollRegistered() {
+	registerDNSPollOnce.Do(func() {
+		grpcDNS.SetMinResolutionInterval(dnsMinResolutionInterval)
+		resolver.Register(dnsPollBuilder{})
+	})
+}
+
+type dnsPollBuilder struct{}
+
+func (dnsPollBuilder) Scheme() string { return dnsPollScheme }
+
+func (dnsPollBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	target.URL.Scheme = "dns"
+	r, err := resolver.Get("dns").Build(target, cc, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, stop := context.WithCancel(context.Background())
+	pr := &dnsPollResolver{Resolver: r, stop: stop}
+	go pollResolveNow(ctx, r)
+	return pr, nil
+}
+
+type dnsPollResolver struct {
+	resolver.Resolver
+	stop context.CancelFunc
+}
+
+func (r *dnsPollResolver) Close() {
+	r.stop()
+	r.Resolver.Close()
+}
+
+// pollResolveNow forces DNS re-resolution on every tick until ctx is done.
+func pollResolveNow(ctx context.Context, r resolver.Resolver) {
+	t := time.NewTicker(dnsPollInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.ResolveNow(resolver.ResolveNowOptions{})
+		}
+	}
+}
+
+// buildDialTarget normalizes service host config into a dns-poll target.
+// Host arrives as "dns:///svc.ns.svc" on Kubernetes and as a bare "svc" on
+// compose, so strip any scheme and always dial through dns-poll. The triple
+// slash matters: gRPC resolves the endpoint from the URL path, so the host
+// must sit in the path slot ("dns-poll:///host:port"), not the authority
+// slot ("dns-poll://host:port", which resolves to an empty endpoint and
+// leaves the channel with zero addresses).
+func buildDialTarget(host string, port int) string {
+	host = strings.TrimPrefix(strings.TrimPrefix(host, "dns:///"), "dns://")
+	return fmt.Sprintf("%s:///%s:%d", dnsPollScheme, host, port)
+}

--- a/internal/pkg/grpc/client/dns.go
+++ b/internal/pkg/grpc/client/dns.go
@@ -47,9 +47,8 @@ func (dnsPollBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts
 	}
 
 	ctx, stop := context.WithCancel(context.Background())
-	pr := &dnsPollResolver{Resolver: r, stop: stop}
 	go pollResolveNow(ctx, r)
-	return pr, nil
+	return &dnsPollResolver{Resolver: r, stop: stop}, nil
 }
 
 type dnsPollResolver struct {

--- a/internal/pkg/grpc/client/dns.go
+++ b/internal/pkg/grpc/client/dns.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"google.golang.org/grpc/resolver"
@@ -24,17 +23,15 @@ const (
 	dnsMinResolutionInterval = 10 * time.Second
 )
 
-var registerDNSPollOnce sync.Once
-
-// ensureDNSPollRegistered registers the polling DNS resolver once: the
-// registry panics on duplicates and every process dials several services.
+// init registers the polling resolver before main: both calls mutate
+// process-wide, non-thread-safe gRPC globals (bare-map registry,
+// watcher-read interval), so a lazy sync.Once at first dial is too late —
+// it cannot serialize against OTEL exporter or future handler-path dials.
 // It also lowers the re-resolution floor, otherwise the 15s tick is
 // throttled by the 30s stock default.
-func ensureDNSPollRegistered() {
-	registerDNSPollOnce.Do(func() {
-		grpcDNS.SetMinResolutionInterval(dnsMinResolutionInterval)
-		resolver.Register(dnsPollBuilder{})
-	})
+func init() {
+	grpcDNS.SetMinResolutionInterval(dnsMinResolutionInterval)
+	resolver.Register(dnsPollBuilder{})
 }
 
 type dnsPollBuilder struct{}

--- a/internal/pkg/grpc/client/dns.go
+++ b/internal/pkg/grpc/client/dns.go
@@ -38,6 +38,7 @@ type dnsPollBuilder struct{}
 
 func (dnsPollBuilder) Scheme() string { return dnsPollScheme }
 
+//nolint:hugeParam // Signature fixed by grpc resolver.Builder interface.
 func (dnsPollBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	target.URL.Scheme = "dns"
 	r, err := resolver.Get("dns").Build(target, cc, opts)

--- a/internal/pkg/grpc/client/dns.go
+++ b/internal/pkg/grpc/client/dns.go
@@ -38,7 +38,7 @@ type dnsPollBuilder struct{}
 
 func (dnsPollBuilder) Scheme() string { return dnsPollScheme }
 
-//nolint:hugeParam // Signature fixed by grpc resolver.Builder interface.
+//nolint:gocritic // Build signature fixed by grpc resolver.Builder interface.
 func (dnsPollBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	target.URL.Scheme = "dns"
 	r, err := resolver.Get("dns").Build(target, cc, opts)


### PR DESCRIPTION
Stock grpc-go DNS only re-resolves on connection failure, so healthy long-lived clients keep dial-time membership forever: after HPA scale-up, new backend pods stay idle while old pods saturate (observed 17x CPU skew, perfectly age-ordered, on analytics-service during load test).

- Add a dns-poll resolver wrapper that ticks ResolveNow every 15s (re-resolution floor 30s to 10s) and normalize all dial targets through dns-poll:/// so k8s and compose host forms converge.
- Register both process-wide gRPC globals at init time: resolver.Register writes a bare map and SetMinResolutionInterval is watcher-read, both init-only and not thread-safe (review P2).
- Regression tests pin the triple-slash target shape and assert the builder yields addresses (authority-slot targets stay unresolvable).

Verified in the multi-node lab: same flood now spreads 58-106m across all 10 backend pods (<2x) instead of 14-240m; login/users/workflows/analytics all 200.