### PR TITLE
Provision chronoverse Grafana dashboard as code in all environments

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -325,6 +325,9 @@ services:
     restart: on-failure
     volumes:
       - lgtm:/data
+      - ./infra/k8s/base/grafana-dashboards:/otel-lgtm/dashboards:ro
+      - ./infra/k8s/base/grafana-dashboards/chronoverse.yaml:/otel-lgtm/grafana/conf/provisioning/dashboards/chronoverse.yaml:ro
+      - ./infra/k8s/base/grafana-dashboards/defaults-off.yaml:/otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml:ro
     ports:
       - "127.0.0.1:4317:4317"
     networks:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -376,6 +376,9 @@ services:
     restart: on-failure
     volumes:
       - lgtm:/data
+      - ./infra/k8s/base/grafana-dashboards:/otel-lgtm/dashboards:ro
+      - ./infra/k8s/base/grafana-dashboards/chronoverse.yaml:/otel-lgtm/grafana/conf/provisioning/dashboards/chronoverse.yaml:ro
+      - ./infra/k8s/base/grafana-dashboards/defaults-off.yaml:/otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml:ro
     networks:
       - chronoverse
 

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
-	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
@@ -120,6 +119,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
+	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/infra/k8s/base/grafana-dashboards/chronoverse.json
+++ b/infra/k8s/base/grafana-dashboards/chronoverse.json
@@ -2071,7 +2071,7 @@
     "templating": {
         "list": [
             {
-                "allValue": ".+",
+                "allValue": ".{1,}",
                 "current": {
                     "selected": true,
                     "text": [

--- a/infra/k8s/base/grafana-dashboards/chronoverse.json
+++ b/infra/k8s/base/grafana-dashboards/chronoverse.json
@@ -1463,7 +1463,7 @@
             },
             "id": 23,
             "options": {
-                "content": "Tempo search is flaky as an embedded panel in this stack, use one click:\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
+                "content": "Trace search lives in Explore (this LGTM build can't render Tempo search inside dashboards):\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
                 "mode": "markdown"
             },
             "targets": [],

--- a/infra/k8s/base/grafana-dashboards/chronoverse.json
+++ b/infra/k8s/base/grafana-dashboards/chronoverse.json
@@ -1463,7 +1463,7 @@
             },
             "id": 23,
             "options": {
-                "content": "Trace search lives in Explore (this LGTM build can't render Tempo search inside dashboards):\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
+                "content": "Trace search lives in Explore:\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
                 "mode": "markdown"
             },
             "targets": [],

--- a/infra/k8s/base/grafana-dashboards/chronoverse.json
+++ b/infra/k8s/base/grafana-dashboards/chronoverse.json
@@ -222,7 +222,7 @@
                         "uid": "prometheus"
                     },
                     "editorMode": "code",
-                    "expr": "100 * sum(rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[5m])) / sum(rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m]))",
+                    "expr": "100 * (sum(rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[5m])) or sum(rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m])) * 0) / sum(rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m]))",
                     "instant": false,
                     "range": true,
                     "refId": "A"
@@ -1749,7 +1749,7 @@
                         "uid": "prometheus"
                     },
                     "editorMode": "code",
-                    "expr": "topk(8, 100 * sum by (http_route) (rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[5m])) / sum by (http_route) (rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m])))",
+                    "expr": "topk(8, 100 * (sum by (http_route) (rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[5m])) or sum by (http_route) (rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m])) * 0) / sum by (http_route) (rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m])))",
                     "instant": false,
                     "legendFormat": "{{http_route}}",
                     "range": true,
@@ -2032,7 +2032,7 @@
                         "type": "prometheus",
                         "uid": "prometheus"
                     },
-                    "expr": "max by (service_name) (go_memory_used_bytes{service_name=~\"$service\"})",
+                    "expr": "sum by (service_name) (go_memory_used_bytes{service_name=~\"$service\"})",
                     "format": "table",
                     "instant": true,
                     "range": false,

--- a/infra/k8s/base/grafana-dashboards/chronoverse.json
+++ b/infra/k8s/base/grafana-dashboards/chronoverse.json
@@ -1,0 +1,2109 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+        ]
+    },
+    "description": "Chronoverse RED metrics, runtime, logs and trace links (OTEL LGTM).",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 1,
+    "links": [
+        {
+            "targetBlank": true,
+            "title": "Explore logs",
+            "type": "link",
+            "url": "/explore?orgId=1&left=%7B%22datasource%22%3A%20%22loki%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22loki%22%2C%20%22uid%22%3A%20%22loki%22%7D%2C%20%22queryType%22%3A%20%22range%22%2C%20%22query%22%3A%20%22%7Bservice_name%3D~%5C%22%24service%5C%22%7D%22%7D%5D%7D"
+        },
+        {
+            "targetBlank": true,
+            "title": "Explore traces",
+            "type": "link",
+            "url": "/explore?orgId=1&left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%7D%5D%7D"
+        }
+    ],
+    "panels": [
+        {
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 1,
+            "panels": [],
+            "title": "Overview",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            }
+                        ]
+                    },
+                    "unit": "reqpm"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 0,
+                "y": 1
+            },
+            "id": 2,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m]) * 60)",
+                    "instant": false,
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "HTTP RPM",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            }
+                        ]
+                    },
+                    "unit": "reqpm"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 6,
+                "y": 1
+            },
+            "id": 3,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(rpc_server_call_duration_seconds_count{service_name=~\"$service\",rpc_method!=\"grpc.health.v1.Health/Check\"}[5m]) * 60)",
+                    "instant": false,
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "gRPC RPM",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "yellow",
+                                "value": 1
+                            },
+                            {
+                                "color": "red",
+                                "value": 5
+                            }
+                        ]
+                    },
+                    "unit": "percent"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 12,
+                "y": 1
+            },
+            "id": 4,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "100 * sum(rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[5m])) / sum(rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m]))",
+                    "instant": false,
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "HTTP 5xx %",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "loki",
+                "uid": "loki"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "red",
+                                "value": 1
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 18,
+                "y": 1
+            },
+            "id": 5,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "loki",
+                        "uid": "loki"
+                    },
+                    "expr": "sum(count_over_time({service_name=~\"$service\"} | detected_level=\"error\" [5m]))",
+                    "queryType": "range",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Error logs (5m)",
+            "type": "stat"
+        },
+        {
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+            },
+            "id": 6,
+            "panels": [],
+            "title": "Traffic",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "reqpm"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 7
+            },
+            "id": 7,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (http_route) (rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m]) * 60)",
+                    "instant": false,
+                    "legendFormat": "{{http_route}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "HTTP RPM by route",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "reqpm"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 7
+            },
+            "id": 8,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "topk(12, sum by (rpc_method) (rate(rpc_server_call_duration_seconds_count{service_name=~\"$service\",rpc_method!=\"grpc.health.v1.Health/Check\"}[5m]) * 60))",
+                    "instant": false,
+                    "legendFormat": "{{rpc_method}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "gRPC RPM by method",
+            "type": "timeseries"
+        },
+        {
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 15
+            },
+            "id": 9,
+            "panels": [],
+            "title": "Latency & errors",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 16
+            },
+            "id": 10,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "histogram_quantile(0.95, sum by (le, http_route) (rate(http_server_request_duration_seconds_bucket{http_route!=\"\",service_name=~\"$service\"}[5m])))",
+                    "instant": false,
+                    "legendFormat": "{{http_route}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "HTTP p95 by route",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 16
+            },
+            "id": 11,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "topk(12, histogram_quantile(0.95, sum by (le, rpc_method) (rate(rpc_server_call_duration_seconds_bucket{service_name=~\"$service\",rpc_method!=\"grpc.health.v1.Health/Check\"}[5m]))))",
+                    "instant": false,
+                    "legendFormat": "{{rpc_method}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "gRPC p95 by method",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 30,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "normal"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "reqpm"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 32
+            },
+            "id": 12,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m]) * 60)",
+                    "instant": false,
+                    "legendFormat": "{{http_response_status_code}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "HTTP by status",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 30,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "normal"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "reqpm"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 32
+            },
+            "id": 13,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (rpc_response_status_code) (rate(rpc_server_call_duration_seconds_count{service_name=~\"$service\"}[5m]) * 60)",
+                    "instant": false,
+                    "legendFormat": "{{rpc_response_status_code}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "gRPC by status",
+            "type": "timeseries"
+        },
+        {
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 57
+            },
+            "id": 14,
+            "panels": [],
+            "title": "Runtime",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 58
+            },
+            "id": 15,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (service_name) (go_goroutine_count{service_name=~\"$service\"})",
+                    "instant": false,
+                    "legendFormat": "{{service_name}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Goroutines",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 58
+            },
+            "id": 16,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (service_name) (go_memory_used_bytes{service_name=~\"$service\"})",
+                    "instant": false,
+                    "legendFormat": "{{service_name}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Memory used",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 58
+            },
+            "id": 17,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (service_name) (rate(process_cpu_time_seconds_total{service_name=~\"$service\"}[5m]))",
+                    "instant": false,
+                    "legendFormat": "{{service_name}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "CPU cores",
+            "type": "timeseries"
+        },
+        {
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 73
+            },
+            "id": 18,
+            "panels": [],
+            "title": "Logs",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "loki",
+                "uid": "loki"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 74
+            },
+            "id": 19,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "loki",
+                        "uid": "loki"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (detected_level) (count_over_time({service_name=~\"$service\"}[1m]))",
+                    "legendFormat": "{{detected_level}}",
+                    "queryType": "range",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Log volume by level",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "loki",
+                "uid": "loki"
+            },
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 80
+            },
+            "id": 20,
+            "options": {
+                "dedupStrategy": "none",
+                "enableLogDetails": true,
+                "prettifyLogMessage": false,
+                "showCommonLabels": false,
+                "showLabels": false,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "wrapLogMessage": true
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "loki",
+                        "uid": "loki"
+                    },
+                    "expr": "{service_name=~\"$service\"} | detected_level=\"error\"",
+                    "refId": "A"
+                }
+            ],
+            "title": "Error logs",
+            "type": "logs"
+        },
+        {
+            "datasource": {
+                "type": "loki",
+                "uid": "loki"
+            },
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 90
+            },
+            "id": 21,
+            "options": {
+                "dedupStrategy": "none",
+                "enableLogDetails": true,
+                "prettifyLogMessage": false,
+                "showCommonLabels": false,
+                "showLabels": false,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "wrapLogMessage": true
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "loki",
+                        "uid": "loki"
+                    },
+                    "expr": "{service_name=~\"$service\"}",
+                    "refId": "A"
+                }
+            ],
+            "title": "All logs",
+            "type": "logs"
+        },
+        {
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 100
+            },
+            "id": 22,
+            "panels": [],
+            "title": "Traces",
+            "type": "row"
+        },
+        {
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 24,
+                "x": 0,
+                "y": 101
+            },
+            "id": 23,
+            "options": {
+                "content": "Tempo search is flaky as an embedded panel in this stack, use one click:\n\n- [Search traces (Tempo)](http://localhost:3000/explore?orgId=1&left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
+                "mode": "markdown"
+            },
+            "targets": [],
+            "title": "Traces",
+            "type": "text"
+        },
+        {
+            "datasource": {
+                "type": "loki",
+                "uid": "loki"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 49
+            },
+            "id": 24,
+            "options": {
+                "displayLabels": [
+                    "name",
+                    "value"
+                ],
+                "legend": {
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true
+                },
+                "pieType": "donut",
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "loki",
+                        "uid": "loki"
+                    },
+                    "expr": "topk(8, sum by (service_name) (count_over_time({service_name=~\"$service\"}[5m])))",
+                    "instant": false,
+                    "legendFormat": "{{service_name}}",
+                    "queryType": "range",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Log share by service",
+            "type": "piechart"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "scheme",
+                        "scheme": "Oranges"
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 24
+            },
+            "id": 25,
+            "options": {
+                "calculate": false,
+                "cellGap": 1,
+                "color": {
+                    "exponent": 0.5,
+                    "fill": "dark-orange",
+                    "mode": "scheme",
+                    "scheme": "Oranges"
+                },
+                "legend": {
+                    "show": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "showColorScale": true
+                },
+                "yAxis": {
+                    "reverse": false,
+                    "unit": "s"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (le) (rate(http_server_request_duration_seconds_bucket{http_route!=\"\",service_name=~\"$service\"}[5m]))",
+                    "instant": false,
+                    "legendFormat": "{{le}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "HTTP latency heatmap",
+            "type": "heatmap"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "scheme",
+                        "scheme": "Oranges"
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 24
+            },
+            "id": 26,
+            "options": {
+                "calculate": false,
+                "cellGap": 1,
+                "color": {
+                    "exponent": 0.5,
+                    "fill": "dark-orange",
+                    "mode": "scheme",
+                    "scheme": "Oranges"
+                },
+                "legend": {
+                    "show": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "showColorScale": true
+                },
+                "yAxis": {
+                    "reverse": false,
+                    "unit": "s"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (le) (rate(rpc_server_call_duration_seconds_bucket{service_name=~\"$service\",rpc_method!=\"grpc.health.v1.Health/Check\"}[5m]))",
+                    "instant": false,
+                    "legendFormat": "{{le}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "gRPC latency heatmap",
+            "type": "heatmap"
+        },
+        {
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 40
+            },
+            "id": 27,
+            "panels": [],
+            "title": "Errors spotlight",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "percent"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 41
+            },
+            "id": 28,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "topk(8, 100 * sum by (http_route) (rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\",http_response_status_code=~\"5..\"}[5m])) / sum by (http_route) (rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m])))",
+                    "instant": false,
+                    "legendFormat": "{{http_route}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "HTTP 5xx % by route",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "opacity",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 2,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 41
+            },
+            "id": 29,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max"
+                    ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "12.1.1",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (http_route) (rate(http_server_response_body_size_bytes_sum{http_route!=\"\",service_name=~\"$service\"}[5m])) / sum by (http_route) (rate(http_server_request_duration_seconds_count{http_route!=\"\",service_name=~\"$service\"}[5m]))",
+                    "instant": false,
+                    "legendFormat": "{{http_route}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Avg response size by route",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "loki",
+                "uid": "loki"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "yellow",
+                                "value": 10
+                            },
+                            {
+                                "color": "red",
+                                "value": 50
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 49
+            },
+            "id": 30,
+            "options": {
+                "displayMode": "gradient",
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "orientation": "horizontal",
+                "showUnfilled": true,
+                "valueMode": "value"
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "loki",
+                        "uid": "loki"
+                    },
+                    "expr": "topk(8, sum by (service_name) (count_over_time({service_name=~\"$service\"} | detected_level=\"error\" [5m])))",
+                    "instant": false,
+                    "legendFormat": "{{service_name}}",
+                    "queryType": "range",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Error logs by service",
+            "type": "bargauge"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "auto"
+                        }
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Time"
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.hidden",
+                                "value": true
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #A"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "Goroutines"
+                            },
+                            {
+                                "id": "unit",
+                                "value": "short"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #B"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "Memory"
+                            },
+                            {
+                                "id": "unit",
+                                "value": "bytes"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "Value #C"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "CPU (cores)"
+                            },
+                            {
+                                "id": "unit",
+                                "value": "short"
+                            },
+                            {
+                                "id": "decimals",
+                                "value": 3
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 66
+            },
+            "id": 31,
+            "options": {
+                "showHeader": true,
+                "sortBy": []
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "expr": "max by (service_name, service_version) (go_goroutine_count{service_name=~\"$service\"})",
+                    "format": "table",
+                    "instant": true,
+                    "range": false,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "expr": "max by (service_name) (go_memory_used_bytes{service_name=~\"$service\"})",
+                    "format": "table",
+                    "instant": true,
+                    "range": false,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "expr": "sum by (service_name) (rate(process_cpu_time_seconds_total{service_name=~\"$service\"}[5m]))",
+                    "format": "table",
+                    "instant": true,
+                    "range": false,
+                    "refId": "C"
+                }
+            ],
+            "title": "Fleet",
+            "transformations": [
+                {
+                    "id": "merge",
+                    "options": {}
+                }
+            ],
+            "type": "table"
+        }
+    ],
+    "preload": false,
+    "refresh": "30s",
+    "schemaVersion": 41,
+    "tags": [
+        "chronoverse",
+        "otel",
+        "RED"
+    ],
+    "templating": {
+        "list": [
+            {
+                "allValue": ".+",
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                },
+                "definition": "label_values(service_name)",
+                "includeAll": true,
+                "label": "Service",
+                "multi": true,
+                "name": "service",
+                "query": {
+                    "query": "label_values(service_name)",
+                    "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                },
+                "refresh": 1,
+                "sort": 1,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-3h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "chronoverse",
+    "uid": "50c49054-7ce3-46b1-bb4f-990f182191dd"
+}

--- a/infra/k8s/base/grafana-dashboards/chronoverse.json
+++ b/infra/k8s/base/grafana-dashboards/chronoverse.json
@@ -24,13 +24,13 @@
             "targetBlank": true,
             "title": "Explore logs",
             "type": "link",
-            "url": "/explore?left=%7B%22datasource%22%3A%20%22loki%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22loki%22%2C%20%22uid%22%3A%20%22loki%22%7D%2C%20%22queryType%22%3A%20%22range%22%2C%20%22expr%22%3A%20%22%7Bservice_name%3D~%5C%22$service%5C%22%7D%22%7D%5D%7D"
+            "url": "/explore?left=%7B%22datasource%22%3A%20%22loki%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22loki%22%2C%20%22uid%22%3A%20%22loki%22%7D%2C%20%22queryType%22%3A%20%22range%22%2C%20%22expr%22%3A%20%22%7Bservice_name%3D~%5C%22${service:regex}%5C%22%7D%22%7D%5D%7D"
         },
         {
             "targetBlank": true,
             "title": "Explore traces",
             "type": "link",
-            "url": "/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22$service%5C%22%20%7D%22%7D%5D%7D"
+            "url": "/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22${service:regex}%5C%22%20%7D%22%7D%5D%7D"
         }
     ],
     "panels": [
@@ -1463,7 +1463,7 @@
             },
             "id": 23,
             "options": {
-                "content": "Trace search lives in Explore:\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22$service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
+                "content": "Trace search lives in Explore:\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22${service:regex}%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
                 "mode": "markdown"
             },
             "targets": [],

--- a/infra/k8s/base/grafana-dashboards/chronoverse.json
+++ b/infra/k8s/base/grafana-dashboards/chronoverse.json
@@ -24,13 +24,13 @@
             "targetBlank": true,
             "title": "Explore logs",
             "type": "link",
-            "url": "/explore?orgId=1&left=%7B%22datasource%22%3A%20%22loki%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22loki%22%2C%20%22uid%22%3A%20%22loki%22%7D%2C%20%22queryType%22%3A%20%22range%22%2C%20%22query%22%3A%20%22%7Bservice_name%3D~%5C%22%24service%5C%22%7D%22%7D%5D%7D"
+            "url": "/explore?left=%7B%22datasource%22%3A%20%22loki%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22loki%22%2C%20%22uid%22%3A%20%22loki%22%7D%2C%20%22queryType%22%3A%20%22range%22%2C%20%22query%22%3A%20%22%7Bservice_name%3D~%5C%22%24service%5C%22%7D%22%7D%5D%7D"
         },
         {
             "targetBlank": true,
             "title": "Explore traces",
             "type": "link",
-            "url": "/explore?orgId=1&left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%7D%5D%7D"
+            "url": "/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%7D%5D%7D"
         }
     ],
     "panels": [
@@ -1463,7 +1463,7 @@
             },
             "id": 23,
             "options": {
-                "content": "Tempo search is flaky as an embedded panel in this stack, use one click:\n\n- [Search traces (Tempo)](http://localhost:3000/explore?orgId=1&left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
+                "content": "Tempo search is flaky as an embedded panel in this stack, use one click:\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
                 "mode": "markdown"
             },
             "targets": [],

--- a/infra/k8s/base/grafana-dashboards/chronoverse.json
+++ b/infra/k8s/base/grafana-dashboards/chronoverse.json
@@ -24,13 +24,13 @@
             "targetBlank": true,
             "title": "Explore logs",
             "type": "link",
-            "url": "/explore?left=%7B%22datasource%22%3A%20%22loki%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22loki%22%2C%20%22uid%22%3A%20%22loki%22%7D%2C%20%22queryType%22%3A%20%22range%22%2C%20%22query%22%3A%20%22%7Bservice_name%3D~%5C%22%24service%5C%22%7D%22%7D%5D%7D"
+            "url": "/explore?left=%7B%22datasource%22%3A%20%22loki%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22loki%22%2C%20%22uid%22%3A%20%22loki%22%7D%2C%20%22queryType%22%3A%20%22range%22%2C%20%22expr%22%3A%20%22%7Bservice_name%3D~%5C%22$service%5C%22%7D%22%7D%5D%7D"
         },
         {
             "targetBlank": true,
             "title": "Explore traces",
             "type": "link",
-            "url": "/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%7D%5D%7D"
+            "url": "/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22$service%5C%22%20%7D%22%7D%5D%7D"
         }
     ],
     "panels": [
@@ -1463,7 +1463,7 @@
             },
             "id": 23,
             "options": {
-                "content": "Trace search lives in Explore:\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
+                "content": "Trace search lives in Explore:\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22$service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
                 "mode": "markdown"
             },
             "targets": [],
@@ -1574,6 +1574,7 @@
                     },
                     "editorMode": "code",
                     "expr": "sum by (le) (rate(http_server_request_duration_seconds_bucket{http_route!=\"\",service_name=~\"$service\"}[5m]))",
+                    "format": "heatmap",
                     "instant": false,
                     "legendFormat": "{{le}}",
                     "range": true,
@@ -1634,6 +1635,7 @@
                     },
                     "editorMode": "code",
                     "expr": "sum by (le) (rate(rpc_server_call_duration_seconds_bucket{service_name=~\"$service\",rpc_method!=\"grpc.health.v1.Health/Check\"}[5m]))",
+                    "format": "heatmap",
                     "instant": false,
                     "legendFormat": "{{le}}",
                     "range": true,

--- a/infra/k8s/base/grafana-dashboards/chronoverse.yaml
+++ b/infra/k8s/base/grafana-dashboards/chronoverse.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: chronoverse
+    type: file
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /otel-lgtm/dashboards
+      foldersFromFilesStructure: false

--- a/infra/k8s/base/grafana-dashboards/defaults-off.yaml
+++ b/infra/k8s/base/grafana-dashboards/defaults-off.yaml
@@ -1,0 +1,8 @@
+# Mounted over the LGTM image's bundled demo-dashboard providers
+# (/otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml).
+# Those JVM/RED demo dashboards are provisioned (allowUiUpdates=false), which is
+# why they cannot be deleted from the Grafana UI. Neutralizing their provider
+# file removes them; our dashboards are provisioned by chronoverse.yaml instead.
+apiVersion: 1
+
+providers: []

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -25,6 +25,15 @@ resources:
 - kafka-scaling.yaml
 - keda-kafka-network-policy.yaml
 
+configMapGenerator:
+- name: grafana-dashboards
+  files:
+  - chronoverse.json=grafana-dashboards/chronoverse.json
+  - chronoverse.yaml=grafana-dashboards/chronoverse.yaml
+  - defaults-off.yaml=grafana-dashboards/defaults-off.yaml
+  options:
+    disableNameSuffixHash: true
+
 patches:
 - target:
     kind: Deployment

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -26,13 +26,17 @@ resources:
 - keda-kafka-network-policy.yaml
 
 configMapGenerator:
+# Two ConfigMaps so each can be mounted as a directory (directory mounts
+# receive ConfigMap updates live; subPath mounts do not). Re-enabling the
+# default name hash additionally triggers a rollout whenever dashboard
+# content changes.
 - name: grafana-dashboards
   files:
   - chronoverse.json=grafana-dashboards/chronoverse.json
+- name: grafana-provisioning
+  files:
   - chronoverse.yaml=grafana-dashboards/chronoverse.yaml
   - defaults-off.yaml=grafana-dashboards/defaults-off.yaml
-  options:
-    disableNameSuffixHash: true
 
 patches:
 - target:

--- a/infra/k8s/overlays/local/infrastructure.yaml
+++ b/infra/k8s/overlays/local/infrastructure.yaml
@@ -759,16 +759,10 @@ spec:
               optional: false
         volumeMounts:
         - name: grafana-dashboards
-          mountPath: /otel-lgtm/dashboards/chronoverse.json
-          subPath: chronoverse.json
+          mountPath: /otel-lgtm/dashboards
           readOnly: true
-        - name: grafana-dashboards
-          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/chronoverse.yaml
-          subPath: chronoverse.yaml
-          readOnly: true
-        - name: grafana-dashboards
-          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml
-          subPath: defaults-off.yaml
+        - name: grafana-provisioning
+          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards
           readOnly: true
         resources:
           requests:
@@ -781,6 +775,9 @@ spec:
       - name: grafana-dashboards
         configMap:
           name: grafana-dashboards
+      - name: grafana-provisioning
+        configMap:
+          name: grafana-provisioning
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/overlays/local/infrastructure.yaml
+++ b/infra/k8s/overlays/local/infrastructure.yaml
@@ -757,6 +757,19 @@ spec:
               name: grafana-secret
               key: GF_SECURITY_ADMIN_PASSWORD
               optional: false
+        volumeMounts:
+        - name: grafana-dashboards
+          mountPath: /otel-lgtm/dashboards/chronoverse.json
+          subPath: chronoverse.json
+          readOnly: true
+        - name: grafana-dashboards
+          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/chronoverse.yaml
+          subPath: chronoverse.yaml
+          readOnly: true
+        - name: grafana-dashboards
+          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml
+          subPath: defaults-off.yaml
+          readOnly: true
         resources:
           requests:
             cpu: 250m
@@ -764,6 +777,10 @@ spec:
           limits:
             cpu: "1"
             memory: 1024Mi
+      volumes:
+      - name: grafana-dashboards
+        configMap:
+          name: grafana-dashboards
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/overlays/production/infrastructure.yaml
+++ b/infra/k8s/overlays/production/infrastructure.yaml
@@ -771,16 +771,10 @@ spec:
               optional: false
         volumeMounts:
         - name: grafana-dashboards
-          mountPath: /otel-lgtm/dashboards/chronoverse.json
-          subPath: chronoverse.json
+          mountPath: /otel-lgtm/dashboards
           readOnly: true
-        - name: grafana-dashboards
-          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/chronoverse.yaml
-          subPath: chronoverse.yaml
-          readOnly: true
-        - name: grafana-dashboards
-          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml
-          subPath: defaults-off.yaml
+        - name: grafana-provisioning
+          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards
           readOnly: true
         resources:
           requests:
@@ -793,6 +787,9 @@ spec:
       - name: grafana-dashboards
         configMap:
           name: grafana-dashboards
+      - name: grafana-provisioning
+        configMap:
+          name: grafana-provisioning
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/overlays/production/infrastructure.yaml
+++ b/infra/k8s/overlays/production/infrastructure.yaml
@@ -769,6 +769,19 @@ spec:
               name: grafana-secret
               key: GF_SECURITY_ADMIN_PASSWORD
               optional: false
+        volumeMounts:
+        - name: grafana-dashboards
+          mountPath: /otel-lgtm/dashboards/chronoverse.json
+          subPath: chronoverse.json
+          readOnly: true
+        - name: grafana-dashboards
+          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/chronoverse.yaml
+          subPath: chronoverse.yaml
+          readOnly: true
+        - name: grafana-dashboards
+          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml
+          subPath: defaults-off.yaml
+          readOnly: true
         resources:
           requests:
             cpu: 500m
@@ -776,6 +789,10 @@ spec:
           limits:
             cpu: "2"
             memory: 2Gi
+      volumes:
+      - name: grafana-dashboards
+        configMap:
+          name: grafana-dashboards
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

Ships the RED/latency/runtime/logs **chronoverse** Grafana dashboard as versioned files and file-provisions it into the bundled LGTM stack in all four environments (compose dev/prod, k8s local/prod), so it is auto-created on stack bring-up.

- `infra/k8s/base/grafana-dashboards/`: `chronoverse.json` (31 panels — overview stats, HTTP/gRPC RPM, p95 + latency heatmaps, errors spotlight, runtime, Fleet table with goroutines/memory/CPU, logs, trace links), `chronoverse.yaml` provider (`allowUiUpdates: true`, 30s resync), `defaults-off.yaml` removing the LGTM image's bundled JVM/RED demo dashboards (provisioned, not deletable via UI)
- Compose dev/prod and k8s local/prod mount/provision the same files (ConfigMap via `configMapGenerator` + subPath mounts on `lgtm` in k8s); source lives under `infra/k8s/base/` because kustomize cannot read outside its root
- Dashboard links use relative `/explore` URLs with portable datasource UIDs and template vars, so the same file works in every environment
- `go mod tidy` (`otel/metric` direct -> indirect)
- Verified: dev recreate + full `down`/`up` re-provisions from file automatically; both `kubectl kustomize` builds clean; container file checksums and live DB row match the repo with zero stale refs