### PR TITLE
fix(compose): replace static production Kafka TLS passwords

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,8 @@ MEILI_MASTER_KEY=
 CRYPTO_SECRET=
 SERVER_CSRF_HMAC_SECRET=
 GF_SECURITY_ADMIN_PASSWORD=
+
+# Generate each Kafka password with openssl rand -hex 32 (minimum 32 hex characters).
+# The private-key password is the keystore password (PKCS12 requirement).
+KAFKA_SSL_KEYSTORE_PASSWORD=
+KAFKA_SSL_TRUSTSTORE_PASSWORD=

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -280,13 +280,14 @@ services:
         replication_factor="$${KAFKA_TOPIC_REPLICATION_FACTOR:-1}"
         client_config="/tmp/kafka-client.properties"
 
-        cat > "$$client_config" <<'PROPERTIES'
+        umask 077
+        cat > "$$client_config" <<PROPERTIES
         security.protocol=SSL
         ssl.truststore.location=/etc/kafka/secrets/kafka.truststore.jks
-        ssl.truststore.password=chronoverse
+        ssl.truststore.password=$$(cat /etc/kafka/secrets/truststore_creds.txt)
         ssl.keystore.location=/etc/kafka/secrets/kafka.keystore.jks
-        ssl.keystore.password=chronoverse
-        ssl.key.password=chronoverse
+        ssl.keystore.password=$$(cat /etc/kafka/secrets/keystore_creds.txt)
+        ssl.key.password=$$(cat /etc/kafka/secrets/key_creds.txt)
         PROPERTIES
 
         kafka_topics() {
@@ -473,12 +474,22 @@ services:
   init-certs:
     image: alpine:3.22.2
     container_name: init-certs
+    environment:
+      KAFKA_SSL_KEYSTORE_PASSWORD: ${KAFKA_SSL_KEYSTORE_PASSWORD:?Set KAFKA_SSL_KEYSTORE_PASSWORD}
+      KAFKA_SSL_TRUSTSTORE_PASSWORD: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:?Set KAFKA_SSL_TRUSTSTORE_PASSWORD}
     volumes:
       - ./certs:/certs:rw
       - ./docker-proxy-certs:/docker-proxy-certs:rw
       - ./scripts/compose/init-docker-proxy-certs.sh:/usr/local/bin/init-docker-proxy-certs:ro
     entrypoint: |
-      sh -c '
+      sh -ec '
+        # Hex passwords work unchanged in Java properties and Confluent credential files.
+        for password in "$$KAFKA_SSL_KEYSTORE_PASSWORD" "$$KAFKA_SSL_TRUSTSTORE_PASSWORD"; do
+          case "$$password" in
+            *[!0-9a-fA-F]*|"") echo "Kafka TLS passwords must be hexadecimal" >&2; exit 1 ;;
+          esac
+          [ "$${#password}" -ge 32 ] || { echo "Kafka TLS passwords need at least 32 hex characters" >&2; exit 1; }
+        done
         AUTH_ISSUERS="server users-service workflows-service jobs-service notifications-service analytics-service scheduling-worker workflow-worker execution-worker runtime-agent joblogs-processor analytics-processor outbox-relay"
         echo "🔐 Generating per-issuer Ed25519 keys..."
         apk add --no-cache openssl >/dev/null 2>&1 || (apk update && apk add --no-cache openssl)
@@ -555,6 +566,9 @@ services:
           fi
         done
 
+        # Rebuild derived stores so reruns and password changes do not reuse old passwords.
+        rm -f /certs/kafka/kafka.keystore.new.jks /certs/kafka/kafka.truststore.new.jks
+
         # Convert Kafka PEM to PKCS12
         echo "🔄 Converting Kafka PEM to PKCS12..."
         openssl pkcs12 -export \
@@ -563,25 +577,28 @@ services:
           -certfile /certs/ca/ca.crt \
           -out /certs/kafka/kafka.p12 \
           -name kafka \
-          -password pass:chronoverse
+          -password env:KAFKA_SSL_KEYSTORE_PASSWORD
 
         # Import PKCS12 to JKS keystore
         echo "🔄 Importing PKCS12 to JKS keystore..."
         keytool -importkeystore \
-          -deststorepass chronoverse \
-          -destkeypass chronoverse \
-          -destkeystore /certs/kafka/kafka.keystore.jks \
+          -deststorepass:env KAFKA_SSL_KEYSTORE_PASSWORD \
+          -destkeypass:env KAFKA_SSL_KEYSTORE_PASSWORD \
+          -destkeystore /certs/kafka/kafka.keystore.new.jks \
           -srckeystore /certs/kafka/kafka.p12 \
           -srcstoretype PKCS12 \
-          -srcstorepass chronoverse \
+          -srcstorepass:env KAFKA_SSL_KEYSTORE_PASSWORD \
           -alias kafka
 
         # Create Kafka truststore
         echo "🔄 Creating Kafka truststore..."
         keytool -import -trustcacerts -alias CARoot \
           -file /certs/ca/ca.crt \
-          -keystore /certs/kafka/kafka.truststore.jks \
-          -storepass chronoverse -noprompt
+          -keystore /certs/kafka/kafka.truststore.new.jks \
+          -storepass:env KAFKA_SSL_TRUSTSTORE_PASSWORD -noprompt
+
+        mv -f /certs/kafka/kafka.keystore.new.jks /certs/kafka/kafka.keystore.jks
+        mv -f /certs/kafka/kafka.truststore.new.jks /certs/kafka/kafka.truststore.jks
 
         # PKCS12 bundle holds the private key in transportable form; the JKS
         # keystore above is the only runtime consumer, so remove it.
@@ -624,9 +641,9 @@ services:
         chmod 440 /certs/kafka/kafka.key /certs/kafka/kafka.keystore.jks /certs/kafka/kafka.truststore.jks
 
         echo "🔐 Creating Kafka keystore credentials files..."
-        echo "chronoverse" > /certs/kafka/keystore_creds.txt
-        echo "chronoverse" > /certs/kafka/truststore_creds.txt
-        echo "chronoverse" > /certs/kafka/key_creds.txt
+        echo "$$KAFKA_SSL_KEYSTORE_PASSWORD" > /certs/kafka/keystore_creds.txt
+        echo "$$KAFKA_SSL_TRUSTSTORE_PASSWORD" > /certs/kafka/truststore_creds.txt
+        echo "$$KAFKA_SSL_KEYSTORE_PASSWORD" > /certs/kafka/key_creds.txt
         chown 1000:1000 /certs/kafka/*_creds.txt
         chmod 440 /certs/kafka/*_creds.txt
 

--- a/scripts/compose/validate.sh
+++ b/scripts/compose/validate.sh
@@ -28,7 +28,9 @@ render_compose() {
   output_file=$2
 
   if [ "$compose_file" = "compose.prod.yaml" ]; then
-    POSTGRES_PASSWORD=compose-validation \
+    KAFKA_SSL_KEYSTORE_PASSWORD=0123456789abcdef0123456789abcdef \
+      KAFKA_SSL_TRUSTSTORE_PASSWORD=abcdef0123456789abcdef0123456789 \
+      POSTGRES_PASSWORD=compose-validation \
       CLICKHOUSE_PASSWORD=compose-validation \
       MEILI_MASTER_KEY=compose-validation \
       CRYPTO_SECRET=0123456789abcdef0123456789abcdef \
@@ -178,6 +180,28 @@ validate_env_init() {
 validate_env_init
 validate_compose compose.dev.yaml
 validate_compose compose.prod.yaml
+
+# Exercise the production password guard before any certificate files are touched.
+prod_json="$tmp_dir/compose.prod.yaml.json"
+jq -r '.services["init-certs"].entrypoint[2]' "$prod_json" | sed 's/\$\$/$/g; /AUTH_ISSUERS=/,$d' > "$tmp_dir/kafka-password-guard.sh"
+for bad_password in '' chronoverse 0123456789abcdef0123456789abcdefZ; do
+  for bad_variable in KAFKA_SSL_KEYSTORE_PASSWORD KAFKA_SSL_TRUSTSTORE_PASSWORD; do
+    if env KAFKA_SSL_KEYSTORE_PASSWORD=0123456789abcdef0123456789abcdef \
+      KAFKA_SSL_TRUSTSTORE_PASSWORD=abcdef0123456789abcdef0123456789 \
+      "$bad_variable=$bad_password" sh -e "$tmp_dir/kafka-password-guard.sh" >/dev/null 2>&1; then
+      echo "production Kafka accepted an invalid $bad_variable" >&2
+      exit 1
+    fi
+  done
+done
+KAFKA_SSL_KEYSTORE_PASSWORD=0123456789abcdef0123456789abcdef \
+  KAFKA_SSL_TRUSTSTORE_PASSWORD=abcdef0123456789abcdef0123456789 \
+  sh -e "$tmp_dir/kafka-password-guard.sh"
+jq -e '
+  .services["init-certs"].environment.KAFKA_SSL_KEYSTORE_PASSWORD == "0123456789abcdef0123456789abcdef"
+  and .services["init-certs"].environment.KAFKA_SSL_TRUSTSTORE_PASSWORD == "abcdef0123456789abcdef0123456789"
+  and (.services["init-kafka-topics"].entrypoint[2] | contains("cat /etc/kafka/secrets/keystore_creds.txt") and contains("cat /etc/kafka/secrets/truststore_creds.txt") and contains("cat /etc/kafka/secrets/key_creds.txt"))
+' "$prod_json" >/dev/null
 
 validate_auth_bundle() {
   # Per-issuer JWT keys must be wired through build args, Compose init-certs, and K8s volumes.


### PR DESCRIPTION
Production Compose used the public `chronoverse` password for Kafka store generation, broker credential files, and the topic initializer. Require operator-provided `KAFKA_SSL_KEYSTORE_PASSWORD` and `KAFKA_SSL_TRUSTSTORE_PASSWORD`, rebuild derived stores on bootstrap, and have the topic initializer read the same credential files as the broker. The key password equals the keystore password, as required by the generated PKCS12 store.

Before production startup, set both new variables using `openssl rand -hex 32`. Bootstrap rejects non-hex passwords and values shorter than 32 characters before touching certificates. This intentionally changes the preproduction configuration contract.

### Review disposition and evidence

Only VERIFY-003 requires a change. This is a configuration weakness, not evidence of a remotely exploitable Kafka vulnerability.

- VERIFY-001: no demonstrated filter injection or cross-tenant leak. A two-tenant probe against the pinned Meilisearch v1.45.2 returned only the owner document for the valid filter, and no documents or parser errors for slash, backslash, quote, trailing-backslash, newline, and quote/backslash-plus-OR job-ID payloads. This was a direct engine probe, not a complete API integration test. `SearchJobLogs` checks workflow ownership first (`internal/repository/jobs/jobs.go`, `GetWorkflow` call), includes the user/workflow/job predicates in the filter, and waits for a separate tenant-scoped PostgreSQL job lookup before returning. `GetWorkflow` scopes both ID and user ID in `internal/repository/workflows/workflows.go`; database IDs are UUIDs. Workflow cleanup consumes workflow records in `internal/repository/workflow/workflow.go`, rather than directly using an unchecked HTTP path. Go quoting is not a general-purpose Meilisearch string serializer, but the reported security failure was not reproduced. Reference: https://specs.meilisearch.dev/specifications/text/0118-search-api.html
- VERIFY-002: every checked-in dev host port binds to 127.0.0.1; `git ls-files .env` returns nothing, and the only tracked file beneath `certs/` is `.gitkeep`. No evidence of shared local secrets was found. This verifies the repository configuration, not historical port forwarding or secret sharing. Given no production deployment, there is no basis for mandatory rotation.
- VERIFY-003: confirmed the constant password across bootstrap, JKS/PKCS12 generation, credential files and topic initialization. All affected production paths are updated together; changing the topic properties alone would have broken authentication.

### Validation

- `sh scripts/compose/validate.sh` passed, including new executable invalid-password checks for both variables and credential wiring checks. Existing Linux UID readability checks are skipped on this macOS host; file mode checks passed.
- Actual OpenSSL/keytool smoke test using the rendered production generation commands: initial generation, rerun with a changed password, opening both stores with the configured passwords, rejecting `chronoverse`, and removal of the intermediate PKCS12 file all passed.
- Rendered topic-initializer commands produced the matching credential-file passwords and a mode-0600 client properties file.
- Compose rejects each missing/empty required Kafka password.
- `git diff --check` passed. Both commits are signed and verified.

The scope is the three supplied verification items, not a new certification of every cleared claim in the original repository-wide review. CI is triggered by the push/PR and is not being monitored.
