### PR TITLE
refactor: share helpers, name constants, simplify validation

### DIFF
--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -51,6 +51,14 @@ func InitServerConfig() (*ServerConfig, error) {
 	return &cfg, nil
 }
 
+// Secret length requirements for server authentication.
+const (
+	// cryptoSecretLength is the exact required CRYPTO_SECRET length in bytes.
+	cryptoSecretLength = 32
+	// minCSRFHMACSecretLength is the minimum SERVER_CSRF_HMAC_SECRET length in bytes.
+	minCSRFHMACSecretLength = 32
+)
+
 func validateServerSecrets(cfg *ServerConfig) error {
 	if cfg.Secret == "" {
 		return errors.New("CRYPTO_SECRET must not be empty")
@@ -61,10 +69,10 @@ func validateServerSecrets(cfg *ServerConfig) error {
 	if cfg.Secret == cfg.CSRFHMACSecret {
 		return errors.New("CRYPTO_SECRET and SERVER_CSRF_HMAC_SECRET must be different")
 	}
-	if len(cfg.Secret) != 32 {
+	if len(cfg.Secret) != cryptoSecretLength {
 		return errors.New("CRYPTO_SECRET must be 32 bytes long")
 	}
-	if len(cfg.CSRFHMACSecret) < 32 {
+	if len(cfg.CSRFHMACSecret) < minCSRFHMACSecretLength {
 		return errors.New("SERVER_CSRF_HMAC_SECRET must be at least 32 bytes long")
 	}
 

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -317,27 +317,9 @@ func newWithPaths(issuer, privateKeyPath, publicKeyPath string) (*Auth, error) {
 	// bundle-backed validators reject, leaving the service silently broken.
 	// A missing bundle fails closed here instead of silently disabling
 	// kid-bound verification in ValidateToken.
-	foundInBundle := false
-	for candKid, entry := range bundle {
-		if entry.Iss != issuer {
-			continue
-		}
-		if candPub, ok := entry.PublicKey.(ed25519.PublicKey); ok && len(candPub) == len(edPub) {
-			match := true
-			for i := range candPub {
-				if candPub[i] != edPub[i] {
-					match = false
-					break
-				}
-			}
-			if match {
-				kid = candKid
-				foundInBundle = true
-				break
-			}
-		}
-	}
-	if !foundInBundle {
+	if bundleKid, ok := findBundleKid(bundle, issuer, edPub); ok {
+		kid = bundleKid
+	} else {
 		if bundlePath == "" {
 			return nil, status.Errorf(codes.Internal, "trusted bundle is required for issuer %q but was not found; refusing to start without kid-bound verification", issuer)
 		}
@@ -353,6 +335,20 @@ func newWithPaths(issuer, privateKeyPath, publicKeyPath string) (*Auth, error) {
 		bundlePath: bundlePath,
 		tp:         otel.Tracer(issuer),
 	}, nil
+}
+
+// findBundleKid returns the bundle kid whose issuer matches and whose ed25519
+// public key equals edPub.
+func findBundleKid(bundle map[string]*bundleEntry, issuer string, edPub ed25519.PublicKey) (string, bool) {
+	for candKid, entry := range bundle {
+		if entry.Iss != issuer {
+			continue
+		}
+		if candPub, ok := entry.PublicKey.(ed25519.PublicKey); ok && bytes.Equal(candPub, edPub) {
+			return candKid, true
+		}
+	}
+	return "", false
 }
 
 // IssueToken issues a new token with the given subject. audiences controls

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -268,8 +268,6 @@ func New() (*Auth, error) {
 }
 
 // newWithPaths creates a new Auth instance from explicit key paths (test helper).
-//
-//nolint:gocyclo // key load + bundle resolution + kid selection is linear, split would add indirection
 func newWithPaths(issuer, privateKeyPath, publicKeyPath string) (*Auth, error) {
 	privateKeyBytes, err := os.ReadFile(privateKeyPath)
 	if err != nil {

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -205,17 +205,7 @@ func ExtractAuthorizationTokenFromMetadata(ctx context.Context) (string, error) 
 		return "", status.Error(codes.NotFound, "metadata is required")
 	}
 
-	data := md.Get(authorizationMetadataKey)
-	if len(data) == 0 {
-		return "", status.Error(codes.FailedPrecondition, "missing authorization token")
-	}
-
-	parts := strings.Split(data[0], " ")
-	if len(parts) < 2 || parts[0] != "Bearer" {
-		return "", status.Error(codes.FailedPrecondition, "missing authorization token")
-	}
-
-	return parts[1], nil
+	return parseBearerToken(md.Get(authorizationMetadataKey))
 }
 
 // ExtractRoleFromContext extracts the role placed in the context by ValidateToken.
@@ -232,7 +222,10 @@ func ExtractAudienceFromContext(ctx context.Context) (string, error) {
 
 // ExtractAuthorizationTokenFromHeaders extracts the authorization token from the headers.
 func ExtractAuthorizationTokenFromHeaders(headers metadata.MD) (string, error) {
-	data := headers.Get(authorizationMetadataKey)
+	return parseBearerToken(headers.Get(authorizationMetadataKey))
+}
+
+func parseBearerToken(data []string) (string, error) {
 	if len(data) == 0 {
 		return "", status.Error(codes.FailedPrecondition, "missing authorization token")
 	}

--- a/internal/pkg/commandidempotency/ledger.go
+++ b/internal/pkg/commandidempotency/ledger.go
@@ -121,6 +121,13 @@ type LegacyIdentity struct {
 	RequestHash string
 }
 
+const (
+	// idempotencyKeyMinLength is the minimum normalized idempotency key length in bytes.
+	idempotencyKeyMinLength = 1
+	// idempotencyKeyMaxLength is the maximum normalized idempotency key length in bytes.
+	idempotencyKeyMaxLength = 255
+)
+
 // NormalizeKey validates and applies the published ASCII-space normalization.
 func NormalizeKey(raw string) (string, error) {
 	if !utf8.ValidString(raw) {
@@ -140,7 +147,7 @@ func NormalizeKey(raw string) (string, error) {
 		end--
 	}
 	key := raw[start:end]
-	if len(key) < 1 || len(key) > 255 {
+	if len(key) < idempotencyKeyMinLength || len(key) > idempotencyKeyMaxLength {
 		return "", status.Error(codes.InvalidArgument, "idempotency key must be between 1 and 255 UTF-8 bytes")
 	}
 	return key, nil

--- a/internal/pkg/commandidempotency/ledger.go
+++ b/internal/pkg/commandidempotency/ledger.go
@@ -237,13 +237,17 @@ func Reserve(
 }
 
 func requestHashMatches(storedHash string, storedAliases []string, requestHash string, requestAliases []string) bool {
-	stored := append([]string{storedHash}, storedAliases...)
-	requested := append([]string{requestHash}, requestAliases...)
-	for _, storedCandidate := range stored {
-		for _, requestedCandidate := range requested {
-			if storedCandidate == requestedCandidate {
-				return true
-			}
+	wanted := make(map[string]struct{}, len(requestAliases)+1)
+	wanted[requestHash] = struct{}{}
+	for _, h := range requestAliases {
+		wanted[h] = struct{}{}
+	}
+	if _, ok := wanted[storedHash]; ok {
+		return true
+	}
+	for _, h := range storedAliases {
+		if _, ok := wanted[h]; ok {
+			return true
 		}
 	}
 	return false

--- a/internal/pkg/commandidempotency/ledger.go
+++ b/internal/pkg/commandidempotency/ledger.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hitesh22rana/chronoverse/internal/pkg/idempotency"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/postgres"
 )
 
@@ -64,12 +65,12 @@ const (
 
 // WorkflowUpdateOperation returns the stable workflow-update operation name.
 func WorkflowUpdateOperation(workflowID string) string {
-	return workflowUpdateOperationPrefix + canonicalUUIDText(workflowID)
+	return workflowUpdateOperationPrefix + idempotency.CanonicalUUIDText(workflowID)
 }
 
 // ManualScheduleOperation returns the stable manual-schedule operation name.
 func ManualScheduleOperation(workflowID string) string {
-	return manualScheduleOperationPrefix + canonicalUUIDText(workflowID)
+	return manualScheduleOperationPrefix + idempotency.CanonicalUUIDText(workflowID)
 }
 
 // LegacyWorkflowUpdateOperation returns the exact pre-shared-ledger operation
@@ -80,18 +81,20 @@ func LegacyWorkflowUpdateOperation(rawWorkflowID string) string {
 }
 
 // UserScope returns a user command scope.
-func UserScope(userID string) string { return userScopePrefix + canonicalUUIDText(userID) }
+func UserScope(userID string) string { return userScopePrefix + idempotency.CanonicalUUIDText(userID) }
 
 // WorkflowScope returns a workflow command scope.
 func WorkflowScope(workflowID string) string {
-	return workflowScopePrefix + canonicalUUIDText(workflowID)
+	return workflowScopePrefix + idempotency.CanonicalUUIDText(workflowID)
 }
 
 // JobScope returns a job command scope.
-func JobScope(jobID string) string { return jobScopePrefix + canonicalUUIDText(jobID) }
+func JobScope(jobID string) string { return jobScopePrefix + idempotency.CanonicalUUIDText(jobID) }
 
 // WorkerScope returns a process-specific worker command scope.
-func WorkerScope(processID string) string { return workerScopePrefix + canonicalUUIDText(processID) }
+func WorkerScope(processID string) string {
+	return workerScopePrefix + idempotency.CanonicalUUIDText(processID)
+}
 
 // CanonicalUUID validates a UUID identity and returns PostgreSQL's canonical
 // lowercase, hyphenated spelling. Ledger callers must use the returned value
@@ -102,14 +105,6 @@ func CanonicalUUID(raw, field string) (string, error) {
 		return "", status.Errorf(codes.InvalidArgument, "%s must be a valid UUID: %v", field, err)
 	}
 	return id.String(), nil
-}
-
-func canonicalUUIDText(raw string) string {
-	id, err := uuid.Parse(raw)
-	if err != nil {
-		return raw
-	}
-	return id.String()
 }
 
 // Reservation is a fresh command reservation or a completed replay.

--- a/internal/pkg/idempotency/idempotency.go
+++ b/internal/pkg/idempotency/idempotency.go
@@ -16,8 +16,8 @@ import (
 // ClaimCommandID returns the deterministic command ID for one process-local
 // Kafka dispatch occurrence. NUL framing prevents concatenation ambiguity.
 func ClaimCommandID(processInstanceID, jobID string, dispatchAttempt int32) string {
-	processInstanceID = canonicalUUIDText(processInstanceID)
-	jobID = canonicalUUIDText(jobID)
+	processInstanceID = CanonicalUUIDText(processInstanceID)
+	jobID = CanonicalUUIDText(jobID)
 	value := fmt.Sprintf("job.claim\x00%s\x00%s\x00%d", processInstanceID, jobID, dispatchAttempt)
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:])
@@ -25,7 +25,7 @@ func ClaimCommandID(processInstanceID, jobID string, dispatchAttempt int32) stri
 
 // JobCancelCommandID returns a permanent deterministic cancellation command ID.
 func JobCancelCommandID(jobID string) string {
-	jobID = canonicalUUIDText(jobID)
+	jobID = CanonicalUUIDText(jobID)
 	value := fmt.Sprintf("job.cancel\x00%s", jobID)
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:])
@@ -68,7 +68,7 @@ func WorkflowBuildHash(kind, payload string) (string, error) {
 
 // WorkflowEventKey returns the deterministic idempotency key for a workflow event.
 func WorkflowEventKey(workflowID, action string, generation int64) string {
-	workflowID = canonicalUUIDText(workflowID)
+	workflowID = CanonicalUUIDText(workflowID)
 	if generation > 0 {
 		return fmt.Sprintf("workflow:%s:%s:%d", workflowID, action, generation)
 	}
@@ -77,7 +77,7 @@ func WorkflowEventKey(workflowID, action string, generation int64) string {
 
 // JobDispatchEventKey returns the deterministic idempotency key for dispatching a job.
 func JobDispatchEventKey(jobID string, dispatchAttempt ...int32) string {
-	jobID = canonicalUUIDText(jobID)
+	jobID = CanonicalUUIDText(jobID)
 	if len(dispatchAttempt) > 0 && dispatchAttempt[0] > 0 {
 		return fmt.Sprintf("job:%s:dispatch:%d", jobID, dispatchAttempt[0])
 	}
@@ -85,7 +85,9 @@ func JobDispatchEventKey(jobID string, dispatchAttempt ...int32) string {
 	return fmt.Sprintf("job:%s:dispatch", jobID)
 }
 
-func canonicalUUIDText(raw string) string {
+// CanonicalUUIDText returns the canonical lowercase hyphenated UUID spelling,
+// falling back to the raw input when it is not a valid UUID.
+func CanonicalUUIDText(raw string) string {
 	id, err := uuid.Parse(raw)
 	if err != nil {
 		return raw
@@ -104,25 +106,25 @@ func AutomaticScheduleEventKey(workflowEventKey string) string {
 
 // JobWorkflowEventKey returns the deterministic event key for workflow-side job terminal effects.
 func JobWorkflowEventKey(jobID, action string) string {
-	jobID = canonicalUUIDText(jobID)
+	jobID = CanonicalUUIDText(jobID)
 	return fmt.Sprintf("workflow:job:%s:%s", jobID, action)
 }
 
 // JobCompletedAnalyticsEventKey returns the deterministic analytics event key for a completed job.
 func JobCompletedAnalyticsEventKey(jobID string) string {
-	jobID = canonicalUUIDText(jobID)
+	jobID = CanonicalUUIDText(jobID)
 	return fmt.Sprintf("analytics:job:%s:completed", jobID)
 }
 
 // WorkflowAnalyticsEventKey returns the deterministic analytics event key for a workflow.
 func WorkflowAnalyticsEventKey(workflowID string) string {
-	workflowID = canonicalUUIDText(workflowID)
+	workflowID = CanonicalUUIDText(workflowID)
 	return fmt.Sprintf("analytics:workflow:%s", workflowID)
 }
 
 // LogEventKey returns the deterministic event key for a single job log line.
 func LogEventKey(jobID, stream string, sequenceNum uint32, attempts ...int32) string {
-	jobID = canonicalUUIDText(jobID)
+	jobID = CanonicalUUIDText(jobID)
 	if len(attempts) > 0 && attempts[0] > 1 {
 		return fmt.Sprintf("log:%s:attempt:%d:%s:%d", jobID, attempts[0], stream, sequenceNum)
 	}
@@ -132,13 +134,13 @@ func LogEventKey(jobID, stream string, sequenceNum uint32, attempts ...int32) st
 
 // NotificationEventKey returns the deterministic idempotency key for a notification.
 func NotificationEventKey(entity, entityID, eventType string) string {
-	entityID = canonicalUUIDText(entityID)
+	entityID = CanonicalUUIDText(entityID)
 	return fmt.Sprintf("notification:%s:%s:%s", entity, entityID, eventType)
 }
 
 // NotificationOccurrenceEventKey returns the deterministic idempotency key for a notification occurrence.
 func NotificationOccurrenceEventKey(entity, entityID, eventType, occurrenceKey string) string {
-	entityID = canonicalUUIDText(entityID)
+	entityID = CanonicalUUIDText(entityID)
 	if occurrenceKey == "" {
 		return NotificationEventKey(entity, entityID, eventType)
 	}

--- a/internal/pkg/kafka/topics.go
+++ b/internal/pkg/kafka/topics.go
@@ -24,6 +24,9 @@ const (
 	// maxCreateTopicsAttempts bounds EnsureTopics retries (2s apart, so at
 	// most ~1 minute of waiting for the broker to answer admin requests).
 	maxCreateTopicsAttempts = 30
+
+	// createTopicsTimeoutMillis bounds a single CreateTopics admin request.
+	createTopicsTimeoutMillis = 10000
 )
 
 // EnsureTopics creates the given topics with a single partition, retrying until
@@ -53,7 +56,7 @@ func EnsureTopics(ctx context.Context, client *kgo.Client, topics ...string) err
 
 // createTopicsOnce issues a single CreateTopics request.
 func createTopicsOnce(ctx context.Context, client *kgo.Client, topics ...string) error {
-	req := &kmsg.CreateTopicsRequest{TimeoutMillis: 10000}
+	req := &kmsg.CreateTopicsRequest{TimeoutMillis: createTopicsTimeoutMillis}
 	for _, topic := range topics {
 		req.Topics = append(req.Topics, kmsg.CreateTopicsRequestTopic{
 			Topic:             topic,

--- a/internal/pkg/paginate/paginate.go
+++ b/internal/pkg/paginate/paginate.go
@@ -1,0 +1,20 @@
+// Package paginate trims limit+1 over-fetched pages.
+package paginate
+
+// Trim returns data limited to limit rows and whether more rows existed.
+// Callers fetch limit+1 rows; the extra row (if any) only signals hasMore.
+func Trim[T any](data []T, limit int) ([]T, bool) {
+	if len(data) > limit {
+		return data[:limit], true
+	}
+	return data, false
+}
+
+// TrimWithCursor trims the over-fetched page and builds the next cursor from
+// the first unreturned row. It returns an empty cursor when there is no next page.
+func TrimWithCursor[T any](data []T, limit int, cursorOf func(T) string) ([]T, string) {
+	if len(data) > limit {
+		return data[:limit], cursorOf(data[limit])
+	}
+	return data, ""
+}

--- a/internal/pkg/paginate/paginate.go
+++ b/internal/pkg/paginate/paginate.go
@@ -12,7 +12,7 @@ func Trim[T any](data []T, limit int) ([]T, bool) {
 
 // TrimWithCursor trims the over-fetched page and builds the next cursor from
 // the first unreturned row. It returns an empty cursor when there is no next page.
-func TrimWithCursor[T any](data []T, limit int, cursorOf func(T) string) ([]T, string) {
+func TrimWithCursor[T any](data []T, limit int, cursorOf func(T) string) (page []T, cursor string) {
 	if len(data) > limit {
 		return data[:limit], cursorOf(data[limit])
 	}

--- a/internal/pkg/paginate/paginate_test.go
+++ b/internal/pkg/paginate/paginate_test.go
@@ -1,0 +1,34 @@
+package paginate_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hitesh22rana/chronoverse/internal/pkg/paginate"
+)
+
+func TestTrim(t *testing.T) {
+	if page, more := paginate.Trim([]int{}, 2); len(page) != 0 || more {
+		t.Fatalf("empty = %v, %v", page, more)
+	}
+	if page, more := paginate.Trim([]int{1, 2}, 2); len(page) != 2 || more {
+		t.Fatalf("exact limit = %v, %v", page, more)
+	}
+	page, more := paginate.Trim([]int{1, 2, 3}, 2)
+	if len(page) != 2 || !more || page[1] != 2 {
+		t.Fatalf("over limit = %v, %v", page, more)
+	}
+}
+
+func TestTrimWithCursor(t *testing.T) {
+	cursorOf := func(v int) string { return fmt.Sprintf("cursor-%d", v) }
+
+	page, cursor := paginate.TrimWithCursor([]int{1, 2}, 2, cursorOf)
+	if len(page) != 2 || cursor != "" {
+		t.Fatalf("exact limit = %v, %q", page, cursor)
+	}
+	page, cursor = paginate.TrimWithCursor([]int{1, 2, 3}, 2, cursorOf)
+	if len(page) != 2 || cursor != "cursor-3" {
+		t.Fatalf("over limit = %v, %q", page, cursor)
+	}
+}

--- a/internal/pkg/terminalreason/terminalreason.go
+++ b/internal/pkg/terminalreason/terminalreason.go
@@ -69,16 +69,17 @@ func Message(code Code) (string, bool) {
 
 // ValidateFailure validates that value belongs to the failure reason family.
 func ValidateFailure(value string) error {
-	if _, ok := failureCodes[Code(value)]; !ok {
-		return fmt.Errorf("invalid failure reason code %q", value)
-	}
-	return nil
+	return validateCode(value, failureCodes, "failure reason code")
 }
 
 // ValidateCancellation validates that value belongs to the cancellation reason family.
 func ValidateCancellation(value string) error {
-	if _, ok := cancellationCodes[Code(value)]; !ok {
-		return fmt.Errorf("invalid cancellation reason code %q", value)
+	return validateCode(value, cancellationCodes, "cancellation reason code")
+}
+
+func validateCode(value string, set map[Code]struct{}, kind string) error {
+	if _, ok := set[Code(value)]; !ok {
+		return fmt.Errorf("invalid %s %q", kind, value)
 	}
 	return nil
 }

--- a/internal/repository/jobs/jobs.go
+++ b/internal/repository/jobs/jobs.go
@@ -735,8 +735,8 @@ func (r *Repository) GetJobLogs(
 		}
 		defer rows.Close()
 
-		tmp := make([]*jobsmodel.JobLog, 0, r.cfg.LogsFetchLimit+1)
-		tmpCursors := make([]jobLogsCursor, 0, r.cfg.LogsFetchLimit+1)
+		fetched := make([]*jobsmodel.JobLog, 0, r.cfg.LogsFetchLimit+1)
+		fetchedCursors := make([]jobLogsCursor, 0, r.cfg.LogsFetchLimit+1)
 		for rows.Next() {
 			var (
 				ts      time.Time
@@ -748,14 +748,14 @@ func (r *Repository) GetJobLogs(
 			if scanErr := rows.Scan(&ts, &msg, &seq, &strm, &eventID); scanErr != nil {
 				return status.Errorf(codes.Internal, "failed to scan logs: %v", scanErr)
 			}
-			tmp = append(tmp, &jobsmodel.JobLog{
+			fetched = append(fetched, &jobsmodel.JobLog{
 				EventID:     eventID,
 				Timestamp:   ts,
 				Message:     msg,
 				SequenceNum: seq,
 				Stream:      strm,
 			})
-			tmpCursors = append(tmpCursors, jobLogsCursor{
+			fetchedCursors = append(fetchedCursors, jobLogsCursor{
 				SequenceNum: seq,
 				Stream:      strm,
 				EventID:     eventID,
@@ -765,11 +765,11 @@ func (r *Repository) GetJobLogs(
 			return status.Errorf(codes.Internal, "rows error: %v", rowsErr)
 		}
 
-		tmp, hasMore := paginate.Trim(tmp, r.cfg.LogsFetchLimit)
+		fetched, hasMore := paginate.Trim(fetched, r.cfg.LogsFetchLimit)
 		if hasMore {
-			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
+			nextCursor = fetchedCursors[r.cfg.LogsFetchLimit]
 		}
-		logs = tmp
+		logs = fetched
 		return nil
 	})
 
@@ -1024,8 +1024,8 @@ func (r *Repository) SearchJobLogs(
 			return status.Errorf(codes.Internal, "failed to search job logs: %v", searchErr)
 		}
 
-		tmp := make([]*jobsmodel.JobLog, 0, len(searchRes.Hits))
-		tmpCursors := make([]jobLogsCursor, 0, len(searchRes.Hits))
+		fetched := make([]*jobsmodel.JobLog, 0, len(searchRes.Hits))
+		fetchedCursors := make([]jobLogsCursor, 0, len(searchRes.Hits))
 		for _, hit := range searchRes.Hits {
 			source, scanErr := searchHitSource(hit)
 			if scanErr != nil {
@@ -1065,19 +1065,19 @@ func (r *Repository) SearchJobLogs(
 				log.Stream = stream
 			}
 
-			tmp = append(tmp, log)
-			tmpCursors = append(tmpCursors, jobLogsCursor{
+			fetched = append(fetched, log)
+			fetchedCursors = append(fetchedCursors, jobLogsCursor{
 				SequenceNum: log.SequenceNum,
 				Stream:      log.Stream,
 				EventID:     searchHitString(source, "id"),
 			})
 		}
 
-		tmp, hasMore := paginate.Trim(tmp, r.cfg.LogsFetchLimit)
+		fetched, hasMore := paginate.Trim(fetched, r.cfg.LogsFetchLimit)
 		if hasMore {
-			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
+			nextCursor = fetchedCursors[r.cfg.LogsFetchLimit]
 		}
-		logs = tmp
+		logs = fetched
 		return nil
 	})
 

--- a/internal/repository/jobs/jobs.go
+++ b/internal/repository/jobs/jobs.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hitesh22rana/chronoverse/internal/pkg/commandidempotency"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/idempotency"
 	meilisearchpkg "github.com/hitesh22rana/chronoverse/internal/pkg/meilisearch"
+	"github.com/hitesh22rana/chronoverse/internal/pkg/paginate"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/postgres"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/redis"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
@@ -764,9 +765,10 @@ func (r *Repository) GetJobLogs(
 			return status.Errorf(codes.Internal, "rows error: %v", rowsErr)
 		}
 
-		if len(tmp) > r.cfg.LogsFetchLimit {
+		trimmed, hasMore := paginate.Trim(tmp, r.cfg.LogsFetchLimit)
+		tmp = trimmed
+		if hasMore {
 			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
-			tmp = tmp[:r.cfg.LogsFetchLimit]
 		}
 		logs = tmp
 		return nil
@@ -1072,9 +1074,10 @@ func (r *Repository) SearchJobLogs(
 			})
 		}
 
-		if len(tmp) > r.cfg.LogsFetchLimit {
+		trimmed, hasMore := paginate.Trim(tmp, r.cfg.LogsFetchLimit)
+		tmp = trimmed
+		if hasMore {
 			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
-			tmp = tmp[:r.cfg.LogsFetchLimit]
 		}
 		logs = tmp
 		return nil
@@ -1191,16 +1194,14 @@ func (r *Repository) ListJobs(ctx context.Context, workflowID, userID, cursor st
 	}
 
 	// Check if there are more jobs
-	cursor = ""
-	if len(data) > r.cfg.FetchLimit {
-		cursor = fmt.Sprintf(
+	data, cursor = paginate.TrimWithCursor(data, r.cfg.FetchLimit, func(v *jobsmodel.JobByWorkflowIDResponse) string {
+		return fmt.Sprintf(
 			"%s%c%s",
-			data[r.cfg.FetchLimit].ID,
+			v.ID,
 			delimiter,
-			data[r.cfg.FetchLimit].CreatedAt.Format(time.RFC3339Nano),
+			v.CreatedAt.Format(time.RFC3339Nano),
 		)
-		data = data[:r.cfg.FetchLimit]
-	}
+	})
 
 	return &jobsmodel.ListJobsResponse{
 		Jobs:   data,

--- a/internal/repository/jobs/jobs.go
+++ b/internal/repository/jobs/jobs.go
@@ -765,8 +765,7 @@ func (r *Repository) GetJobLogs(
 			return status.Errorf(codes.Internal, "rows error: %v", rowsErr)
 		}
 
-		trimmed, hasMore := paginate.Trim(tmp, r.cfg.LogsFetchLimit)
-		tmp = trimmed
+		tmp, hasMore := paginate.Trim(tmp, r.cfg.LogsFetchLimit)
 		if hasMore {
 			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
 		}
@@ -1074,8 +1073,7 @@ func (r *Repository) SearchJobLogs(
 			})
 		}
 
-		trimmed, hasMore := paginate.Trim(tmp, r.cfg.LogsFetchLimit)
-		tmp = trimmed
+		tmp, hasMore := paginate.Trim(tmp, r.cfg.LogsFetchLimit)
 		if hasMore {
 			nextCursor = tmpCursors[r.cfg.LogsFetchLimit]
 		}

--- a/internal/repository/notifications/notifications.go
+++ b/internal/repository/notifications/notifications.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/commandidempotency"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/idempotency"
+	"github.com/hitesh22rana/chronoverse/internal/pkg/paginate"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/postgres"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 )
@@ -438,16 +439,14 @@ func (r *Repository) ListNotifications(ctx context.Context, userID, cursor strin
 	}
 
 	// Check if there are more notifications
-	cursor = ""
-	if len(data) > r.cfg.FetchLimit {
-		cursor = fmt.Sprintf(
+	data, cursor = paginate.TrimWithCursor(data, r.cfg.FetchLimit, func(v *notificationsmodel.NotificationResponse) string {
+		return fmt.Sprintf(
 			"%s%c%s",
-			data[r.cfg.FetchLimit].ID,
+			v.ID,
 			delimiter,
-			data[r.cfg.FetchLimit].CreatedAt.Format(time.RFC3339Nano),
+			v.CreatedAt.Format(time.RFC3339Nano),
 		)
-		data = data[:r.cfg.FetchLimit]
-	}
+	})
 
 	return &notificationsmodel.ListNotificationsResponse{
 		Notifications: data,

--- a/internal/repository/workflows/workflows.go
+++ b/internal/repository/workflows/workflows.go
@@ -19,6 +19,7 @@ import (
 	workflowsmodel "github.com/hitesh22rana/chronoverse/internal/model/workflows"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/commandidempotency"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/idempotency"
+	"github.com/hitesh22rana/chronoverse/internal/pkg/paginate"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/postgres"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/terminalreason"
@@ -1286,16 +1287,14 @@ func (r *Repository) ListWorkflows(ctx context.Context, userID, cursor string, f
 	}
 
 	// Check if there are more workflows
-	cursor = ""
-	if len(data) > r.cfg.FetchLimit {
-		cursor = fmt.Sprintf(
+	data, cursor = paginate.TrimWithCursor(data, r.cfg.FetchLimit, func(v *workflowsmodel.WorkflowByUserIDResponse) string {
+		return fmt.Sprintf(
 			"%s%c%s",
-			data[r.cfg.FetchLimit].ID,
+			v.ID,
 			delimiter,
-			data[r.cfg.FetchLimit].CreatedAt.Format(time.RFC3339Nano),
+			v.CreatedAt.Format(time.RFC3339Nano),
 		)
-		data = data[:r.cfg.FetchLimit]
-	}
+	})
 
 	return &workflowsmodel.ListWorkflowsResponse{
 		Workflows: data,

--- a/internal/repository/workflows/workflows.go
+++ b/internal/repository/workflows/workflows.go
@@ -1184,8 +1184,6 @@ func (r *Repository) DeleteWorkflow(ctx context.Context, workflowID, userID stri
 }
 
 // ListWorkflows returns workflows by user ID.
-//
-//nolint:gocyclo // The cyclomatic complexity is high due to the different conditions and queries.
 func (r *Repository) ListWorkflows(ctx context.Context, userID, cursor string, filters *workflowsmodel.ListWorkflowsFilters) (res *workflowsmodel.ListWorkflowsResponse, err error) {
 	ctx, span := r.tp.Start(ctx, "Repository.ListWorkflows")
 	defer func() {

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -185,24 +185,29 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 	return w.gzipWriter.Write(b)
 }
 
+// isValidValue reports whether value belongs to the valid set.
+func isValidValue(value string, valid []string) bool {
+	return slices.Contains(valid, value)
+}
+
 // isValidKind checks if the given kind is valid.
 func isValidKind(kind string) bool {
-	return slices.Contains(validKinds, kind)
+	return isValidValue(kind, validKinds)
 }
 
 // isValidBuildStatus checks if the given build status is valid.
 func isValidBuildStatus(buildStatus string) bool {
-	return slices.Contains(validBuildStatuses, buildStatus)
+	return isValidValue(buildStatus, validBuildStatuses)
 }
 
 // isValidJobStatus checks if the given job status is valid.
 func isValidJobStatus(status string) bool {
-	return slices.Contains(validJobStatuses, status)
+	return isValidValue(status, validJobStatuses)
 }
 
 // isValidJobTrigger checks if the given job trigger is valid.
 func isValidJobTrigger(trigger string) bool {
-	return slices.Contains(validJobTriggers, trigger)
+	return isValidValue(trigger, validJobTriggers)
 }
 
 // getJobLogsStreamType returns the joblogs stream type.
@@ -221,5 +226,5 @@ func getJobLogsStreamType(stream string) (jobspb.LogStream, error) {
 
 // isTerminalJobStatus checks if the given job status is terminal(will no longer change).
 func isTerminalJobStatus(status string) bool {
-	return slices.Contains(terminalJobStatuses, status)
+	return isValidValue(status, terminalJobStatuses)
 }

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -92,21 +92,17 @@ func sessionFromContext(ctx context.Context) (string, error) {
 
 // setCookie sets a cookie in the response.
 func setCookie(w http.ResponseWriter, name, value, host string, secure bool, expires time.Duration, sameSite http.SameSite) {
-	maxAge := int(expires.Seconds())
-	if expires < 0 {
-		maxAge = -1
-	}
-
 	cookie := &http.Cookie{ //nolint:gosec // Secure is configurable so local HTTP development remains supported.
 		Name:     name,
 		Value:    value,
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   secure,
-		MaxAge:   maxAge,
+		MaxAge:   int(expires.Seconds()),
 		SameSite: sameSite,
 	}
 	if expires < 0 {
+		cookie.MaxAge = -1
 		cookie.Expires = time.Unix(0, 0).UTC()
 	}
 
@@ -119,49 +115,42 @@ func setCookie(w http.ResponseWriter, name, value, host string, secure bool, exp
 	http.SetCookie(w, cookie)
 }
 
-//nolint:gocyclo // handleErrors is a helper function to handle gRPC errors.
+// grpcToHTTPStatus maps gRPC codes to HTTP statuses. codes.OK is absent on
+// purpose: like the switch it replaces, OK and unmapped codes write nothing.
+var grpcToHTTPStatus = map[codes.Code]int{
+	codes.Unauthenticated:    http.StatusUnauthorized,
+	codes.PermissionDenied:   http.StatusForbidden,
+	codes.NotFound:           http.StatusNotFound,
+	codes.AlreadyExists:      http.StatusConflict,
+	codes.Aborted:            http.StatusConflict,
+	codes.InvalidArgument:    http.StatusBadRequest,
+	codes.Unimplemented:      http.StatusNotImplemented,
+	codes.Unavailable:        http.StatusServiceUnavailable,
+	codes.FailedPrecondition: http.StatusPreconditionFailed,
+	codes.ResourceExhausted:  http.StatusTooManyRequests,
+	codes.Canceled:           http.StatusRequestTimeout,
+	codes.DeadlineExceeded:   http.StatusGatewayTimeout,
+	codes.Internal:           http.StatusInternalServerError,
+	codes.DataLoss:           http.StatusInternalServerError,
+	codes.OutOfRange:         http.StatusInternalServerError,
+	codes.Unknown:            http.StatusInternalServerError,
+}
+
 func handleError(w http.ResponseWriter, err error, message ...string) {
 	msg := err.Error()
 	if len(message) > 0 {
 		msg = strings.Join(message, " ")
 	}
 
-	switch status.Code(err) {
-	case codes.OK:
+	code := status.Code(err)
+	if code == codes.OK {
 		return
-	case codes.Unauthenticated:
-		http.Error(w, msg, http.StatusUnauthorized)
-	case codes.PermissionDenied:
-		http.Error(w, msg, http.StatusForbidden)
-	case codes.NotFound:
-		http.Error(w, msg, http.StatusNotFound)
-	case codes.AlreadyExists:
-		http.Error(w, msg, http.StatusConflict)
-	case codes.InvalidArgument:
-		http.Error(w, msg, http.StatusBadRequest)
-	case codes.Unimplemented:
-		http.Error(w, msg, http.StatusNotImplemented)
-	case codes.Unavailable:
-		http.Error(w, msg, http.StatusServiceUnavailable)
-	case codes.FailedPrecondition:
-		http.Error(w, msg, http.StatusPreconditionFailed)
-	case codes.ResourceExhausted:
-		http.Error(w, msg, http.StatusTooManyRequests)
-	case codes.Canceled:
-		http.Error(w, msg, http.StatusRequestTimeout)
-	case codes.DeadlineExceeded:
-		http.Error(w, msg, http.StatusGatewayTimeout)
-	case codes.Internal:
-		http.Error(w, msg, http.StatusInternalServerError)
-	case codes.DataLoss:
-		http.Error(w, msg, http.StatusInternalServerError)
-	case codes.Aborted:
-		http.Error(w, msg, http.StatusConflict)
-	case codes.OutOfRange:
-		http.Error(w, msg, http.StatusInternalServerError)
-	case codes.Unknown:
-		http.Error(w, msg, http.StatusInternalServerError)
 	}
+	httpStatus, ok := grpcToHTTPStatus[code]
+	if !ok {
+		return
+	}
+	http.Error(w, msg, httpStatus)
 }
 
 // gzipResponseWriter combines gzip compression with status code capture.


### PR DESCRIPTION
Behavior-preserving refactoring pass over internal/: deduplicate shared helpers, name magic constants, and simplify validation paths. No behavior change intended.

What changed:
- Auth: one shared Bearer-token parser for metadata/headers callers; bundle kid lookup extracted with bytes.Equal comparison.
- Idempotency: one canonical UUID-text helper shared by the event-key and command-ledger packages; request-hash matching uses a set lookup instead of a nested loop.
- Pagination: one limit-plus-one trim helper backing the jobs/workflows/notifications list queries and the job-log pages.
- Config: named constants for the Kafka admin timeout, server secret lengths, and idempotency key bounds.
- Validation: terminal reason codes validated through one helper; server allowlist checks share one contains helper; gRPC-to-HTTP status mapping is a table, and the cookie setter has a single expiry branch.

Deliberately untouched (shared knowledge, but unifying would change behavior or couple layers without an agreed contract):
- gRPC bootstrap copies across app services, retryable-code defaults with opposite allow/deny semantics, and the service-level terminal-status check.

Verification:
- ./.bin/golangci-lint run ./... : 0 issues
- gofmt clean on touched files; go vet clean on touched packages
- go test -count=1 -short ./internal/... : all ok, no FAIL