### PR TITLE
perf(notifications): speed up ListNotifications pagination

### DIFF
--- a/internal/config/notifications_service.go
+++ b/internal/config/notifications_service.go
@@ -16,7 +16,7 @@ type NotificationsConfig struct {
 
 // NotificationsServiceConfig holds the configuration for the notifications service.
 type NotificationsServiceConfig struct {
-	FetchLimit int `envconfig:"NOTIFICATIONS_SERVICE_CONFIG_FETCH_LIMIT" default:"1000"`
+	FetchLimit int `envconfig:"NOTIFICATIONS_SERVICE_CONFIG_FETCH_LIMIT" default:"100"`
 }
 
 // InitNotificationsServiceConfig initializes the notifications service configuration.

--- a/internal/pkg/postgres/migrations/000013_notifications_unread_kind_created_index.down.sql
+++ b/internal/pkg/postgres/migrations/000013_notifications_unread_kind_created_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_notifications_user_unread_kind_created_desc;

--- a/internal/pkg/postgres/migrations/000013_notifications_unread_kind_created_index.up.sql
+++ b/internal/pkg/postgres/migrations/000013_notifications_unread_kind_created_index.up.sql
@@ -1,0 +1,10 @@
+-- Covers the ListNotifications hot path:
+-- WHERE user_id = $1 AND read_at IS NULL AND kind = $2
+-- ORDER BY created_at DESC, id DESC LIMIT N.
+-- Equality on (user_id, kind) with in-order (created_at, id) avoids a
+-- filter + sort over all unread notifications for the default ALERTS
+-- preference. ALL-preference queries (no kind predicate) keep using
+-- idx_notifications_user_read_created_at_desc.
+CREATE INDEX IF NOT EXISTS idx_notifications_user_unread_kind_created_desc
+ON notifications (user_id, kind, created_at DESC, id DESC)
+WHERE read_at IS NULL;

--- a/internal/repository/notifications/notifications.go
+++ b/internal/repository/notifications/notifications.go
@@ -335,6 +335,19 @@ func (r *Repository) mapNotificationReadDatabaseError(err error, operation strin
 	return status.Errorf(codes.Internal, "failed to %s: %v", operation, err)
 }
 
+func (r *Repository) mapListNotificationsDatabaseError(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return status.Error(codes.DeadlineExceeded, err.Error())
+	}
+	if errors.Is(err, context.Canceled) {
+		return status.Error(codes.Canceled, err.Error())
+	}
+	if r.pg.IsInvalidTextRepresentation(err) {
+		return status.Errorf(codes.InvalidArgument, "invalid user ID or cursor: %v", err)
+	}
+	return status.Errorf(codes.Internal, "failed to list all notifications: %v", err)
+}
+
 // ListNotifications returns notifications by user ID.
 // By default, it only returns the unread notifications.
 func (r *Repository) ListNotifications(ctx context.Context, userID, cursor string) (res *notificationsmodel.ListNotificationsResponse, err error) {
@@ -413,29 +426,14 @@ func (r *Repository) ListNotifications(ctx context.Context, userID, cursor strin
 	query += fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT %d;`, r.cfg.FetchLimit+1)
 
 	rows, err := r.pg.Query(ctx, query, args...)
-	if errors.Is(err, context.DeadlineExceeded) {
-		err = status.Error(codes.DeadlineExceeded, err.Error())
-		return nil, err
-	} else if errors.Is(err, context.Canceled) {
-		err = status.Error(codes.Canceled, err.Error())
-		return nil, err
-	} else if err != nil {
-		if r.pg.IsInvalidTextRepresentation(err) {
-			err = status.Errorf(codes.InvalidArgument, "invalid user ID or cursor: %v", err)
-			return nil, err
-		}
-		err = status.Errorf(codes.Internal, "failed to list all notifications: %v", err)
+	if err != nil {
+		err = r.mapListNotificationsDatabaseError(err)
 		return nil, err
 	}
 
 	data, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[notificationsmodel.NotificationResponse])
 	if err != nil {
-		if r.pg.IsInvalidTextRepresentation(err) {
-			err = status.Errorf(codes.InvalidArgument, "invalid user ID: %v", err)
-			return nil, err
-		}
-
-		err = status.Errorf(codes.Internal, "failed to list all notifications: %v", err)
+		err = r.mapListNotificationsDatabaseError(err)
 		return nil, err
 	}
 

--- a/internal/repository/notifications/notifications.go
+++ b/internal/repository/notifications/notifications.go
@@ -363,15 +363,11 @@ func (r *Repository) ListNotifications(ctx context.Context, userID, cursor strin
 	}
 
 	var notificationsPreferences []string
+	filterByKind := true
 	switch user.GetNotificationPreference() {
 	case "ALL":
-		notificationsPreferences = []string{
-			notificationsmodel.KindWebAlert.ToString(),
-			notificationsmodel.KindWebError.ToString(),
-			notificationsmodel.KindWebWarn.ToString(),
-			notificationsmodel.KindWebInfo.ToString(),
-			notificationsmodel.KindWebSuccess.ToString(),
-		}
+		// Every kind matches, so skip the kind predicate entirely.
+		filterByKind = false
 	case "ALERTS":
 		notificationsPreferences = []string{
 			notificationsmodel.KindWebAlert.ToString(),
@@ -391,9 +387,14 @@ func (r *Repository) ListNotifications(ctx context.Context, userID, cursor strin
 	query := fmt.Sprintf(`
         SELECT id, kind, payload, read_at, created_at, updated_at
         FROM %s
-        WHERE user_id = $1 AND read_at IS NULL AND kind = ANY($2)
+        WHERE user_id = $1 AND read_at IS NULL
     `, postgres.TableNotifications)
-	args := []any{userID, notificationsPreferences}
+	args := []any{userID}
+
+	if filterByKind {
+		args = append(args, notificationsPreferences)
+		query += fmt.Sprintf(` AND kind = ANY($%d)`, len(args))
+	}
 
 	// Add cursor pagination
 	if cursor != "" {
@@ -403,8 +404,10 @@ func (r *Repository) ListNotifications(ctx context.Context, userID, cursor strin
 			return nil, err
 		}
 
-		query += ` AND (created_at, id) <= ($3, $4)`
 		args = append(args, createdAt, id)
+		// Inclusive: the cursor points at the first unreturned row, so the
+		// next page must include it.
+		query += fmt.Sprintf(` AND (created_at, id) <= ($%d, $%d)`, len(args)-1, len(args))
 	}
 
 	query += fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT %d;`, r.cfg.FetchLimit+1)
@@ -415,6 +418,13 @@ func (r *Repository) ListNotifications(ctx context.Context, userID, cursor strin
 		return nil, err
 	} else if errors.Is(err, context.Canceled) {
 		err = status.Error(codes.Canceled, err.Error())
+		return nil, err
+	} else if err != nil {
+		if r.pg.IsInvalidTextRepresentation(err) {
+			err = status.Errorf(codes.InvalidArgument, "invalid user ID or cursor: %v", err)
+			return nil, err
+		}
+		err = status.Errorf(codes.Internal, "failed to list all notifications: %v", err)
 		return nil, err
 	}
 
@@ -467,10 +477,15 @@ func extractDataFromCursor(cursor string) (string, time.Time, error) {
 		return "", time.Time{}, status.Error(codes.InvalidArgument, "invalid cursor: expected two parts")
 	}
 
+	id, err := uuid.Parse(string(parts[0]))
+	if err != nil {
+		return "", time.Time{}, status.Errorf(codes.InvalidArgument, "invalid cursor ID: %v", err)
+	}
+
 	createdAt, err := time.Parse(time.RFC3339Nano, string(parts[1]))
 	if err != nil {
 		return "", time.Time{}, status.Errorf(codes.InvalidArgument, "invalid timestamp: %v", err)
 	}
 
-	return string(parts[0]), createdAt, nil
+	return id.String(), createdAt, nil
 }

--- a/internal/repository/notifications/notifications_integration_test.go
+++ b/internal/repository/notifications/notifications_integration_test.go
@@ -3,6 +3,7 @@ package notifications
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -47,7 +48,7 @@ func (f *fakeUsersService) UpdateUser(context.Context, *userspb.UpdateUserReques
 
 // newTestRepository builds a notifications repository against the shared
 // PostgreSQL container.
-func newTestRepository(t *testing.T, preference string) *Repository {
+func newTestRepository(t *testing.T, preference string, fetchLimit int) *Repository {
 	t.Helper()
 
 	ctrl := gomock.NewController(t)
@@ -57,12 +58,12 @@ func newTestRepository(t *testing.T, preference string) *Repository {
 		Return("test-token", nil).
 		AnyTimes()
 
-	return New(&Config{FetchLimit: 20}, _auth, testkit.Postgres(t), &Services{UsersService: &fakeUsersService{preference: preference}})
+	return New(&Config{FetchLimit: fetchLimit}, _auth, testkit.Postgres(t), &Services{UsersService: &fakeUsersService{preference: preference}})
 }
 
 func TestIntegrationCreateListMarkReadNotifications(t *testing.T) {
 	ctx := context.Background()
-	repo := newTestRepository(t, "ALERTS")
+	repo := newTestRepository(t, "ALERTS", 20)
 
 	userID := seedUser(ctx, t, testkit.Postgres(t))
 
@@ -119,7 +120,7 @@ func TestIntegrationCreateListMarkReadNotifications(t *testing.T) {
 
 func TestIntegrationListNotificationsHonorsNonePreference(t *testing.T) {
 	ctx := context.Background()
-	repo := newTestRepository(t, "NONE")
+	repo := newTestRepository(t, "NONE", 20)
 
 	userID := seedUser(ctx, t, testkit.Postgres(t))
 	if _, err := repo.CreateNotification(ctx, userID, notificationsmodel.KindWebAlert.ToString(), `{"message":"ignored"}`, "idem-none-"+t.Name()); err != nil {
@@ -141,4 +142,105 @@ func seedUser(ctx context.Context, t *testing.T, pg *postgres.Postgres) string {
 	t.Helper()
 
 	return testkit.SeedUser(ctx, t, pg, fmt.Sprintf("notifications-%s@chronoverse.test", t.Name()))
+}
+
+func TestIntegrationListNotificationsHonorsAllPreference(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestRepository(t, "ALL", 20)
+
+	userID := seedUser(ctx, t, testkit.Postgres(t))
+
+	kinds := []string{
+		notificationsmodel.KindWebAlert.ToString(),
+		notificationsmodel.KindWebInfo.ToString(),
+		notificationsmodel.KindWebError.ToString(),
+	}
+	for i, kind := range kinds {
+		if _, err := repo.CreateNotification(ctx, userID, kind, `{"message":"hello"}`, fmt.Sprintf("idem-all-%s-%d", t.Name(), i)); err != nil {
+			t.Fatalf("CreateNotification(%s): %v", kind, err)
+		}
+	}
+
+	list, err := repo.ListNotifications(ctx, userID, "")
+	if err != nil {
+		t.Fatalf("ListNotifications: %v", err)
+	}
+	if len(list.Notifications) != len(kinds) {
+		t.Fatalf("ListNotifications returned %d notifications, want %d", len(list.Notifications), len(kinds))
+	}
+	if list.Cursor != "" {
+		t.Fatalf("expected no cursor, got %q", list.Cursor)
+	}
+}
+
+func TestIntegrationListNotificationsPaginatesWithoutDuplicatesOrSkips(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestRepository(t, "ALERTS", 2)
+
+	userID := seedUser(ctx, t, testkit.Postgres(t))
+
+	const total = 5
+	want := make(map[string]struct{}, total)
+	for i := range total {
+		id, err := repo.CreateNotification(ctx, userID, notificationsmodel.KindWebAlert.ToString(), fmt.Sprintf(`{"message":"alert-%d"}`, i), fmt.Sprintf("idem-page-%s-%d", t.Name(), i))
+		if err != nil {
+			t.Fatalf("CreateNotification: %v", err)
+		}
+		want[id] = struct{}{}
+	}
+
+	var pages int
+	cursor := ""
+	for {
+		page, err := repo.ListNotifications(ctx, userID, cursor)
+		if err != nil {
+			t.Fatalf("ListNotifications: %v", err)
+		}
+		pages++
+		if len(page.Notifications) > 2 {
+			t.Fatalf("page returned %d notifications, want at most 2", len(page.Notifications))
+		}
+		for _, n := range page.Notifications {
+			if _, ok := want[n.ID]; !ok {
+				t.Fatalf("unexpected notification id %q", n.ID)
+			}
+			delete(want, n.ID)
+		}
+		if page.Cursor == "" {
+			break
+		}
+		decoded, err := base64.StdEncoding.DecodeString(page.Cursor)
+		if err != nil {
+			t.Fatalf("decode cursor: %v", err)
+		}
+		cursor = string(decoded)
+		if pages > total {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	if len(want) != 0 {
+		t.Fatalf("pagination skipped %d notifications", len(want))
+	}
+	if pages != 3 {
+		t.Fatalf("pagination took %d pages, want 3", pages)
+	}
+}
+
+func TestIntegrationListNotificationsRejectsMalformedCursor(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestRepository(t, "ALERTS", 20)
+
+	userID := seedUser(ctx, t, testkit.Postgres(t))
+
+	cursors := map[string]string{
+		"missing delimiter": "not-a-cursor",
+		"malformed id":      "not-a-uuid$2024-01-01T00:00:00Z",
+		"malformed time":    "123e4567-e89b-12d3-a456-426614174000$not-a-time",
+	}
+	for name, cursor := range cursors {
+		if _, err := repo.ListNotifications(ctx, userID, cursor); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("%s: ListNotifications err code = %v, want %v", name, status.Code(err), codes.InvalidArgument)
+		}
+	}
 }


### PR DESCRIPTION
Speeds up `ListNotifications` (GetUser gRPC hop intentionally left untouched):

- Default `NOTIFICATIONS_SERVICE_CONFIG_FETCH_LIMIT` 1000 -> 100 (was an outlier vs jobs/workflows at 10; caps the wide JSONB rows scanned per poll).
- New partial index `idx_notifications_user_unread_kind_created_desc` on `notifications (user_id, kind, created_at DESC, id DESC) WHERE read_at IS NULL`, matching the kind-filtered unread query so it avoids filter + sort (migration 000013 + down).
- Skip the `kind = ANY(...)` predicate for the ALL preference (it matched every kind but blocked index use).
- Reject malformed cursors (bad shape, non-UUID id, bad timestamp) with `InvalidArgument`; guard `Query` errors so bind failures (e.g. bad user ID text) return `InvalidArgument`/`Internal` instead of reaching `CollectRows` with nil rows.
- Kept the inclusive `<= \keyset predicate: the cursor points at the first unreturned row, so `<` would skip a row per page.

Tests: extended `newTestRepository` with a fetch-limit param and added integration coverage: ALL-preference returns all kinds, 5 rows over FetchLimit 2 paginate in 3 pages with no duplicates or skips, malformed cursors return `InvalidArgument`. All notifications package tests pass (unit + integration, migrations applied).