### PR TITLE
Refactor shared client config, gRPC TLS, and workflow validation

### DIFF
--- a/cmd/analytics-processor/main.go
+++ b/cmd/analytics-processor/main.go
@@ -48,24 +48,7 @@ func run() int {
 		return ExitError
 	}
 
-	pdb, err := postgres.New(ctx, &postgres.Config{
-		Host:        cfg.Postgres.Host,
-		Port:        cfg.Postgres.Port,
-		User:        cfg.Postgres.User,
-		Password:    cfg.Postgres.Password,
-		Database:    cfg.Postgres.Database,
-		MaxConns:    cfg.Postgres.MaxConns,
-		MinConns:    cfg.Postgres.MinConns,
-		MaxConnLife: cfg.Postgres.MaxConnLife,
-		MaxConnIdle: cfg.Postgres.MaxConnIdle,
-		DialTimeout: cfg.Postgres.DialTimeout,
-		TLSConfig: &postgres.TLSConfig{
-			Enabled:  cfg.Postgres.TLS.Enabled,
-			CAFile:   cfg.Postgres.TLS.CAFile,
-			CertFile: cfg.Postgres.TLS.CertFile,
-			KeyFile:  cfg.Postgres.TLS.KeyFile,
-		},
-	})
+	pdb, err := postgres.New(ctx, cfg.Postgres.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/analytics-service/main.go
+++ b/cmd/analytics-service/main.go
@@ -49,24 +49,7 @@ func run() int {
 		return ExitError
 	}
 
-	pdb, err := postgres.New(ctx, &postgres.Config{
-		Host:        cfg.Postgres.Host,
-		Port:        cfg.Postgres.Port,
-		User:        cfg.Postgres.User,
-		Password:    cfg.Postgres.Password,
-		Database:    cfg.Postgres.Database,
-		MaxConns:    cfg.Postgres.MaxConns,
-		MinConns:    cfg.Postgres.MinConns,
-		MaxConnLife: cfg.Postgres.MaxConnLife,
-		MaxConnIdle: cfg.Postgres.MaxConnIdle,
-		DialTimeout: cfg.Postgres.DialTimeout,
-		TLSConfig: &postgres.TLSConfig{
-			Enabled:  cfg.Postgres.TLS.Enabled,
-			CAFile:   cfg.Postgres.TLS.CAFile,
-			CertFile: cfg.Postgres.TLS.CertFile,
-			KeyFile:  cfg.Postgres.TLS.KeyFile,
-		},
-	})
+	pdb, err := postgres.New(ctx, cfg.Postgres.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/database-migration/main.go
+++ b/cmd/database-migration/main.go
@@ -76,22 +76,7 @@ func run() int {
 		pgDSN += fmt.Sprintf("?sslmode=%s", "disable")
 	}
 
-	clickhouseClient, err := clickhouse.New(ctx, &clickhouse.Config{
-		Hosts:           cfg.ClickHouse.Hosts,
-		Database:        cfg.ClickHouse.Database,
-		Username:        cfg.ClickHouse.Username,
-		Password:        cfg.ClickHouse.Password,
-		MaxOpenConns:    cfg.ClickHouse.MaxOpenConns,
-		MaxIdleConns:    cfg.ClickHouse.MaxIdleConns,
-		ConnMaxLifetime: cfg.ClickHouse.ConnMaxLifetime,
-		DialTimeout:     cfg.ClickHouse.DialTimeout,
-		TLSConfig: &clickhouse.TLSConfig{
-			Enabled:  cfg.ClickHouse.TLS.Enabled,
-			CAFile:   cfg.ClickHouse.TLS.CAFile,
-			CertFile: cfg.ClickHouse.TLS.CertFile,
-			KeyFile:  cfg.ClickHouse.TLS.KeyFile,
-		},
-	})
+	clickhouseClient, err := clickhouse.New(ctx, cfg.ClickHouse.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/execution-worker/main.go
+++ b/cmd/execution-worker/main.go
@@ -89,25 +89,7 @@ func run() int {
 	}
 	defer kfk.Close()
 
-	rdb, err := redis.New(ctx, &redis.Config{
-		Host:                     cfg.Redis.Host,
-		Port:                     cfg.Redis.Port,
-		Password:                 cfg.Redis.Password,
-		DB:                       cfg.Redis.DB,
-		PoolSize:                 cfg.Redis.PoolSize,
-		MinIdleConns:             cfg.Redis.MinIdleConns,
-		ReadTimeout:              cfg.Redis.ReadTimeout,
-		WriteTimeout:             cfg.Redis.WriteTimeout,
-		MaxMemory:                cfg.Redis.MaxMemory,
-		EvictionPolicy:           cfg.Redis.EvictionPolicy,
-		EvictionPolicySampleSize: cfg.Redis.EvictionPolicySampleSize,
-		TLSConfig: &redis.TLSConfig{
-			Enabled:  cfg.Redis.TLS.Enabled,
-			CAFile:   cfg.Redis.TLS.CAFile,
-			CertFile: cfg.Redis.TLS.CertFile,
-			KeyFile:  cfg.Redis.TLS.KeyFile,
-		},
-	})
+	rdb, err := redis.New(ctx, cfg.Redis.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
@@ -145,16 +127,7 @@ func run() int {
 	}()
 
 	workflowsConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.WorkflowsService.Host,
-			Port: cfg.WorkflowsService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.WorkflowsService.TLS.Enabled,
-				CAFile:         cfg.WorkflowsService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.WorkflowsService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		executionWorkerRetryConfig(),
 	)
@@ -165,16 +138,7 @@ func run() int {
 	defer workflowsConn.Close()
 
 	jobsConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.JobsService.Host,
-			Port: cfg.JobsService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.JobsService.TLS.Enabled,
-				CAFile:         cfg.JobsService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.JobsService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		executionWorkerRetryConfig(),
 	)

--- a/cmd/joblogs-processor/main.go
+++ b/cmd/joblogs-processor/main.go
@@ -51,71 +51,21 @@ func run() int {
 		return ExitError
 	}
 
-	rdb, err := redis.New(ctx, &redis.Config{
-		Host:                     cfg.Redis.Host,
-		Port:                     cfg.Redis.Port,
-		Password:                 cfg.Redis.Password,
-		DB:                       cfg.Redis.DB,
-		PoolSize:                 cfg.Redis.PoolSize,
-		MinIdleConns:             cfg.Redis.MinIdleConns,
-		ReadTimeout:              cfg.Redis.ReadTimeout,
-		WriteTimeout:             cfg.Redis.WriteTimeout,
-		MaxMemory:                cfg.Redis.MaxMemory,
-		EvictionPolicy:           cfg.Redis.EvictionPolicy,
-		EvictionPolicySampleSize: cfg.Redis.EvictionPolicySampleSize,
-		TLSConfig: &redis.TLSConfig{
-			Enabled:  cfg.Redis.TLS.Enabled,
-			CAFile:   cfg.Redis.TLS.CAFile,
-			CertFile: cfg.Redis.TLS.CertFile,
-			KeyFile:  cfg.Redis.TLS.KeyFile,
-		},
-	})
+	rdb, err := redis.New(ctx, cfg.Redis.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 	defer rdb.Close()
 
-	pg, err := postgres.New(ctx, &postgres.Config{
-		Host:        cfg.Postgres.Host,
-		Port:        cfg.Postgres.Port,
-		User:        cfg.Postgres.User,
-		Password:    cfg.Postgres.Password,
-		Database:    cfg.Postgres.Database,
-		MaxConns:    cfg.Postgres.MaxConns,
-		MinConns:    cfg.Postgres.MinConns,
-		MaxConnLife: cfg.Postgres.MaxConnLife,
-		MaxConnIdle: cfg.Postgres.MaxConnIdle,
-		DialTimeout: cfg.Postgres.DialTimeout,
-		TLSConfig: &postgres.TLSConfig{
-			Enabled:  cfg.Postgres.TLS.Enabled,
-			CAFile:   cfg.Postgres.TLS.CAFile,
-			CertFile: cfg.Postgres.TLS.CertFile,
-			KeyFile:  cfg.Postgres.TLS.KeyFile,
-		},
-	})
+	pg, err := postgres.New(ctx, cfg.Postgres.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 	defer pg.Close()
 
-	cdb, err := clickhouse.New(ctx, &clickhouse.Config{
-		Hosts:           cfg.ClickHouse.Hosts,
-		Database:        cfg.ClickHouse.Database,
-		Username:        cfg.ClickHouse.Username,
-		Password:        cfg.ClickHouse.Password,
-		MaxOpenConns:    cfg.ClickHouse.MaxOpenConns,
-		MaxIdleConns:    cfg.ClickHouse.MaxIdleConns,
-		ConnMaxLifetime: cfg.ClickHouse.ConnMaxLifetime,
-		DialTimeout:     cfg.ClickHouse.DialTimeout,
-		TLSConfig: &clickhouse.TLSConfig{
-			Enabled:  cfg.ClickHouse.TLS.Enabled,
-			CAFile:   cfg.ClickHouse.TLS.CAFile,
-			CertFile: cfg.ClickHouse.TLS.CertFile,
-			KeyFile:  cfg.ClickHouse.TLS.KeyFile,
-		},
-	})
+	cdb, err := clickhouse.New(ctx, cfg.ClickHouse.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/jobs-service/main.go
+++ b/cmd/jobs-service/main.go
@@ -55,71 +55,29 @@ func run() int {
 		return ExitError
 	}
 
-	pdb, err := postgres.New(ctx, &postgres.Config{
-		Host:        cfg.Postgres.Host,
-		Port:        cfg.Postgres.Port,
-		User:        cfg.Postgres.User,
-		Password:    cfg.Postgres.Password,
-		Database:    cfg.Postgres.Database,
-		MaxConns:    cfg.Postgres.MaxConns,
-		MinConns:    cfg.Postgres.MinConns,
-		MaxConnLife: cfg.Postgres.MaxConnLife,
-		MaxConnIdle: cfg.Postgres.MaxConnIdle,
-		DialTimeout: cfg.Postgres.DialTimeout,
-		TLSConfig: &postgres.TLSConfig{
-			Enabled:  cfg.Postgres.TLS.Enabled,
-			CAFile:   cfg.Postgres.TLS.CAFile,
-			CertFile: cfg.Postgres.TLS.CertFile,
-			KeyFile:  cfg.Postgres.TLS.KeyFile,
-		},
-	})
+	pdb, err := postgres.New(ctx, cfg.Postgres.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 	defer pdb.Close()
 
-	rdb, err := redis.New(ctx, &redis.Config{
-		Host:                     cfg.Redis.Host,
-		Port:                     cfg.Redis.Port,
-		Password:                 cfg.Redis.Password,
-		DB:                       cfg.Redis.DB,
-		PoolSize:                 cfg.Redis.PoolSize,
-		MinIdleConns:             cfg.Redis.MinIdleConns,
-		ReadTimeout:              cfg.Redis.ReadTimeout,
-		WriteTimeout:             cfg.Redis.WriteTimeout,
-		MaxMemory:                cfg.Redis.MaxMemory,
-		EvictionPolicy:           cfg.Redis.EvictionPolicy,
-		EvictionPolicySampleSize: cfg.Redis.EvictionPolicySampleSize,
-		TLSConfig: &redis.TLSConfig{
-			Enabled:  cfg.Redis.TLS.Enabled,
-			CAFile:   cfg.Redis.TLS.CAFile,
-			CertFile: cfg.Redis.TLS.CertFile,
-			KeyFile:  cfg.Redis.TLS.KeyFile,
-		},
-	})
+	rdb, err := redis.New(ctx, cfg.Redis.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 	defer rdb.Close()
 
-	cdb, err := clickhouse.New(ctx, &clickhouse.Config{
-		Hosts:           cfg.ClickHouse.Hosts,
-		Database:        cfg.ClickHouse.Database,
-		Username:        cfg.ClickHouse.Username,
-		Password:        cfg.ClickHouse.Password,
-		MaxOpenConns:    cfg.ClickHouse.MaxOpenConns,
-		MaxIdleConns:    cfg.ClickHouse.MaxIdleConns,
-		ConnMaxLifetime: cfg.ClickHouse.ConnMaxLifetime,
-		DialTimeout:     cfg.ClickHouse.DialTimeout,
-		TLSConfig: &clickhouse.TLSConfig{
-			Enabled:  cfg.Redis.TLS.Enabled,
-			CAFile:   cfg.Redis.TLS.CAFile,
-			CertFile: cfg.Redis.TLS.CertFile,
-			KeyFile:  cfg.Redis.TLS.KeyFile,
-		},
-	})
+	clickhouseCfg := cfg.ClickHouse.ClientConfig()
+	// Preserve the existing jobs-service TLS source during config deduplication.
+	clickhouseCfg.TLSConfig = &clickhouse.TLSConfig{
+		Enabled:  cfg.Redis.TLS.Enabled,
+		CAFile:   cfg.Redis.TLS.CAFile,
+		CertFile: cfg.Redis.TLS.CertFile,
+		KeyFile:  cfg.Redis.TLS.KeyFile,
+	}
+	cdb, err := clickhouse.New(ctx, clickhouseCfg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
@@ -139,16 +97,7 @@ func run() int {
 	defer msdb.Close()
 
 	workflowsConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.WorkflowsService.Host,
-			Port: cfg.WorkflowsService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.WorkflowsService.TLS.Enabled,
-				CAFile:         cfg.WorkflowsService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.WorkflowsService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		grpcclient.DefaultRetryConfig(),
 	)

--- a/cmd/notifications-service/main.go
+++ b/cmd/notifications-service/main.go
@@ -53,16 +53,7 @@ func run() int {
 	}
 
 	usersConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.UsersService.Host,
-			Port: cfg.UsersService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.UsersService.TLS.Enabled,
-				CAFile:         cfg.UsersService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.UsersService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		grpcclient.DefaultRetryConfig(),
 	)
@@ -72,24 +63,7 @@ func run() int {
 	}
 	defer usersConn.Close()
 
-	pdb, err := postgres.New(ctx, &postgres.Config{
-		Host:        cfg.Postgres.Host,
-		Port:        cfg.Postgres.Port,
-		User:        cfg.Postgres.User,
-		Password:    cfg.Postgres.Password,
-		Database:    cfg.Postgres.Database,
-		MaxConns:    cfg.Postgres.MaxConns,
-		MinConns:    cfg.Postgres.MinConns,
-		MaxConnLife: cfg.Postgres.MaxConnLife,
-		MaxConnIdle: cfg.Postgres.MaxConnIdle,
-		DialTimeout: cfg.Postgres.DialTimeout,
-		TLSConfig: &postgres.TLSConfig{
-			Enabled:  cfg.Postgres.TLS.Enabled,
-			CAFile:   cfg.Postgres.TLS.CAFile,
-			CertFile: cfg.Postgres.TLS.CertFile,
-			KeyFile:  cfg.Postgres.TLS.KeyFile,
-		},
-	})
+	pdb, err := postgres.New(ctx, cfg.Postgres.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/outbox-relay/main.go
+++ b/cmd/outbox-relay/main.go
@@ -47,24 +47,7 @@ func run() int {
 		return ExitError
 	}
 
-	pdb, err := postgres.New(ctx, &postgres.Config{
-		Host:        cfg.Postgres.Host,
-		Port:        cfg.Postgres.Port,
-		User:        cfg.Postgres.User,
-		Password:    cfg.Postgres.Password,
-		Database:    cfg.Postgres.Database,
-		MaxConns:    cfg.Postgres.MaxConns,
-		MinConns:    cfg.Postgres.MinConns,
-		MaxConnLife: cfg.Postgres.MaxConnLife,
-		MaxConnIdle: cfg.Postgres.MaxConnIdle,
-		DialTimeout: cfg.Postgres.DialTimeout,
-		TLSConfig: &postgres.TLSConfig{
-			Enabled:  cfg.Postgres.TLS.Enabled,
-			CAFile:   cfg.Postgres.TLS.CAFile,
-			CertFile: cfg.Postgres.TLS.CertFile,
-			KeyFile:  cfg.Postgres.TLS.KeyFile,
-		},
-	})
+	pdb, err := postgres.New(ctx, cfg.Postgres.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/runtime-agent/main.go
+++ b/cmd/runtime-agent/main.go
@@ -53,24 +53,7 @@ func run() int {
 		return ExitError
 	}
 
-	pdb, err := postgres.New(ctx, &postgres.Config{
-		Host:        cfg.Postgres.Host,
-		Port:        cfg.Postgres.Port,
-		User:        cfg.Postgres.User,
-		Password:    cfg.Postgres.Password,
-		Database:    cfg.Postgres.Database,
-		MaxConns:    cfg.Postgres.MaxConns,
-		MinConns:    cfg.Postgres.MinConns,
-		MaxConnLife: cfg.Postgres.MaxConnLife,
-		MaxConnIdle: cfg.Postgres.MaxConnIdle,
-		DialTimeout: cfg.Postgres.DialTimeout,
-		TLSConfig: &postgres.TLSConfig{
-			Enabled:  cfg.Postgres.TLS.Enabled,
-			CAFile:   cfg.Postgres.TLS.CAFile,
-			CertFile: cfg.Postgres.TLS.CertFile,
-			KeyFile:  cfg.Postgres.TLS.KeyFile,
-		},
-	})
+	pdb, err := postgres.New(ctx, cfg.Postgres.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/scheduling-worker/main.go
+++ b/cmd/scheduling-worker/main.go
@@ -47,24 +47,7 @@ func run() int {
 		return ExitError
 	}
 
-	pdb, err := postgres.New(ctx, &postgres.Config{
-		Host:        cfg.Postgres.Host,
-		Port:        cfg.Postgres.Port,
-		User:        cfg.Postgres.User,
-		Password:    cfg.Postgres.Password,
-		Database:    cfg.Postgres.Database,
-		MaxConns:    cfg.Postgres.MaxConns,
-		MinConns:    cfg.Postgres.MinConns,
-		MaxConnLife: cfg.Postgres.MaxConnLife,
-		MaxConnIdle: cfg.Postgres.MaxConnIdle,
-		DialTimeout: cfg.Postgres.DialTimeout,
-		TLSConfig: &postgres.TLSConfig{
-			Enabled:  cfg.Postgres.TLS.Enabled,
-			CAFile:   cfg.Postgres.TLS.CAFile,
-			CertFile: cfg.Postgres.TLS.CertFile,
-			KeyFile:  cfg.Postgres.TLS.KeyFile,
-		},
-	})
+	pdb, err := postgres.New(ctx, cfg.Postgres.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -58,16 +58,7 @@ func run() int {
 	}
 
 	usersConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.UsersService.Host,
-			Port: cfg.UsersService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.UsersService.TLS.Enabled,
-				CAFile:         cfg.UsersService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.UsersService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		grpcclient.DefaultRetryConfig(),
 	)
@@ -78,16 +69,7 @@ func run() int {
 	defer usersConn.Close()
 
 	workflowsConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.WorkflowsService.Host,
-			Port: cfg.WorkflowsService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.WorkflowsService.TLS.Enabled,
-				CAFile:         cfg.WorkflowsService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.WorkflowsService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		grpcclient.DefaultRetryConfig(),
 	)
@@ -98,16 +80,7 @@ func run() int {
 	defer workflowsConn.Close()
 
 	jobsConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.JobsService.Host,
-			Port: cfg.JobsService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.JobsService.TLS.Enabled,
-				CAFile:         cfg.JobsService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.JobsService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		grpcclient.DefaultRetryConfig(),
 	)
@@ -118,16 +91,7 @@ func run() int {
 	defer jobsConn.Close()
 
 	notificationsConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.NotificationsService.Host,
-			Port: cfg.NotificationsService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.NotificationsService.TLS.Enabled,
-				CAFile:         cfg.NotificationsService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.NotificationsService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		grpcclient.DefaultRetryConfig(),
 	)
@@ -138,16 +102,7 @@ func run() int {
 	defer notificationsConn.Close()
 
 	analyticsConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.AnalyticsService.Host,
-			Port: cfg.AnalyticsService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.AnalyticsService.TLS.Enabled,
-				CAFile:         cfg.AnalyticsService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.AnalyticsService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		grpcclient.DefaultRetryConfig(),
 	)
@@ -157,25 +112,7 @@ func run() int {
 	}
 	defer analyticsConn.Close()
 
-	rdb, err := redis.New(ctx, &redis.Config{
-		Host:                     cfg.Redis.Host,
-		Port:                     cfg.Redis.Port,
-		Password:                 cfg.Redis.Password,
-		DB:                       cfg.Redis.DB,
-		PoolSize:                 cfg.Redis.PoolSize,
-		MinIdleConns:             cfg.Redis.MinIdleConns,
-		ReadTimeout:              cfg.Redis.ReadTimeout,
-		WriteTimeout:             cfg.Redis.WriteTimeout,
-		MaxMemory:                cfg.Redis.MaxMemory,
-		EvictionPolicy:           cfg.Redis.EvictionPolicy,
-		EvictionPolicySampleSize: cfg.Redis.EvictionPolicySampleSize,
-		TLSConfig: &redis.TLSConfig{
-			Enabled:  cfg.Redis.TLS.Enabled,
-			CAFile:   cfg.Redis.TLS.CAFile,
-			CertFile: cfg.Redis.TLS.CertFile,
-			KeyFile:  cfg.Redis.TLS.KeyFile,
-		},
-	})
+	rdb, err := redis.New(ctx, cfg.Redis.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/users-service/main.go
+++ b/cmd/users-service/main.go
@@ -50,49 +50,14 @@ func run() int {
 		return ExitError
 	}
 
-	pdb, err := postgres.New(ctx, &postgres.Config{
-		Host:        cfg.Postgres.Host,
-		Port:        cfg.Postgres.Port,
-		User:        cfg.Postgres.User,
-		Password:    cfg.Postgres.Password,
-		Database:    cfg.Postgres.Database,
-		MaxConns:    cfg.Postgres.MaxConns,
-		MinConns:    cfg.Postgres.MinConns,
-		MaxConnLife: cfg.Postgres.MaxConnLife,
-		MaxConnIdle: cfg.Postgres.MaxConnIdle,
-		DialTimeout: cfg.Postgres.DialTimeout,
-		TLSConfig: &postgres.TLSConfig{
-			Enabled:  cfg.Postgres.TLS.Enabled,
-			CAFile:   cfg.Postgres.TLS.CAFile,
-			CertFile: cfg.Postgres.TLS.CertFile,
-			KeyFile:  cfg.Postgres.TLS.KeyFile,
-		},
-	})
+	pdb, err := postgres.New(ctx, cfg.Postgres.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 	defer pdb.Close()
 
-	rdb, err := redis.New(ctx, &redis.Config{
-		Host:                     cfg.Redis.Host,
-		Port:                     cfg.Redis.Port,
-		Password:                 cfg.Redis.Password,
-		DB:                       cfg.Redis.DB,
-		PoolSize:                 cfg.Redis.PoolSize,
-		MinIdleConns:             cfg.Redis.MinIdleConns,
-		ReadTimeout:              cfg.Redis.ReadTimeout,
-		WriteTimeout:             cfg.Redis.WriteTimeout,
-		MaxMemory:                cfg.Redis.MaxMemory,
-		EvictionPolicy:           cfg.Redis.EvictionPolicy,
-		EvictionPolicySampleSize: cfg.Redis.EvictionPolicySampleSize,
-		TLSConfig: &redis.TLSConfig{
-			Enabled:  cfg.Redis.TLS.Enabled,
-			CAFile:   cfg.Redis.TLS.CAFile,
-			CertFile: cfg.Redis.TLS.CertFile,
-			KeyFile:  cfg.Redis.TLS.KeyFile,
-		},
-	})
+	rdb, err := redis.New(ctx, cfg.Redis.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/cmd/workflow-worker/main.go
+++ b/cmd/workflow-worker/main.go
@@ -64,47 +64,14 @@ func run() int {
 		return ExitError
 	}
 
-	rdb, err := redis.New(ctx, &redis.Config{
-		Host:                     cfg.Redis.Host,
-		Port:                     cfg.Redis.Port,
-		Password:                 cfg.Redis.Password,
-		DB:                       cfg.Redis.DB,
-		PoolSize:                 cfg.Redis.PoolSize,
-		MinIdleConns:             cfg.Redis.MinIdleConns,
-		ReadTimeout:              cfg.Redis.ReadTimeout,
-		WriteTimeout:             cfg.Redis.WriteTimeout,
-		MaxMemory:                cfg.Redis.MaxMemory,
-		EvictionPolicy:           cfg.Redis.EvictionPolicy,
-		EvictionPolicySampleSize: cfg.Redis.EvictionPolicySampleSize,
-		TLSConfig: &redis.TLSConfig{
-			Enabled:  cfg.Redis.TLS.Enabled,
-			CAFile:   cfg.Redis.TLS.CAFile,
-			CertFile: cfg.Redis.TLS.CertFile,
-			KeyFile:  cfg.Redis.TLS.KeyFile,
-		},
-	})
+	rdb, err := redis.New(ctx, cfg.Redis.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 	defer rdb.Close()
 
-	cdb, err := clickhouse.New(ctx, &clickhouse.Config{
-		Hosts:           cfg.ClickHouse.Hosts,
-		Database:        cfg.ClickHouse.Database,
-		Username:        cfg.ClickHouse.Username,
-		Password:        cfg.ClickHouse.Password,
-		MaxOpenConns:    cfg.ClickHouse.MaxOpenConns,
-		MaxIdleConns:    cfg.ClickHouse.MaxIdleConns,
-		ConnMaxLifetime: cfg.ClickHouse.ConnMaxLifetime,
-		DialTimeout:     cfg.ClickHouse.DialTimeout,
-		TLSConfig: &clickhouse.TLSConfig{
-			Enabled:  cfg.ClickHouse.TLS.Enabled,
-			CAFile:   cfg.ClickHouse.TLS.CAFile,
-			CertFile: cfg.ClickHouse.TLS.CertFile,
-			KeyFile:  cfg.ClickHouse.TLS.KeyFile,
-		},
-	})
+	cdb, err := clickhouse.New(ctx, cfg.ClickHouse.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
@@ -174,16 +141,7 @@ func run() int {
 	}
 
 	workflowsConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.WorkflowsService.Host,
-			Port: cfg.WorkflowsService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.WorkflowsService.TLS.Enabled,
-				CAFile:         cfg.WorkflowsService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.WorkflowsService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		grpcclient.DefaultRetryConfig(),
 	)
@@ -194,16 +152,7 @@ func run() int {
 	defer workflowsConn.Close()
 
 	jobsConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.JobsService.Host,
-			Port: cfg.JobsService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.JobsService.TLS.Enabled,
-				CAFile:         cfg.JobsService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.JobsService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		grpcclient.DefaultRetryConfig(),
 	)
@@ -214,16 +163,7 @@ func run() int {
 	defer jobsConn.Close()
 
 	notificationsConn, err := grpcclient.NewClient(
-		&grpcclient.ServiceConfig{
-			Host: cfg.NotificationsService.Host,
-			Port: cfg.NotificationsService.Port,
-			TLS: &grpcclient.TLSConfig{
-				Enabled:        cfg.NotificationsService.TLS.Enabled,
-				CAFile:         cfg.NotificationsService.TLS.CAFile,
-				ClientCertFile: cfg.ClientTLS.CertFile,
-				ClientKeyFile:  cfg.ClientTLS.KeyFile,
-			},
-		},
+		cfg.NotificationsService.ClientConfig(cfg.ClientTLS),
 		grpcclient.DefaultCircuitBreakerConfig(),
 		grpcclient.DefaultRetryConfig(),
 	)

--- a/cmd/workflows-service/main.go
+++ b/cmd/workflows-service/main.go
@@ -50,49 +50,14 @@ func run() int {
 		return ExitError
 	}
 
-	pdb, err := postgres.New(ctx, &postgres.Config{
-		Host:        cfg.Postgres.Host,
-		Port:        cfg.Postgres.Port,
-		User:        cfg.Postgres.User,
-		Password:    cfg.Postgres.Password,
-		Database:    cfg.Postgres.Database,
-		MaxConns:    cfg.Postgres.MaxConns,
-		MinConns:    cfg.Postgres.MinConns,
-		MaxConnLife: cfg.Postgres.MaxConnLife,
-		MaxConnIdle: cfg.Postgres.MaxConnIdle,
-		DialTimeout: cfg.Postgres.DialTimeout,
-		TLSConfig: &postgres.TLSConfig{
-			Enabled:  cfg.Postgres.TLS.Enabled,
-			CAFile:   cfg.Postgres.TLS.CAFile,
-			CertFile: cfg.Postgres.TLS.CertFile,
-			KeyFile:  cfg.Postgres.TLS.KeyFile,
-		},
-	})
+	pdb, err := postgres.New(ctx, cfg.Postgres.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError
 	}
 	defer pdb.Close()
 
-	rdb, err := redis.New(ctx, &redis.Config{
-		Host:                     cfg.Redis.Host,
-		Port:                     cfg.Redis.Port,
-		Password:                 cfg.Redis.Password,
-		DB:                       cfg.Redis.DB,
-		PoolSize:                 cfg.Redis.PoolSize,
-		MinIdleConns:             cfg.Redis.MinIdleConns,
-		ReadTimeout:              cfg.Redis.ReadTimeout,
-		WriteTimeout:             cfg.Redis.WriteTimeout,
-		MaxMemory:                cfg.Redis.MaxMemory,
-		EvictionPolicy:           cfg.Redis.EvictionPolicy,
-		EvictionPolicySampleSize: cfg.Redis.EvictionPolicySampleSize,
-		TLSConfig: &redis.TLSConfig{
-			Enabled:  cfg.Redis.TLS.Enabled,
-			CAFile:   cfg.Redis.TLS.CAFile,
-			CertFile: cfg.Redis.TLS.CertFile,
-			KeyFile:  cfg.Redis.TLS.KeyFile,
-		},
-	})
+	rdb, err := redis.New(ctx, cfg.Redis.ClientConfig())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return ExitError

--- a/dashboard/src/features/workflows/create-workflow-dialog.tsx
+++ b/dashboard/src/features/workflows/create-workflow-dialog.tsx
@@ -5,8 +5,7 @@ import { WorkflowNumberField, ContainerListField } from "./workflow-form-fields"
 import { Fragment } from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm, useWatch, type Resolver } from "react-hook-form"
-import { z } from "zod"
-import { Duration, parseDuration } from '@alwatr/parse-duration'
+import { createWorkflowSchema } from "./workflow-schemas"
 import {
     Loader2,
     Plus,
@@ -51,87 +50,6 @@ import {
 
 import { useWorkflows } from "@/features/workflows/use-workflows"
 
-const baseCreateWorkflowSchema = z.object({
-    name: z.string().trim().min(3, "Name must be at least 3 characters").max(50, "Name must be at most 50 characters"),
-    interval: z.union([
-        z.string().trim().refine(val => val === "" || /^\d+$/.test(val), {
-            message: "Please enter a valid number"
-        }),
-        z.number()
-    ])
-        .transform(val => val === "" ? undefined : Number(val))
-        .refine(val => val === undefined || (val >= 1 && val <= 10080), {
-            message: "Must be between 1 and 10080 minutes (1 week)"
-        }),
-    maxConsecutiveJobFailuresAllowed: z.coerce.number().int().min(3).max(100).default(3),
-    retainLogs: z.boolean().default(true)
-})
-
-const heartbeatPayloadSchema = z.object({
-    endpoint: z.url().trim().refine(val => val !== "", {
-        message: "Please enter a valid URL"
-    }),
-    expectedStatusCode: z.coerce.number().int().min(100).max(599).default(200).refine(val => val >= 100 && val <= 599, {
-        message: "Expected status code must be between 100 and 599"
-    }),
-    headers: z.array(
-        z.object({
-            key: z.string().trim().min(1, "Header key is required"),
-            value: z.string().trim()
-        })
-    ).default([]),
-    timeout: z.string().default("")
-        .refine(val => {
-            if (!val) return true
-            try {
-                const parsed = parseDuration(val as unknown as Duration, 's')
-                return parsed > 0 && parsed <= 300
-            } catch {
-                return false
-            }
-        }, "Timeout must be a valid duration (e.g., '30s', '1m') max up to 5 minutes")
-})
-
-const containerPayloadSchema = z.object({
-    image: z.string().trim().min(1, "Container image is required"),
-    cmd: z.array(z.string().trim())
-        .optional()
-        .default([])
-        .transform(val => val?.filter(item => item !== "") || []),
-    env: z.array(z.string().trim())
-        .optional()
-        .default([])
-        .transform(val => val?.filter(item => item !== "") || []),
-    timeout: z.string().default("")
-        .refine(val => {
-            if (!val) return true
-            try {
-                const parsed = parseDuration(val as unknown as Duration, 's')
-                return parsed > 0 && parsed <= 3600
-            } catch {
-                return false
-            }
-        }, "Timeout must be a valid duration (e.g., '30s', '5m') max up to 1 hour")
-})
-
-const heartbeatWorkflowSchema = baseCreateWorkflowSchema.extend({
-    kind: z.literal("HEARTBEAT"),
-    heartbeatPayload: heartbeatPayloadSchema,
-}).transform(data => ({
-    ...data,
-    retainLogs: false // HEARTBEAT workflows always have log_retention as false
-}))
-
-const containerWorkflowSchema = baseCreateWorkflowSchema.extend({
-    kind: z.literal("CONTAINER"),
-    containerPayload: containerPayloadSchema,
-})
-
-const workflowSchema = z.discriminatedUnion("kind", [
-    heartbeatWorkflowSchema,
-    containerWorkflowSchema
-])
-
 type HeaderFormValue = {
     id?: string
     key: string
@@ -175,7 +93,7 @@ type KindType = keyof typeof kindType
 export function CreateWorkflowDialog({ open, onOpenChange }: CreateWorkflowDialogProps) {
     const { createWorkflow, isCreating } = useWorkflows()
     const form = useForm<WorkflowFormValues>({
-        resolver: zodResolver(workflowSchema) as Resolver<WorkflowFormValues>,
+        resolver: zodResolver(createWorkflowSchema) as Resolver<WorkflowFormValues>,
         defaultValues: {
             name: "",
             kind: "HEARTBEAT",

--- a/dashboard/src/features/workflows/update-workflow-dialog.tsx
+++ b/dashboard/src/features/workflows/update-workflow-dialog.tsx
@@ -5,8 +5,7 @@ import { WorkflowNumberField, ContainerListField } from "./workflow-form-fields"
 import { Fragment, useEffect } from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm, useWatch, type Resolver } from "react-hook-form"
-import { z } from "zod"
-import { Duration, parseDuration } from "@alwatr/parse-duration"
+import { updateWorkflowSchema } from "./workflow-schemas"
 import {
     Loader2,
     Plus,
@@ -40,75 +39,6 @@ import {
 } from "@/components/ui/card"
 
 import { useWorkflowDetails } from "@/features/workflows/use-workflow-details"
-
-const baseUpdateWorkflowSchema = z.object({
-    name: z.string().trim().min(3, "Name must be at least 3 characters").max(50, "Name must be at most 50 characters"),
-    interval: z.union([
-        z.string().trim().refine(val => val === "" || /^\d+$/.test(val), {
-            message: "Please enter a valid number"
-        }),
-        z.number()
-    ])
-        .transform(val => val === "" ? undefined : Number(val))
-        .refine(val => val === undefined || (val >= 1 && val <= 10080), {
-            message: "Must be between 1 and 10080 minutes (1 week)"
-        }),
-    maxConsecutiveJobFailuresAllowed: z.coerce.number().int().min(3).max(100).default(3).refine(val => val >= 3, {
-        message: "Maximum consecutive job failures allowed must be at least 3"
-    })
-})
-
-const heartbeatPayloadSchema = z.object({
-    endpoint: z.url().trim().refine(val => val !== "", {
-        message: "Please enter a valid URL"
-    }),
-    expectedStatusCode: z.coerce.number().int().min(100).max(599).refine(val => val >= 100 && val <= 599, {
-        message: "Expected status code must be between 100 and 599"
-    }),
-    headers: z.array(
-        z.object({
-            key: z.string().trim().min(1, "Header key is required"),
-            value: z.string().trim()
-        })
-    ).default([]),
-    timeout: z.string().default("")
-        .refine(val => {
-            if (!val) return true
-            try {
-                const parsed = parseDuration(val as unknown as Duration, 's')
-                return parsed > 0 && parsed <= 300
-            } catch {
-                return false
-            }
-        }, "Timeout must be a valid duration (e.g., '30s', '1m') max up to 5 minutes")
-})
-
-const containerPayloadSchema = z.object({
-    image: z.string().trim().min(1, "Container image is required"),
-    cmd: z.array(z.string().trim())
-        .optional()
-        .default([])
-        .transform(val => val?.filter(item => item !== "") || []),
-    env: z.array(z.string().trim())
-        .optional()
-        .default([])
-        .transform(val => val?.filter(item => item !== "") || []),
-    timeout: z.string().default("")
-        .refine(val => {
-            if (!val) return true
-            try {
-                const parsed = parseDuration(val as unknown as Duration, 's')
-                return parsed > 0 && parsed <= 3600
-            } catch {
-                return false
-            }
-        }, "Timeout must be a valid duration (e.g., '30s', '5m') max up to 1 hour")
-})
-
-const updateWorkflowSchema = baseUpdateWorkflowSchema.extend({
-    heartbeatPayload: heartbeatPayloadSchema.optional(),
-    containerPayload: containerPayloadSchema.optional(),
-})
 
 type HeaderFormValue = {
     id?: string

--- a/dashboard/src/features/workflows/workflow-schemas.test.ts
+++ b/dashboard/src/features/workflows/workflow-schemas.test.ts
@@ -1,0 +1,60 @@
+import { expect, it } from "vitest"
+import { createWorkflowSchema, updateWorkflowSchema } from "./workflow-schemas"
+
+const base = { name: " My workflow ", interval: "5" }
+const heartbeat = { endpoint: "https://example.com", expectedStatusCode: "200" }
+
+it("preserves create-only defaults and update payload optionality", () => {
+    expect(createWorkflowSchema.parse({ ...base, kind: "HEARTBEAT", retainLogs: true, heartbeatPayload: { endpoint: heartbeat.endpoint } })).toEqual({
+        name: "My workflow", interval: 5, maxConsecutiveJobFailuresAllowed: 3, kind: "HEARTBEAT", retainLogs: false,
+        heartbeatPayload: { endpoint: heartbeat.endpoint, expectedStatusCode: 200, headers: [], timeout: "" },
+    })
+    expect(createWorkflowSchema.parse({ ...base, kind: "CONTAINER", containerPayload: { image: " alpine " } })).toMatchObject({
+        retainLogs: true, containerPayload: { image: "alpine", cmd: [], env: [], timeout: "" },
+    })
+    expect(updateWorkflowSchema.parse(base)).toEqual({ name: "My workflow", interval: 5, maxConsecutiveJobFailuresAllowed: 3 })
+    expect(updateWorkflowSchema.safeParse({ ...base, heartbeatPayload: { endpoint: heartbeat.endpoint } }).success).toBe(false)
+    expect(createWorkflowSchema.safeParse({ ...base, kind: "HEARTBEAT" }).success).toBe(false)
+    expect(createWorkflowSchema.safeParse({ ...base, kind: "OTHER" }).success).toBe(false)
+})
+
+it.each([createWorkflowSchema, updateWorkflowSchema])("preserves shared validation and normalization %#", (schema) => {
+    const input = { ...base, kind: "HEARTBEAT", heartbeatPayload: heartbeat }
+    expect(schema.parse({ ...input, interval: "" }).interval).toBeUndefined()
+    for (const interval of ["1", "10080"]) {
+        expect(schema.parse({ ...input, interval }).interval).toBe(Number(interval))
+    }
+    for (const interval of ["0", "10081", "5m", "1.5"]) {
+        expect(schema.safeParse({ ...input, interval }).success).toBe(false)
+    }
+    for (const name of [" a ", "a".repeat(51)]) {
+        expect(schema.safeParse({ ...input, name }).success).toBe(false)
+    }
+    for (const maxConsecutiveJobFailuresAllowed of [2, 101, 3.5]) {
+        expect(schema.safeParse({ ...input, maxConsecutiveJobFailuresAllowed }).success).toBe(false)
+    }
+    for (const expectedStatusCode of [100, 599]) {
+        expect(schema.safeParse({ ...input, heartbeatPayload: { ...heartbeat, expectedStatusCode } }).success).toBe(true)
+    }
+    for (const expectedStatusCode of [99, 600, 200.5]) {
+        expect(schema.safeParse({ ...input, heartbeatPayload: { ...heartbeat, expectedStatusCode } }).success).toBe(false)
+    }
+    for (const payload of [{ ...heartbeat, endpoint: "invalid" }, { ...heartbeat, headers: [{ key: " ", value: "" }] }]) {
+        expect(schema.safeParse({ ...input, heartbeatPayload: payload }).success).toBe(false)
+    }
+    for (const [kind, field, payload, limit] of [
+        ["HEARTBEAT", "heartbeatPayload", heartbeat, 300],
+        ["CONTAINER", "containerPayload", { image: "alpine" }, 3600],
+    ] as const) {
+        for (const timeout of ["", `${limit}s`]) {
+            expect(schema.safeParse({ ...base, kind, [field]: { ...payload, timeout } }).success).toBe(true)
+        }
+        for (const timeout of ["0s", `${limit + 1}s`, "invalid"]) {
+            expect(schema.safeParse({ ...base, kind, [field]: { ...payload, timeout } }).success).toBe(false)
+        }
+    }
+    expect(schema.parse({ ...base, kind: "CONTAINER", containerPayload: { image: " alpine ", cmd: [" echo ", " "], env: [" A=1 ", ""] } })).toMatchObject({
+        containerPayload: { image: "alpine", cmd: ["echo"], env: ["A=1"], timeout: "" },
+    })
+    expect(schema.safeParse({ ...base, kind: "CONTAINER", containerPayload: { image: " " } }).success).toBe(false)
+})

--- a/dashboard/src/features/workflows/workflow-schemas.ts
+++ b/dashboard/src/features/workflows/workflow-schemas.ts
@@ -1,0 +1,96 @@
+import { z } from "zod"
+import { type Duration, parseDuration } from "@alwatr/parse-duration"
+
+const baseWorkflowSchema = z.object({
+    name: z.string().trim().min(3, "Name must be at least 3 characters").max(50, "Name must be at most 50 characters"),
+    interval: z.union([
+        z.string().trim().refine(val => val === "" || /^\d+$/.test(val), {
+            message: "Please enter a valid number"
+        }),
+        z.number()
+    ])
+        .transform(val => val === "" ? undefined : Number(val))
+        .refine(val => val === undefined || (val >= 1 && val <= 10080), {
+            message: "Must be between 1 and 10080 minutes (1 week)"
+        }),
+    maxConsecutiveJobFailuresAllowed: z.coerce.number().int().min(3).max(100).default(3)
+})
+
+const heartbeatPayloadSchema = z.object({
+    endpoint: z.url().trim().refine(val => val !== "", {
+        message: "Please enter a valid URL"
+    }),
+    expectedStatusCode: z.coerce.number().int().min(100).max(599).refine(val => val >= 100 && val <= 599, {
+        message: "Expected status code must be between 100 and 599"
+    }),
+    headers: z.array(
+        z.object({
+            key: z.string().trim().min(1, "Header key is required"),
+            value: z.string().trim()
+        })
+    ).default([]),
+    timeout: z.string().default("")
+        .refine(val => {
+            if (!val) return true
+            try {
+                const parsed = parseDuration(val as unknown as Duration, 's')
+                return parsed > 0 && parsed <= 300
+            } catch {
+                return false
+            }
+        }, "Timeout must be a valid duration (e.g., '30s', '1m') max up to 5 minutes")
+})
+
+const containerPayloadSchema = z.object({
+    image: z.string().trim().min(1, "Container image is required"),
+    cmd: z.array(z.string().trim())
+        .optional()
+        .default([])
+        .transform(val => val?.filter(item => item !== "") || []),
+    env: z.array(z.string().trim())
+        .optional()
+        .default([])
+        .transform(val => val?.filter(item => item !== "") || []),
+    timeout: z.string().default("")
+        .refine(val => {
+            if (!val) return true
+            try {
+                const parsed = parseDuration(val as unknown as Duration, 's')
+                return parsed > 0 && parsed <= 3600
+            } catch {
+                return false
+            }
+        }, "Timeout must be a valid duration (e.g., '30s', '5m') max up to 1 hour")
+})
+
+const baseCreateWorkflowSchema = baseWorkflowSchema.extend({
+    retainLogs: z.boolean().default(true),
+})
+
+const heartbeatWorkflowSchema = baseCreateWorkflowSchema.extend({
+    kind: z.literal("HEARTBEAT"),
+    heartbeatPayload: heartbeatPayloadSchema.extend({
+        expectedStatusCode: heartbeatPayloadSchema.shape.expectedStatusCode.default(200),
+    }),
+}).transform(data => ({
+    ...data,
+    retainLogs: false // HEARTBEAT workflows always have log_retention as false
+}))
+
+const containerWorkflowSchema = baseCreateWorkflowSchema.extend({
+    kind: z.literal("CONTAINER"),
+    containerPayload: containerPayloadSchema,
+})
+
+export const createWorkflowSchema = z.discriminatedUnion("kind", [
+    heartbeatWorkflowSchema,
+    containerWorkflowSchema
+])
+
+export const updateWorkflowSchema = baseWorkflowSchema.extend({
+    maxConsecutiveJobFailuresAllowed: baseWorkflowSchema.shape.maxConsecutiveJobFailuresAllowed.refine(val => val >= 3, {
+        message: "Maximum consecutive job failures allowed must be at least 3"
+    }),
+    heartbeatPayload: heartbeatPayloadSchema.optional(),
+    containerPayload: containerPayloadSchema.optional(),
+})

--- a/internal/app/analytics/analytics.go
+++ b/internal/app/analytics/analytics.go
@@ -4,9 +4,6 @@ package analytics
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"os"
 	"strings"
 	"time"
 
@@ -26,6 +23,7 @@ import (
 	analyticsmodel "github.com/hitesh22rana/chronoverse/internal/model/analytics"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	grpcmiddlewares "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/middlewares"
+	grpcserverpkg "github.com/hitesh22rana/chronoverse/internal/pkg/grpcserver"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
 	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
@@ -106,44 +104,10 @@ func New(ctx context.Context, cfg *Config, auth auth.IAuth, svc Service) *grpc.S
 
 	var serverOpts []grpc.ServerOption
 	if cfg.TLSConfig != nil && cfg.TLSConfig.Enabled {
-		// Load CA certificate
-		caCert, err := os.ReadFile(cfg.TLSConfig.CAFile)
+		config, err := grpcserverpkg.LoadTLSConfig(cfg.TLSConfig.CAFile, cfg.TLSConfig.CertFile, cfg.TLSConfig.KeyFile)
 		if err != nil {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to read CA certificate file",
-				zap.Error(err),
-				zap.String("ca_file", cfg.TLSConfig.CAFile),
-			)
+			loggerpkg.FromContext(ctx).Fatal("failed to load TLS credentials", zap.Error(err))
 			return nil
-		}
-
-		caCertPool := x509.NewCertPool()
-		if ok := caCertPool.AppendCertsFromPEM(caCert); !ok {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to append CA certificate to pool",
-				zap.String("ca_file", cfg.TLSConfig.CAFile),
-				zap.Error(err),
-			)
-			return nil
-		}
-
-		// Server certificate and private key
-		serverCert, err := tls.LoadX509KeyPair(cfg.TLSConfig.CertFile, cfg.TLSConfig.KeyFile)
-		if err != nil {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to load server certificate and key",
-				zap.Error(err),
-				zap.String("cert_file", cfg.TLSConfig.CertFile),
-				zap.String("key_file", cfg.TLSConfig.KeyFile),
-			)
-			return nil
-		}
-
-		config := &tls.Config{
-			Certificates: []tls.Certificate{serverCert},
-			ClientAuth:   tls.RequireAndVerifyClientCert,
-			ClientCAs:    caCertPool,
-			MinVersion:   tls.VersionTLS12,
 		}
 
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(config)))

--- a/internal/app/jobs/jobs.go
+++ b/internal/app/jobs/jobs.go
@@ -4,9 +4,6 @@ package jobs
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"os"
 	"strings"
 	"time"
 
@@ -29,6 +26,7 @@ import (
 	jobsmodel "github.com/hitesh22rana/chronoverse/internal/model/jobs"
 	authpkg "github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	grpcmiddlewares "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/middlewares"
+	grpcserverpkg "github.com/hitesh22rana/chronoverse/internal/pkg/grpcserver"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
 	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
@@ -205,44 +203,10 @@ func New(ctx context.Context, cfg *Config, auth authpkg.IAuth, svc Service) *grp
 	)
 
 	if cfg.TLSConfig != nil && cfg.TLSConfig.Enabled {
-		// Load CA certificate
-		caCert, err := os.ReadFile(cfg.TLSConfig.CAFile)
+		config, err := grpcserverpkg.LoadTLSConfig(cfg.TLSConfig.CAFile, cfg.TLSConfig.CertFile, cfg.TLSConfig.KeyFile)
 		if err != nil {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to read CA certificate file",
-				zap.Error(err),
-				zap.String("ca_file", cfg.TLSConfig.CAFile),
-			)
+			loggerpkg.FromContext(ctx).Fatal("failed to load TLS credentials", zap.Error(err))
 			return nil
-		}
-
-		caCertPool := x509.NewCertPool()
-		if ok := caCertPool.AppendCertsFromPEM(caCert); !ok {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to append CA certificate to pool",
-				zap.String("ca_file", cfg.TLSConfig.CAFile),
-				zap.Error(err),
-			)
-			return nil
-		}
-
-		// Server certificate and private key
-		serverCert, err := tls.LoadX509KeyPair(cfg.TLSConfig.CertFile, cfg.TLSConfig.KeyFile)
-		if err != nil {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to load server certificate and key",
-				zap.Error(err),
-				zap.String("cert_file", cfg.TLSConfig.CertFile),
-				zap.String("key_file", cfg.TLSConfig.KeyFile),
-			)
-			return nil
-		}
-
-		config := &tls.Config{
-			Certificates: []tls.Certificate{serverCert},
-			ClientAuth:   tls.RequireAndVerifyClientCert,
-			ClientCAs:    caCertPool,
-			MinVersion:   tls.VersionTLS12,
 		}
 
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(config)))

--- a/internal/app/notifications/notifications.go
+++ b/internal/app/notifications/notifications.go
@@ -4,9 +4,6 @@ package notifications
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"os"
 	"strings"
 	"time"
 
@@ -27,6 +24,7 @@ import (
 	notificationsmodel "github.com/hitesh22rana/chronoverse/internal/model/notifications"
 	authpkg "github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	grpcmiddlewares "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/middlewares"
+	grpcserverpkg "github.com/hitesh22rana/chronoverse/internal/pkg/grpcserver"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
 	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
@@ -140,44 +138,10 @@ func New(ctx context.Context, cfg *Config, auth authpkg.IAuth, svc Service) *grp
 	)
 
 	if cfg.TLSConfig != nil && cfg.TLSConfig.Enabled {
-		// Load CA certificate
-		caCert, err := os.ReadFile(cfg.TLSConfig.CAFile)
+		config, err := grpcserverpkg.LoadTLSConfig(cfg.TLSConfig.CAFile, cfg.TLSConfig.CertFile, cfg.TLSConfig.KeyFile)
 		if err != nil {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to read CA certificate file",
-				zap.Error(err),
-				zap.String("ca_file", cfg.TLSConfig.CAFile),
-			)
+			loggerpkg.FromContext(ctx).Fatal("failed to load TLS credentials", zap.Error(err))
 			return nil
-		}
-
-		caCertPool := x509.NewCertPool()
-		if ok := caCertPool.AppendCertsFromPEM(caCert); !ok {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to append CA certificate to pool",
-				zap.String("ca_file", cfg.TLSConfig.CAFile),
-				zap.Error(err),
-			)
-			return nil
-		}
-
-		// Server certificate and private key
-		serverCert, err := tls.LoadX509KeyPair(cfg.TLSConfig.CertFile, cfg.TLSConfig.KeyFile)
-		if err != nil {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to load server certificate and key",
-				zap.Error(err),
-				zap.String("cert_file", cfg.TLSConfig.CertFile),
-				zap.String("key_file", cfg.TLSConfig.KeyFile),
-			)
-			return nil
-		}
-
-		config := &tls.Config{
-			Certificates: []tls.Certificate{serverCert},
-			ClientAuth:   tls.RequireAndVerifyClientCert,
-			ClientCAs:    caCertPool,
-			MinVersion:   tls.VersionTLS12,
 		}
 
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(config)))

--- a/internal/app/users/users.go
+++ b/internal/app/users/users.go
@@ -4,9 +4,6 @@ package users
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"os"
 	"strings"
 	"time"
 
@@ -27,6 +24,7 @@ import (
 	usersmodel "github.com/hitesh22rana/chronoverse/internal/model/users"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	grpcmiddlewares "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/middlewares"
+	grpcserverpkg "github.com/hitesh22rana/chronoverse/internal/pkg/grpcserver"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
 	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
@@ -139,44 +137,10 @@ func New(ctx context.Context, cfg *Config, _auth auth.IAuth, svc Service) *grpc.
 
 	var serverOpts []grpc.ServerOption
 	if cfg.TLSConfig != nil && cfg.TLSConfig.Enabled {
-		// Load CA certificate
-		caCert, err := os.ReadFile(cfg.TLSConfig.CAFile)
+		config, err := grpcserverpkg.LoadTLSConfig(cfg.TLSConfig.CAFile, cfg.TLSConfig.CertFile, cfg.TLSConfig.KeyFile)
 		if err != nil {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to read CA certificate file",
-				zap.Error(err),
-				zap.String("ca_file", cfg.TLSConfig.CAFile),
-			)
+			loggerpkg.FromContext(ctx).Fatal("failed to load TLS credentials", zap.Error(err))
 			return nil
-		}
-
-		caCertPool := x509.NewCertPool()
-		if ok := caCertPool.AppendCertsFromPEM(caCert); !ok {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to append CA certificate to pool",
-				zap.String("ca_file", cfg.TLSConfig.CAFile),
-				zap.Error(err),
-			)
-			return nil
-		}
-
-		// Server certificate and private key
-		serverCert, err := tls.LoadX509KeyPair(cfg.TLSConfig.CertFile, cfg.TLSConfig.KeyFile)
-		if err != nil {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to load server certificate and key",
-				zap.Error(err),
-				zap.String("cert_file", cfg.TLSConfig.CertFile),
-				zap.String("key_file", cfg.TLSConfig.KeyFile),
-			)
-			return nil
-		}
-
-		config := &tls.Config{
-			Certificates: []tls.Certificate{serverCert},
-			ClientAuth:   tls.RequireAndVerifyClientCert,
-			ClientCAs:    caCertPool,
-			MinVersion:   tls.VersionTLS12,
 		}
 
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(config)))

--- a/internal/app/workflows/workflows.go
+++ b/internal/app/workflows/workflows.go
@@ -4,9 +4,6 @@ package workflows
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"os"
 	"strings"
 	"time"
 
@@ -27,6 +24,7 @@ import (
 	workflowsmodel "github.com/hitesh22rana/chronoverse/internal/model/workflows"
 	authpkg "github.com/hitesh22rana/chronoverse/internal/pkg/auth"
 	grpcmiddlewares "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/middlewares"
+	grpcserverpkg "github.com/hitesh22rana/chronoverse/internal/pkg/grpcserver"
 	loggerpkg "github.com/hitesh22rana/chronoverse/internal/pkg/logger"
 	otelpkg "github.com/hitesh22rana/chronoverse/internal/pkg/otel"
 	svcpkg "github.com/hitesh22rana/chronoverse/internal/pkg/svc"
@@ -153,44 +151,10 @@ func New(ctx context.Context, cfg *Config, auth authpkg.IAuth, svc Service) *grp
 	)
 
 	if cfg.TLSConfig != nil && cfg.TLSConfig.Enabled {
-		// Load CA certificate
-		caCert, err := os.ReadFile(cfg.TLSConfig.CAFile)
+		config, err := grpcserverpkg.LoadTLSConfig(cfg.TLSConfig.CAFile, cfg.TLSConfig.CertFile, cfg.TLSConfig.KeyFile)
 		if err != nil {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to read CA certificate file",
-				zap.Error(err),
-				zap.String("ca_file", cfg.TLSConfig.CAFile),
-			)
+			loggerpkg.FromContext(ctx).Fatal("failed to load TLS credentials", zap.Error(err))
 			return nil
-		}
-
-		caCertPool := x509.NewCertPool()
-		if ok := caCertPool.AppendCertsFromPEM(caCert); !ok {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to append CA certificate to pool",
-				zap.String("ca_file", cfg.TLSConfig.CAFile),
-				zap.Error(err),
-			)
-			return nil
-		}
-
-		// Server certificate and private key
-		serverCert, err := tls.LoadX509KeyPair(cfg.TLSConfig.CertFile, cfg.TLSConfig.KeyFile)
-		if err != nil {
-			loggerpkg.FromContext(ctx).Fatal(
-				"failed to load server certificate and key",
-				zap.Error(err),
-				zap.String("cert_file", cfg.TLSConfig.CertFile),
-				zap.String("key_file", cfg.TLSConfig.KeyFile),
-			)
-			return nil
-		}
-
-		config := &tls.Config{
-			Certificates: []tls.Certificate{serverCert},
-			ClientAuth:   tls.RequireAndVerifyClientCert,
-			ClientCAs:    caCertPool,
-			MinVersion:   tls.VersionTLS12,
 		}
 
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(config)))

--- a/internal/config/client_config_test.go
+++ b/internal/config/client_config_test.go
@@ -1,0 +1,82 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hitesh22rana/chronoverse/internal/config"
+	grpcclient "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/client"
+)
+
+func TestClientConfigKeepsEnvironmentSettingsSeparate(t *testing.T) {
+	for name, value := range map[string]string{
+		"POSTGRES_HOST": "postgres.internal", "POSTGRES_PORT": "5433", "POSTGRES_MAX_CONNS": "23",
+		"POSTGRES_MAX_CONN_LIFE": "7m", "POSTGRES_TLS_ENABLED": "true", "POSTGRES_TLS_CA_FILE": "pg-ca.pem",
+		"REDIS_HOST": "redis.internal", "REDIS_PORT": "6380", "REDIS_DB": "4", "REDIS_READ_TIMEOUT": "2s",
+		"REDIS_TLS_ENABLED": "false", "REDIS_TLS_CA_FILE": "redis-ca.pem", "REDIS_TLS_CERT_FILE": "redis-cert.pem",
+		"CLICKHOUSE_HOSTS": "clickhouse.internal:9440,clickhouse2.internal:9440", "CLICKHOUSE_MAX_OPEN_CONNS": "17",
+		"CLICKHOUSE_TLS_ENABLED": "true", "CLICKHOUSE_TLS_CA_FILE": "ch-ca.pem",
+		"CLICKHOUSE_TLS_CERT_FILE": "ch-cert.pem", "CLICKHOUSE_TLS_KEY_FILE": "ch-key.pem",
+		"CLIENT_TLS_CERT_FILE": "caller-cert.pem", "CLIENT_TLS_KEY_FILE": "caller-key.pem",
+	} {
+		t.Setenv(name, value)
+	}
+	var stores struct {
+		config.Postgres
+		config.Redis
+		config.ClickHouse
+		config.ClientTLS
+	}
+	require.NoError(t, envconfig.Process("", &stores))
+	pg, redis, ch := stores.Postgres.ClientConfig(), stores.Redis.ClientConfig(), stores.ClickHouse.ClientConfig()
+	require.Equal(t, "postgres.internal", pg.Host)
+	require.Equal(t, 5433, pg.Port)
+	require.Equal(t, int32(23), pg.MaxConns)
+	require.Equal(t, 7*time.Minute, pg.MaxConnLife)
+	require.True(t, pg.TLSConfig.Enabled)
+	require.Equal(t, "pg-ca.pem", pg.TLSConfig.CAFile)
+	require.Equal(t, "redis.internal", redis.Host)
+	require.Equal(t, 6380, redis.Port)
+	require.Equal(t, 4, redis.DB)
+	require.Equal(t, 2*time.Second, redis.ReadTimeout)
+	require.False(t, redis.TLSConfig.Enabled)
+	require.Equal(t, "redis-ca.pem", redis.TLSConfig.CAFile)
+	require.Equal(t, []string{"clickhouse.internal:9440", "clickhouse2.internal:9440"}, ch.Hosts)
+	require.Equal(t, 17, ch.MaxOpenConns)
+	require.True(t, ch.TLSConfig.Enabled)
+	require.Equal(t, "ch-ca.pem", ch.TLSConfig.CAFile)
+	require.Equal(t, "ch-cert.pem", ch.TLSConfig.CertFile)
+	require.Equal(t, "ch-key.pem", ch.TLSConfig.KeyFile)
+
+	for _, name := range []string{"USERS", "WORKFLOWS", "JOBS", "NOTIFICATIONS", "ANALYTICS"} {
+		t.Setenv(name+"_SERVICE_HOST", name+".internal")
+		t.Setenv(name+"_SERVICE_PORT", "50051")
+		t.Setenv(name+"_SERVICE_TLS_ENABLED", "true")
+		t.Setenv(name+"_SERVICE_TLS_CA_FILE", name+"-ca.pem")
+	}
+	var services struct {
+		config.UsersService
+		config.WorkflowsService
+		config.JobsService
+		config.NotificationsService
+		config.AnalyticsService
+	}
+	require.NoError(t, envconfig.Process("", &services))
+	for name, client := range map[string]*grpcclient.ServiceConfig{
+		"USERS":         services.UsersService.ClientConfig(stores.ClientTLS),
+		"WORKFLOWS":     services.WorkflowsService.ClientConfig(stores.ClientTLS),
+		"JOBS":          services.JobsService.ClientConfig(stores.ClientTLS),
+		"NOTIFICATIONS": services.NotificationsService.ClientConfig(stores.ClientTLS),
+		"ANALYTICS":     services.AnalyticsService.ClientConfig(stores.ClientTLS),
+	} {
+		require.Equal(t, name+".internal", client.Host)
+		require.Equal(t, name+"-ca.pem", client.TLS.CAFile)
+		require.Equal(t, 50051, client.Port)
+		require.True(t, client.TLS.Enabled)
+		require.Equal(t, "caller-cert.pem", client.TLS.ClientCertFile)
+		require.Equal(t, "caller-key.pem", client.TLS.ClientKeyFile)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hitesh22rana/chronoverse/internal/pkg/clickhouse"
 	"github.com/hitesh22rana/chronoverse/internal/pkg/commandidempotency"
+	grpcclient "github.com/hitesh22rana/chronoverse/internal/pkg/grpc/client"
+	"github.com/hitesh22rana/chronoverse/internal/pkg/postgres"
+	"github.com/hitesh22rana/chronoverse/internal/pkg/redis"
 )
 
 const envPrefix = ""
@@ -198,4 +202,139 @@ type DockerProxy struct {
 		ServerName string `envconfig:"DOCKER_PROXY_TLS_SERVER_NAME" default:"docker-proxy"`
 	}
 	Token string `envconfig:"DOCKER_PROXY_TOKEN" default:""`
+}
+
+// ClientConfig converts Postgres settings to the client configuration.
+func (c *Postgres) ClientConfig() *postgres.Config {
+	return &postgres.Config{
+		Host:        c.Host,
+		Port:        c.Port,
+		User:        c.User,
+		Password:    c.Password,
+		Database:    c.Database,
+		MaxConns:    c.MaxConns,
+		MinConns:    c.MinConns,
+		MaxConnLife: c.MaxConnLife,
+		MaxConnIdle: c.MaxConnIdle,
+		DialTimeout: c.DialTimeout,
+		TLSConfig: &postgres.TLSConfig{
+			Enabled:  c.TLS.Enabled,
+			CAFile:   c.TLS.CAFile,
+			CertFile: c.TLS.CertFile,
+			KeyFile:  c.TLS.KeyFile,
+		},
+	}
+}
+
+// ClientConfig converts Redis settings to the client configuration.
+func (c *Redis) ClientConfig() *redis.Config {
+	return &redis.Config{
+		Host:                     c.Host,
+		Port:                     c.Port,
+		Password:                 c.Password,
+		DB:                       c.DB,
+		PoolSize:                 c.PoolSize,
+		MinIdleConns:             c.MinIdleConns,
+		ReadTimeout:              c.ReadTimeout,
+		WriteTimeout:             c.WriteTimeout,
+		MaxMemory:                c.MaxMemory,
+		EvictionPolicy:           c.EvictionPolicy,
+		EvictionPolicySampleSize: c.EvictionPolicySampleSize,
+		TLSConfig: &redis.TLSConfig{
+			Enabled:  c.TLS.Enabled,
+			CAFile:   c.TLS.CAFile,
+			CertFile: c.TLS.CertFile,
+			KeyFile:  c.TLS.KeyFile,
+		},
+	}
+}
+
+// ClientConfig converts ClickHouse settings to the client configuration.
+func (c *ClickHouse) ClientConfig() *clickhouse.Config {
+	return &clickhouse.Config{
+		Hosts:           c.Hosts,
+		Database:        c.Database,
+		Username:        c.Username,
+		Password:        c.Password,
+		MaxOpenConns:    c.MaxOpenConns,
+		MaxIdleConns:    c.MaxIdleConns,
+		ConnMaxLifetime: c.ConnMaxLifetime,
+		DialTimeout:     c.DialTimeout,
+		TLSConfig: &clickhouse.TLSConfig{
+			Enabled:  c.TLS.Enabled,
+			CAFile:   c.TLS.CAFile,
+			CertFile: c.TLS.CertFile,
+			KeyFile:  c.TLS.KeyFile,
+		},
+	}
+}
+
+// ClientConfig combines the UsersService endpoint with the calling service's certificate.
+func (c UsersService) ClientConfig(clientTLS ClientTLS) *grpcclient.ServiceConfig {
+	return &grpcclient.ServiceConfig{
+		Host: c.Host,
+		Port: c.Port,
+		TLS: &grpcclient.TLSConfig{
+			Enabled:        c.TLS.Enabled,
+			CAFile:         c.TLS.CAFile,
+			ClientCertFile: clientTLS.CertFile,
+			ClientKeyFile:  clientTLS.KeyFile,
+		},
+	}
+}
+
+// ClientConfig combines the WorkflowsService endpoint with the calling service's certificate.
+func (c WorkflowsService) ClientConfig(clientTLS ClientTLS) *grpcclient.ServiceConfig {
+	return &grpcclient.ServiceConfig{
+		Host: c.Host,
+		Port: c.Port,
+		TLS: &grpcclient.TLSConfig{
+			Enabled:        c.TLS.Enabled,
+			CAFile:         c.TLS.CAFile,
+			ClientCertFile: clientTLS.CertFile,
+			ClientKeyFile:  clientTLS.KeyFile,
+		},
+	}
+}
+
+// ClientConfig combines the JobsService endpoint with the calling service's certificate.
+func (c JobsService) ClientConfig(clientTLS ClientTLS) *grpcclient.ServiceConfig {
+	return &grpcclient.ServiceConfig{
+		Host: c.Host,
+		Port: c.Port,
+		TLS: &grpcclient.TLSConfig{
+			Enabled:        c.TLS.Enabled,
+			CAFile:         c.TLS.CAFile,
+			ClientCertFile: clientTLS.CertFile,
+			ClientKeyFile:  clientTLS.KeyFile,
+		},
+	}
+}
+
+// ClientConfig combines the NotificationsService endpoint with the calling service's certificate.
+func (c NotificationsService) ClientConfig(clientTLS ClientTLS) *grpcclient.ServiceConfig {
+	return &grpcclient.ServiceConfig{
+		Host: c.Host,
+		Port: c.Port,
+		TLS: &grpcclient.TLSConfig{
+			Enabled:        c.TLS.Enabled,
+			CAFile:         c.TLS.CAFile,
+			ClientCertFile: clientTLS.CertFile,
+			ClientKeyFile:  clientTLS.KeyFile,
+		},
+	}
+}
+
+// ClientConfig combines the AnalyticsService endpoint with the calling service's certificate.
+func (c AnalyticsService) ClientConfig(clientTLS ClientTLS) *grpcclient.ServiceConfig {
+	return &grpcclient.ServiceConfig{
+		Host: c.Host,
+		Port: c.Port,
+		TLS: &grpcclient.TLSConfig{
+			Enabled:        c.TLS.Enabled,
+			CAFile:         c.TLS.CAFile,
+			ClientCertFile: clientTLS.CertFile,
+			ClientKeyFile:  clientTLS.KeyFile,
+		},
+	}
 }

--- a/internal/pkg/grpcserver/tls.go
+++ b/internal/pkg/grpcserver/tls.go
@@ -1,0 +1,30 @@
+package grpcserver
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// LoadTLSConfig loads the server certificate and requires clients signed by the configured CA bundle.
+func LoadTLSConfig(caFile, certFile, keyFile string) (*tls.Config, error) {
+	caCert, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate file: %w", err)
+	}
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to append CA certificate to pool: %s", caFile)
+	}
+	serverCert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load server certificate and key: %w", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    caCertPool,
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}

--- a/internal/pkg/grpcserver/tls_test.go
+++ b/internal/pkg/grpcserver/tls_test.go
@@ -1,0 +1,114 @@
+package grpcserver_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"log"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	grpcserverpkg "github.com/hitesh22rana/chronoverse/internal/pkg/grpcserver"
+)
+
+func TestLoadTLSConfig(t *testing.T) {
+	t.Parallel()
+	certFile, keyFile := writeTLSCertificate(t)
+	cfg, err := grpcserverpkg.LoadTLSConfig(certFile, certFile, keyFile)
+	require.NoError(t, err)
+	require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.TLS = cfg
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	otherCertFile, otherKeyFile := writeTLSCertificate(t)
+	untrusted, err := tls.LoadX509KeyPair(otherCertFile, otherKeyFile)
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name      string
+		certs     []tls.Certificate
+		wantError bool
+	}{
+		{name: "trusted", certs: cfg.Certificates},
+		{name: "missing", wantError: true},
+		{name: "untrusted", certs: []tls.Certificate{untrusted}, wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			transport := &http.Transport{TLSClientConfig: &tls.Config{
+				RootCAs:    cfg.ClientCAs,
+				ServerName: "localhost",
+				MinVersion: tls.VersionTLS12,
+				// Always send the chosen certificate, even when it isn't in the server's CA list.
+				GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					if len(tc.certs) == 0 {
+						return &tls.Certificate{}, nil
+					}
+					return &tc.certs[0], nil
+				},
+			}}
+			t.Cleanup(transport.CloseIdleConnections)
+			client := &http.Client{Transport: transport, Timeout: 3 * time.Second}
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, http.NoBody)
+			require.NoError(t, err)
+			res, err := client.Do(req)
+			if tc.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, res.Body.Close())
+			require.Equal(t, http.StatusNoContent, res.StatusCode)
+		})
+	}
+
+	invalidFile := filepath.Join(t.TempDir(), "invalid.pem")
+	require.NoError(t, os.WriteFile(invalidFile, []byte("not a certificate"), 0o600))
+	for _, paths := range [][3]string{
+		{invalidFile + ".missing", certFile, keyFile},
+		{invalidFile, certFile, keyFile},
+		{certFile, invalidFile, keyFile},
+		{certFile, certFile, otherKeyFile},
+	} {
+		_, err := grpcserverpkg.LoadTLSConfig(paths[0], paths[1], paths[2])
+		require.Error(t, err)
+	}
+}
+
+func writeTLSCertificate(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1), DNSNames: []string{"localhost"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		IsCA: true, BasicConstraintsValid: true,
+		KeyUsage:    x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, cert, cert, &key.PublicKey, key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	certFile, keyFile = filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	require.NoError(t, os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+	return certFile, keyFile
+}


### PR DESCRIPTION
Database/gRPC client configuration, gRPC server certificate loading, and workflow form validation were repeated across callers. Centralize the mappings and TLS loader, and share create/update validation while retaining their different defaults and payload requirements.

- Replace 33 client-config literals with typed conversion methods.
- Share certificate loading across five gRPC servers, preserving required client-certificate verification and TLS 1.2 minimum.
- Share workflow schemas with regression coverage for defaults, normalization, and validation boundaries.

The jobs service retains its existing Redis-derived ClickHouse TLS settings through an explicit override; correcting that wiring is outside this behavior-preserving cleanup. Service wrappers and service metadata initialization are unchanged.

Validation: `go test -race -short ./...`, `go build ./cmd/...`, Go lint/format checks, dashboard tests (112 passed), TypeScript checking, ESLint, and production build all passed. Temporary parity checks confirmed 32 mappings match their originals exactly (the remaining TLS override was inspected separately) and compared 1,520 inputs against the original workflow schemas. All five targeted mutations were caught by the regression tests. Mapping mutation testing: N/A for direct field-copy extraction; environment-wiring tests and exact mapping comparison provide preservation evidence. Docker-backed datastore integration tests were not run locally.

Three signed commits; net reduction of 267 lines including the added tests.
