### PR TITLE
Fix dashboard review findings: links, heatmaps, live k8s mounts

### DIFF
--- a/infra/k8s/base/grafana-dashboards/chronoverse.json
+++ b/infra/k8s/base/grafana-dashboards/chronoverse.json
@@ -24,13 +24,13 @@
             "targetBlank": true,
             "title": "Explore logs",
             "type": "link",
-            "url": "/explore?left=%7B%22datasource%22%3A%20%22loki%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22loki%22%2C%20%22uid%22%3A%20%22loki%22%7D%2C%20%22queryType%22%3A%20%22range%22%2C%20%22query%22%3A%20%22%7Bservice_name%3D~%5C%22%24service%5C%22%7D%22%7D%5D%7D"
+            "url": "/explore?left=%7B%22datasource%22%3A%20%22loki%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22loki%22%2C%20%22uid%22%3A%20%22loki%22%7D%2C%20%22queryType%22%3A%20%22range%22%2C%20%22expr%22%3A%20%22%7Bservice_name%3D~%5C%22$service%5C%22%7D%22%7D%5D%7D"
         },
         {
             "targetBlank": true,
             "title": "Explore traces",
             "type": "link",
-            "url": "/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%7D%5D%7D"
+            "url": "/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22$service%5C%22%20%7D%22%7D%5D%7D"
         }
     ],
     "panels": [
@@ -1463,7 +1463,7 @@
             },
             "id": 23,
             "options": {
-                "content": "Trace search lives in Explore:\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22%24service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
+                "content": "Trace search lives in Explore:\n\n- [Search traces (Tempo)](/explore?left=%7B%22datasource%22%3A%20%22tempo%22%2C%20%22queries%22%3A%20%5B%7B%22refId%22%3A%20%22A%22%2C%20%22datasource%22%3A%20%7B%22type%22%3A%20%22tempo%22%2C%20%22uid%22%3A%20%22tempo%22%7D%2C%20%22queryType%22%3A%20%22traceqlSearch%22%2C%20%22query%22%3A%20%22%7B%20resource.service.name%20%3D~%20%5C%22$service%5C%22%20%7D%22%2C%20%22limit%22%3A%2020%7D%5D%7D)\n- In Explore > Tempo, paste a `trace_id` from any log line above for the full waterfall.\n- Tip: HTTP 5xx spikes in \"HTTP by status\" + error logs at the same time = the trace to open.",
                 "mode": "markdown"
             },
             "targets": [],
@@ -1574,6 +1574,7 @@
                     },
                     "editorMode": "code",
                     "expr": "sum by (le) (rate(http_server_request_duration_seconds_bucket{http_route!=\"\",service_name=~\"$service\"}[5m]))",
+                    "format": "heatmap",
                     "instant": false,
                     "legendFormat": "{{le}}",
                     "range": true,
@@ -1634,6 +1635,7 @@
                     },
                     "editorMode": "code",
                     "expr": "sum by (le) (rate(rpc_server_call_duration_seconds_bucket{service_name=~\"$service\",rpc_method!=\"grpc.health.v1.Health/Check\"}[5m]))",
+                    "format": "heatmap",
                     "instant": false,
                     "legendFormat": "{{le}}",
                     "range": true,

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -26,13 +26,17 @@ resources:
 - keda-kafka-network-policy.yaml
 
 configMapGenerator:
+# Two ConfigMaps so each can be mounted as a directory (directory mounts
+# receive ConfigMap updates live; subPath mounts do not). Re-enabling the
+# default name hash additionally triggers a rollout whenever dashboard
+# content changes.
 - name: grafana-dashboards
   files:
   - chronoverse.json=grafana-dashboards/chronoverse.json
+- name: grafana-provisioning
+  files:
   - chronoverse.yaml=grafana-dashboards/chronoverse.yaml
   - defaults-off.yaml=grafana-dashboards/defaults-off.yaml
-  options:
-    disableNameSuffixHash: true
 
 patches:
 - target:

--- a/infra/k8s/overlays/local/infrastructure.yaml
+++ b/infra/k8s/overlays/local/infrastructure.yaml
@@ -759,16 +759,10 @@ spec:
               optional: false
         volumeMounts:
         - name: grafana-dashboards
-          mountPath: /otel-lgtm/dashboards/chronoverse.json
-          subPath: chronoverse.json
+          mountPath: /otel-lgtm/dashboards
           readOnly: true
-        - name: grafana-dashboards
-          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/chronoverse.yaml
-          subPath: chronoverse.yaml
-          readOnly: true
-        - name: grafana-dashboards
-          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml
-          subPath: defaults-off.yaml
+        - name: grafana-provisioning
+          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards
           readOnly: true
         resources:
           requests:
@@ -781,6 +775,9 @@ spec:
       - name: grafana-dashboards
         configMap:
           name: grafana-dashboards
+      - name: grafana-provisioning
+        configMap:
+          name: grafana-provisioning
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/overlays/production/infrastructure.yaml
+++ b/infra/k8s/overlays/production/infrastructure.yaml
@@ -771,16 +771,10 @@ spec:
               optional: false
         volumeMounts:
         - name: grafana-dashboards
-          mountPath: /otel-lgtm/dashboards/chronoverse.json
-          subPath: chronoverse.json
+          mountPath: /otel-lgtm/dashboards
           readOnly: true
-        - name: grafana-dashboards
-          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/chronoverse.yaml
-          subPath: chronoverse.yaml
-          readOnly: true
-        - name: grafana-dashboards
-          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml
-          subPath: defaults-off.yaml
+        - name: grafana-provisioning
+          mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards
           readOnly: true
         resources:
           requests:
@@ -793,6 +787,9 @@ spec:
       - name: grafana-dashboards
         configMap:
           name: grafana-dashboards
+      - name: grafana-provisioning
+        configMap:
+          name: grafana-provisioning
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

Addresses all four AI review findings (all agreed, evidence below) on top of #142.

- Explore links: `$service` left unencoded so Grafana interpolates selections instead of sending a literal `$service`; Loki link uses `expr` (was `query`, opened Explore empty)
- Heatmap targets set `format: heatmap`, so buckets render as a distribution instead of cumulative series
- k8s: split into `grafana-dashboards`/`grafana-provisioning` ConfigMaps mounted as directories (kubelet syncs live, Grafana re-polls every 30s) and re-enabled hashing, so dashboard edits reach running pods via live sync plus rollout on apply

Evidence: link/heatmap fixes verified live in dev Grafana (v10); both `kubectl kustomize` builds show hashed ConfigMaps with refs rewritten on the lgtm Deployment; `sample.yaml` confirmed fully commented (safe to hide under the dir mount).