### PR TITLE
fix: P1 gateway auth hardening (CSRF bind, host-only cookies, HSTS, per-service JWT)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -137,6 +137,7 @@ func run() int {
 			HostURL:        cfg.Server.HostURL,
 			AllowedOrigins: cfg.AllowedOrigins,
 			SameSiteMode:   cfg.SameSiteMode,
+			CookieDomain:   cfg.Server.CookieDomain,
 		},
 		auth,
 		crypto,

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -585,6 +585,7 @@ services:
         chmod 440 /certs/kafka/kafka.key /certs/kafka/kafka.keystore.jks /certs/kafka/kafka.truststore.jks
 
         echo "🔐 Creating Kafka keystore credentials files..."
+        rm -f /certs/kafka/keystore_creds.txt /certs/kafka/truststore_creds.txt /certs/kafka/key_creds.txt
         echo "chronoverse" > /certs/kafka/keystore_creds.txt
         echo "chronoverse" > /certs/kafka/truststore_creds.txt
         echo "chronoverse" > /certs/kafka/key_creds.txt

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -405,7 +405,7 @@ services:
 
   runtime-agent:
     <<: *services-limit
-    image: ghcr.io/hitesh22rana/chronoverse/runtime-agent:latest
+    image: runtime-agent
     container_name: runtime-agent
     environment:
       POSTGRES_HOST: postgres
@@ -644,6 +644,7 @@ services:
         chmod 440 /certs/kafka/kafka.key /certs/kafka/kafka.keystore.jks /certs/kafka/kafka.truststore.jks
 
         echo "🔐 Creating Kafka keystore credentials files..."
+        rm -f /certs/kafka/keystore_creds.txt /certs/kafka/truststore_creds.txt /certs/kafka/key_creds.txt
         echo "$$KAFKA_SSL_KEYSTORE_PASSWORD" > /certs/kafka/keystore_creds.txt
         echo "$$KAFKA_SSL_TRUSTSTORE_PASSWORD" > /certs/kafka/truststore_creds.txt
         echo "$$KAFKA_SSL_KEYSTORE_PASSWORD" > /certs/kafka/key_creds.txt
@@ -799,7 +800,7 @@ services:
 
   init-database-migration:
     <<: *services-limit
-    image: ghcr.io/hitesh22rana/chronoverse/database-migration:latest
+    image: database-migration
     container_name: init-database-migration
     environment:
       POSTGRES_HOST: postgres
@@ -868,7 +869,7 @@ services:
 
   users-service:
     <<: *services-limit
-    image: ghcr.io/hitesh22rana/chronoverse/users-service:latest
+    image: users-service
     container_name: users-service
     environment:
       POSTGRES_HOST: postgres
@@ -949,7 +950,7 @@ services:
 
   workflows-service:
     <<: *services-limit
-    image: ghcr.io/hitesh22rana/chronoverse/workflows-service:latest
+    image: workflows-service
     container_name: workflows-service
     environment:
       POSTGRES_HOST: postgres
@@ -1030,7 +1031,7 @@ services:
 
   jobs-service:
     <<: *services-limit
-    image: ghcr.io/hitesh22rana/chronoverse/jobs-service:latest
+    image: jobs-service
     container_name: jobs-service
     environment:
       POSTGRES_HOST: postgres
@@ -1137,7 +1138,7 @@ services:
 
   notifications-service:
     <<: *services-limit
-    image: ghcr.io/hitesh22rana/chronoverse/notifications-service:latest
+    image: notifications-service
     container_name: notifications-service
     environment:
       POSTGRES_HOST: postgres
@@ -1219,7 +1220,7 @@ services:
 
   analytics-service:
     <<: *services-limit
-    image: ghcr.io/hitesh22rana/chronoverse/analytics-service:latest
+    image: analytics-service
     container_name: analytics-service
     environment:
       POSTGRES_HOST: postgres
@@ -1292,7 +1293,7 @@ services:
 
   scheduling-worker:
     <<: *low-resources-workers-limit
-    image: ghcr.io/hitesh22rana/chronoverse/scheduling-worker:latest
+    image: scheduling-worker
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_USER: primary
@@ -1348,7 +1349,7 @@ services:
 
   workflow-worker:
     <<: *mid-resources-workers-limit
-    image: ghcr.io/hitesh22rana/chronoverse/workflow-worker:latest
+    image: workflow-worker
     environment:
       REDIS_HOST: redis
       REDIS_MAX_MEMORY: ${REDIS_MAX_MEMORY:-768mb}
@@ -1461,7 +1462,7 @@ services:
 
   execution-worker:
     <<: *high-resources-workers-limit
-    image: ghcr.io/hitesh22rana/chronoverse/execution-worker:latest
+    image: execution-worker
     environment:
       REDIS_HOST: redis
       REDIS_MAX_MEMORY: ${REDIS_MAX_MEMORY:-768mb}
@@ -1575,7 +1576,7 @@ services:
 
   joblogs-processor:
     <<: *mid-resources-workers-limit
-    image: ghcr.io/hitesh22rana/chronoverse/joblogs-processor:latest
+    image: joblogs-processor
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_USER: primary
@@ -1663,7 +1664,7 @@ services:
 
   analytics-processor:
     <<: *low-resources-workers-limit
-    image: ghcr.io/hitesh22rana/chronoverse/analytics-processor:latest
+    image: analytics-processor
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_USER: primary
@@ -1730,7 +1731,7 @@ services:
 
   outbox-relay:
     <<: *low-resources-workers-limit
-    image: ghcr.io/hitesh22rana/chronoverse/outbox-relay:latest
+    image: outbox-relay
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_USER: primary
@@ -1799,7 +1800,7 @@ services:
 
   server:
     <<: *services-limit
-    image: ghcr.io/hitesh22rana/chronoverse/server:latest
+    image: server
     container_name: server
     environment:
       CRYPTO_SECRET: "${CRYPTO_SECRET:?set CRYPTO_SECRET to a persistent random 32-byte value}"
@@ -1885,7 +1886,7 @@ services:
       - chronoverse
 
   dashboard:
-    image: ghcr.io/hitesh22rana/chronoverse/dashboard:latest
+    image: dashboard
     container_name: dashboard
     restart: on-failure
     depends_on:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -405,7 +405,7 @@ services:
 
   runtime-agent:
     <<: *services-limit
-    image: runtime-agent
+    image: ghcr.io/hitesh22rana/chronoverse/runtime-agent:latest
     container_name: runtime-agent
     environment:
       POSTGRES_HOST: postgres
@@ -800,7 +800,7 @@ services:
 
   init-database-migration:
     <<: *services-limit
-    image: database-migration
+    image: ghcr.io/hitesh22rana/chronoverse/database-migration:latest
     container_name: init-database-migration
     environment:
       POSTGRES_HOST: postgres
@@ -869,7 +869,7 @@ services:
 
   users-service:
     <<: *services-limit
-    image: users-service
+    image: ghcr.io/hitesh22rana/chronoverse/users-service:latest
     container_name: users-service
     environment:
       POSTGRES_HOST: postgres
@@ -950,7 +950,7 @@ services:
 
   workflows-service:
     <<: *services-limit
-    image: workflows-service
+    image: ghcr.io/hitesh22rana/chronoverse/workflows-service:latest
     container_name: workflows-service
     environment:
       POSTGRES_HOST: postgres
@@ -1031,7 +1031,7 @@ services:
 
   jobs-service:
     <<: *services-limit
-    image: jobs-service
+    image: ghcr.io/hitesh22rana/chronoverse/jobs-service:latest
     container_name: jobs-service
     environment:
       POSTGRES_HOST: postgres
@@ -1138,7 +1138,7 @@ services:
 
   notifications-service:
     <<: *services-limit
-    image: notifications-service
+    image: ghcr.io/hitesh22rana/chronoverse/notifications-service:latest
     container_name: notifications-service
     environment:
       POSTGRES_HOST: postgres
@@ -1220,7 +1220,7 @@ services:
 
   analytics-service:
     <<: *services-limit
-    image: analytics-service
+    image: ghcr.io/hitesh22rana/chronoverse/analytics-service:latest
     container_name: analytics-service
     environment:
       POSTGRES_HOST: postgres
@@ -1293,7 +1293,7 @@ services:
 
   scheduling-worker:
     <<: *low-resources-workers-limit
-    image: scheduling-worker
+    image: ghcr.io/hitesh22rana/chronoverse/scheduling-worker:latest
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_USER: primary
@@ -1349,7 +1349,7 @@ services:
 
   workflow-worker:
     <<: *mid-resources-workers-limit
-    image: workflow-worker
+    image: ghcr.io/hitesh22rana/chronoverse/workflow-worker:latest
     environment:
       REDIS_HOST: redis
       REDIS_MAX_MEMORY: ${REDIS_MAX_MEMORY:-768mb}
@@ -1462,7 +1462,7 @@ services:
 
   execution-worker:
     <<: *high-resources-workers-limit
-    image: execution-worker
+    image: ghcr.io/hitesh22rana/chronoverse/execution-worker:latest
     environment:
       REDIS_HOST: redis
       REDIS_MAX_MEMORY: ${REDIS_MAX_MEMORY:-768mb}
@@ -1576,7 +1576,7 @@ services:
 
   joblogs-processor:
     <<: *mid-resources-workers-limit
-    image: joblogs-processor
+    image: ghcr.io/hitesh22rana/chronoverse/joblogs-processor:latest
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_USER: primary
@@ -1664,7 +1664,7 @@ services:
 
   analytics-processor:
     <<: *low-resources-workers-limit
-    image: analytics-processor
+    image: ghcr.io/hitesh22rana/chronoverse/analytics-processor:latest
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_USER: primary
@@ -1731,7 +1731,7 @@ services:
 
   outbox-relay:
     <<: *low-resources-workers-limit
-    image: outbox-relay
+    image: ghcr.io/hitesh22rana/chronoverse/outbox-relay:latest
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_USER: primary
@@ -1800,7 +1800,7 @@ services:
 
   server:
     <<: *services-limit
-    image: server
+    image: ghcr.io/hitesh22rana/chronoverse/server:latest
     container_name: server
     environment:
       CRYPTO_SECRET: "${CRYPTO_SECRET:?set CRYPTO_SECRET to a persistent random 32-byte value}"
@@ -1886,7 +1886,7 @@ services:
       - chronoverse
 
   dashboard:
-    image: dashboard
+    image: ghcr.io/hitesh22rana/chronoverse/dashboard:latest
     container_name: dashboard
     restart: on-failure
     depends_on:

--- a/dashboard/src/lib/api/client.test.ts
+++ b/dashboard/src/lib/api/client.test.ts
@@ -22,8 +22,30 @@ describe("fetchApi", () => {
             }),
         )
         try {
-            await fetchApi("http://x/", "boom")
+            await fetchApi("http://x/", "boom", { method: "POST" })
             expect(seen.get("X-CSRF-Token")).toBe("tok123")
+        } finally {
+            vi.unstubAllGlobals()
+        }
+    })
+
+    it("fetches the token over CORS when the cookie is unreadable", async () => {
+        vi.stubGlobal("document", { cookie: "" })
+        const calls: Array<{ url: string; headers: Headers }> = []
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (url: string, opts: RequestInit = {}) => {
+                calls.push({ url, headers: new Headers(opts.headers) })
+                if (url.endsWith("/auth/csrf")) {
+                    return new Response(JSON.stringify({ csrfToken: "fresh" }), { status: 200 })
+                }
+                return new Response("{}", { status: 200 })
+            }),
+        )
+        try {
+            await fetchApi("http://api.example.com/workflows", "boom", { method: "POST" })
+            expect(calls[0].url).toBe("http://api.example.com/auth/csrf")
+            expect(calls.at(-1)?.headers.get("X-CSRF-Token")).toBe("fresh")
         } finally {
             vi.unstubAllGlobals()
         }

--- a/dashboard/src/lib/api/client.test.ts
+++ b/dashboard/src/lib/api/client.test.ts
@@ -31,6 +31,7 @@ describe("fetchApi", () => {
 
     it("fetches the token over CORS when the cookie is unreadable", async () => {
         vi.stubGlobal("document", { cookie: "" })
+        vi.stubGlobal("window", { location: { origin: "http://app.example.com" } })
         const calls: Array<{ url: string; headers: Headers }> = []
         vi.stubGlobal(
             "fetch",
@@ -53,6 +54,7 @@ describe("fetchApi", () => {
 
     it("refetches per mutation instead of reusing a stale token", async () => {
         vi.stubGlobal("document", { cookie: "" })
+        vi.stubGlobal("window", { location: { origin: "http://app.example.com" } })
         const csrfCalls: string[] = []
         const mutationTokens: Array<string | null> = []
         vi.stubGlobal(
@@ -73,6 +75,29 @@ describe("fetchApi", () => {
             await fetchApi("http://api.example.com/workflows", "boom", { method: "POST" })
             expect(csrfCalls).toHaveLength(2)
             expect(mutationTokens).toEqual(["tok1", "tok2"])
+        } finally {
+            vi.unstubAllGlobals()
+        }
+    })
+
+    it("resolves relative API URLs against the browser origin", async () => {
+        vi.stubGlobal("document", { cookie: "" })
+        vi.stubGlobal("window", { location: { origin: "http://app.example.com" } })
+        const calls: Array<{ url: string; headers: Headers }> = []
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (url: string, opts: RequestInit = {}) => {
+                calls.push({ url, headers: new Headers(opts.headers) })
+                if (url.endsWith("/auth/csrf")) {
+                    return new Response(JSON.stringify({ csrfToken: "same-origin" }), { status: 200 })
+                }
+                return new Response("{}", { status: 200 })
+            }),
+        )
+        try {
+            await fetchApi("/workflows", "boom", { method: "POST" })
+            expect(calls[0].url).toBe("http://app.example.com/auth/csrf")
+            expect(calls.at(-1)?.headers.get("X-CSRF-Token")).toBe("same-origin")
         } finally {
             vi.unstubAllGlobals()
         }

--- a/dashboard/src/lib/api/client.test.ts
+++ b/dashboard/src/lib/api/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { createIdempotencyKey, fetchApi } from "./client"
+import { apiEndpoints } from "./endpoints"
 
 describe("createIdempotencyKey", () => {
     it("creates cryptographically secure UUID command identities", () => {
@@ -31,7 +32,6 @@ describe("fetchApi", () => {
 
     it("fetches the token over CORS when the cookie is unreadable", async () => {
         vi.stubGlobal("document", { cookie: "" })
-        vi.stubGlobal("window", { location: { origin: "http://app.example.com" } })
         const calls: Array<{ url: string; headers: Headers }> = []
         vi.stubGlobal(
             "fetch",
@@ -45,7 +45,7 @@ describe("fetchApi", () => {
         )
         try {
             await fetchApi("http://api.example.com/workflows", "boom", { method: "POST" })
-            expect(calls[0].url).toBe("http://api.example.com/auth/csrf")
+            expect(calls[0].url).toBe(apiEndpoints.auth.csrf)
             expect(calls.at(-1)?.headers.get("X-CSRF-Token")).toBe("fresh")
         } finally {
             vi.unstubAllGlobals()
@@ -54,7 +54,6 @@ describe("fetchApi", () => {
 
     it("refetches per mutation instead of reusing a stale token", async () => {
         vi.stubGlobal("document", { cookie: "" })
-        vi.stubGlobal("window", { location: { origin: "http://app.example.com" } })
         const csrfCalls: string[] = []
         const mutationTokens: Array<string | null> = []
         vi.stubGlobal(
@@ -80,24 +79,23 @@ describe("fetchApi", () => {
         }
     })
 
-    it("resolves relative API URLs against the browser origin", async () => {
+    it("uses the configured base so edge path prefixes are kept", async () => {
         vi.stubGlobal("document", { cookie: "" })
-        vi.stubGlobal("window", { location: { origin: "http://app.example.com" } })
         const calls: Array<{ url: string; headers: Headers }> = []
         vi.stubGlobal(
             "fetch",
             vi.fn(async (url: string, opts: RequestInit = {}) => {
                 calls.push({ url, headers: new Headers(opts.headers) })
                 if (url.endsWith("/auth/csrf")) {
-                    return new Response(JSON.stringify({ csrfToken: "same-origin" }), { status: 200 })
+                    return new Response(JSON.stringify({ csrfToken: "prefixed" }), { status: 200 })
                 }
                 return new Response("{}", { status: 200 })
             }),
         )
         try {
             await fetchApi("/workflows", "boom", { method: "POST" })
-            expect(calls[0].url).toBe("http://app.example.com/auth/csrf")
-            expect(calls.at(-1)?.headers.get("X-CSRF-Token")).toBe("same-origin")
+            expect(calls[0].url).toBe(apiEndpoints.auth.csrf)
+            expect(calls.at(-1)?.headers.get("X-CSRF-Token")).toBe("prefixed")
         } finally {
             vi.unstubAllGlobals()
         }

--- a/dashboard/src/lib/api/client.test.ts
+++ b/dashboard/src/lib/api/client.test.ts
@@ -50,4 +50,31 @@ describe("fetchApi", () => {
             vi.unstubAllGlobals()
         }
     })
+
+    it("refetches per mutation instead of reusing a stale token", async () => {
+        vi.stubGlobal("document", { cookie: "" })
+        const csrfCalls: string[] = []
+        const mutationTokens: Array<string | null> = []
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (url: string, opts: RequestInit = {}) => {
+                if (url.endsWith("/auth/csrf")) {
+                    csrfCalls.push(url)
+                    return new Response(JSON.stringify({ csrfToken: `tok${csrfCalls.length}` }), {
+                        status: 200,
+                    })
+                }
+                mutationTokens.push(new Headers(opts.headers).get("X-CSRF-Token"))
+                return new Response("{}", { status: 200 })
+            }),
+        )
+        try {
+            await fetchApi("http://api.example.com/workflows", "boom", { method: "POST" })
+            await fetchApi("http://api.example.com/workflows", "boom", { method: "POST" })
+            expect(csrfCalls).toHaveLength(2)
+            expect(mutationTokens).toEqual(["tok1", "tok2"])
+        } finally {
+            vi.unstubAllGlobals()
+        }
+    })
 })

--- a/dashboard/src/lib/api/client.test.ts
+++ b/dashboard/src/lib/api/client.test.ts
@@ -1,11 +1,31 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
-import { createIdempotencyKey } from "./client"
+import { createIdempotencyKey, fetchApi } from "./client"
 
 describe("createIdempotencyKey", () => {
     it("creates cryptographically secure UUID command identities", () => {
         expect(createIdempotencyKey()).toMatch(
             /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
         )
+    })
+})
+
+describe("fetchApi", () => {
+    it("echoes the csrf cookie as X-CSRF-Token", async () => {
+        vi.stubGlobal("document", { cookie: "csrf=tok123" })
+        const seen = new Headers()
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (_url: string, opts: RequestInit = {}) => {
+                new Headers(opts.headers).forEach((v, k) => seen.set(k, v))
+                return new Response("{}", { status: 200 })
+            }),
+        )
+        try {
+            await fetchApi("http://x/", "boom")
+            expect(seen.get("X-CSRF-Token")).toBe("tok123")
+        } finally {
+            vi.unstubAllGlobals()
+        }
     })
 })

--- a/dashboard/src/lib/api/client.ts
+++ b/dashboard/src/lib/api/client.ts
@@ -11,7 +11,8 @@ async function resolveCsrfToken(url: string): Promise<string> {
         return fromCookie
     }
     try {
-        const res = await fetch(new URL("/auth/csrf", url).href, {
+        // Resolve against the browser origin so relative API URLs work too.
+        const res = await fetch(new URL("/auth/csrf", new URL(url, window.location.origin)).href, {
             credentials: "include",
         })
         if (res.ok) {

--- a/dashboard/src/lib/api/client.ts
+++ b/dashboard/src/lib/api/client.ts
@@ -1,3 +1,5 @@
+import { apiEndpoints } from "./endpoints"
+
 function getCookie(name: string) {
     return document.cookie
         .split("; ")
@@ -5,14 +7,14 @@ function getCookie(name: string) {
         ?.split("=")[1] ?? ""
 }
 
-async function resolveCsrfToken(url: string): Promise<string> {
+async function resolveCsrfToken(): Promise<string> {
     const fromCookie = getCookie("csrf")
     if (fromCookie) {
         return fromCookie
     }
     try {
-        // Resolve against the browser origin so relative API URLs work too.
-        const res = await fetch(new URL("/auth/csrf", new URL(url, window.location.origin)).href, {
+        // Configured base keeps edge path prefixes (e.g. /api).
+        const res = await fetch(apiEndpoints.auth.csrf, {
             credentials: "include",
         })
         if (res.ok) {
@@ -32,7 +34,7 @@ async function fetchWithCredentials(url: string, options: RequestInit = {}) {
     }
     const method = (options.method ?? "GET").toUpperCase()
     if (!headers.has("X-CSRF-Token") && method !== "GET" && method !== "HEAD" && typeof document !== "undefined") {
-        const csrf = await resolveCsrfToken(url)
+        const csrf = await resolveCsrfToken()
         if (csrf) {
             headers.set("X-CSRF-Token", csrf)
         }

--- a/dashboard/src/lib/api/client.ts
+++ b/dashboard/src/lib/api/client.ts
@@ -5,15 +5,10 @@ function getCookie(name: string) {
         ?.split("=")[1] ?? ""
 }
 
-let cachedCsrf = ""
-
 async function resolveCsrfToken(url: string): Promise<string> {
     const fromCookie = getCookie("csrf")
     if (fromCookie) {
         return fromCookie
-    }
-    if (cachedCsrf) {
-        return cachedCsrf
     }
     try {
         const res = await fetch(new URL("/auth/csrf", url).href, {
@@ -21,14 +16,12 @@ async function resolveCsrfToken(url: string): Promise<string> {
         })
         if (res.ok) {
             const data = (await res.json()) as { csrfToken?: string }
-            if (data.csrfToken) {
-                cachedCsrf = data.csrfToken
-            }
+            return data.csrfToken ?? ""
         }
     } catch {
         // No token available; caller sends the request without it.
     }
-    return cachedCsrf
+    return ""
 }
 
 async function fetchWithCredentials(url: string, options: RequestInit = {}) {

--- a/dashboard/src/lib/api/client.ts
+++ b/dashboard/src/lib/api/client.ts
@@ -1,7 +1,18 @@
+function getCookie(name: string) {
+    return document.cookie
+        .split("; ")
+        .find((c) => c.startsWith(name + "="))
+        ?.split("=")[1] ?? ""
+}
+
 async function fetchWithCredentials(url: string, options: RequestInit = {}) {
     const headers = new Headers(options.headers)
     if (!headers.has("Content-Type")) {
         headers.set("Content-Type", "application/json")
+    }
+    const csrf = typeof document !== "undefined" ? getCookie("csrf") : ""
+    if (csrf && !headers.has("X-CSRF-Token")) {
+        headers.set("X-CSRF-Token", csrf)
     }
 
     return fetch(url, {

--- a/dashboard/src/lib/api/client.ts
+++ b/dashboard/src/lib/api/client.ts
@@ -5,14 +5,43 @@ function getCookie(name: string) {
         ?.split("=")[1] ?? ""
 }
 
+let cachedCsrf = ""
+
+async function resolveCsrfToken(url: string): Promise<string> {
+    const fromCookie = getCookie("csrf")
+    if (fromCookie) {
+        return fromCookie
+    }
+    if (cachedCsrf) {
+        return cachedCsrf
+    }
+    try {
+        const res = await fetch(new URL("/auth/csrf", url).href, {
+            credentials: "include",
+        })
+        if (res.ok) {
+            const data = (await res.json()) as { csrfToken?: string }
+            if (data.csrfToken) {
+                cachedCsrf = data.csrfToken
+            }
+        }
+    } catch {
+        // No token available; caller sends the request without it.
+    }
+    return cachedCsrf
+}
+
 async function fetchWithCredentials(url: string, options: RequestInit = {}) {
     const headers = new Headers(options.headers)
     if (!headers.has("Content-Type")) {
         headers.set("Content-Type", "application/json")
     }
-    const csrf = typeof document !== "undefined" ? getCookie("csrf") : ""
-    if (csrf && !headers.has("X-CSRF-Token")) {
-        headers.set("X-CSRF-Token", csrf)
+    const method = (options.method ?? "GET").toUpperCase()
+    if (!headers.has("X-CSRF-Token") && method !== "GET" && method !== "HEAD" && typeof document !== "undefined") {
+        const csrf = await resolveCsrfToken(url)
+        if (csrf) {
+            headers.set("X-CSRF-Token", csrf)
+        }
     }
 
     return fetch(url, {

--- a/dashboard/src/lib/api/endpoints.test.ts
+++ b/dashboard/src/lib/api/endpoints.test.ts
@@ -25,6 +25,13 @@ describe("createApiEndpoints", () => {
     it("supports same-origin API routes when no base URL is configured", () => {
         expect(createApiEndpoints().workflows.list).toBe("/workflows")
     })
+
+    it("keeps edge path prefixes on the csrf endpoint", () => {
+        expect(createApiEndpoints("https://example.com/api").auth.csrf).toBe(
+            "https://example.com/api/auth/csrf",
+        )
+        expect(createApiEndpoints().auth.csrf).toBe("/auth/csrf")
+    })
 })
 
 describe("withQuery", () => {

--- a/dashboard/src/lib/api/endpoints.ts
+++ b/dashboard/src/lib/api/endpoints.ts
@@ -14,6 +14,7 @@ export function createApiEndpoints(baseUrl?: string) {
             login: route("/auth/login"),
             signup: route("/auth/register"),
             logout: route("/auth/logout"),
+            csrf: route("/auth/csrf"),
         },
         users: route("/users"),
         notifications: route("/notifications"),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,6 +161,9 @@ The public HTTP server reads:
 - `SERVER_HOST_URL`
 - `SERVER_ALLOWED_ORIGINS`
 - `SERVER_SAME_SITE_MODE`
+- `SERVER_COOKIE_DOMAIN` (optional; shares session/CSRF cookies with
+  subdomains, e.g. dashboard at `app.example.com` with API at
+  `example.com`; must match or parent the host URL; default host-only)
 - `CRYPTO_SECRET`
 
 In development the dashboard calls the server directly. In production, Nginx

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"errors"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -37,6 +39,7 @@ type Server struct {
 	HostURL           string        `envconfig:"SERVER_HOST_URL" default:"http://localhost:8080"`
 	AllowedOrigins    []string      `envconfig:"SERVER_ALLOWED_ORIGINS" default:"http://localhost:3001,"`
 	SameSiteMode      string        `envconfig:"SERVER_SAME_SITE_MODE" default:"STRICT"`
+	CookieDomain      string        `envconfig:"SERVER_COOKIE_DOMAIN" default:""`
 }
 
 // InitServerConfig initializes the server configuration.
@@ -75,6 +78,21 @@ func validateServerSecrets(cfg *ServerConfig) error {
 	if len(cfg.CSRFHMACSecret) < minCSRFHMACSecretLength {
 		return errors.New("SERVER_CSRF_HMAC_SECRET must be at least 32 bytes long")
 	}
+	return validateCookieDomain(cfg.HostURL, cfg.CookieDomain)
+}
 
+// validateCookieDomain keeps cookies host-only by default. An explicit domain
+// must match or parent the public host, else browsers drop the cookies.
+func validateCookieDomain(hostURL, domain string) error {
+	if domain == "" {
+		return nil
+	}
+	u, err := url.Parse(hostURL)
+	if err != nil {
+		return errors.New("SERVER_HOST_URL must be a valid URL to use SERVER_COOKIE_DOMAIN")
+	}
+	if host := u.Hostname(); host != domain && !strings.HasSuffix(host, "."+domain) {
+		return errors.New("SERVER_COOKIE_DOMAIN must match or parent the SERVER_HOST_URL host")
+	}
 	return nil
 }

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -66,3 +66,34 @@ func TestValidateServerSecrets(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCookieDomain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		hostURL string
+		domain  string
+		wantErr bool
+	}{
+		{name: "empty stays host-only", hostURL: "https://api.example.com", domain: ""},
+		{name: "exact match", hostURL: "https://example.com", domain: "example.com"},
+		{name: "parent domain", hostURL: "https://api.example.com", domain: "example.com"},
+		{name: "sibling rejected", hostURL: "https://api.example.com", domain: "other.com", wantErr: true},
+		{name: "suffix trick rejected", hostURL: "https://evilexample.com", domain: "example.com", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateCookieDomain(tt.hostURL, tt.domain)
+			if tt.wantErr && err == nil {
+				t.Fatal("validateCookieDomain() error = nil, want an error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateCookieDomain() error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -517,6 +517,7 @@ func (a *Auth) ValidateToken(ctx context.Context, expectedAudience string) (outC
 	return outCtx, parsed, nil
 }
 
+// Gateway JWTs are per-service, never broad. New services need an entry here.
 // Keep trustedIssuers in sync with cmd/<svc>/main.go build ldflags.
 var trustedIssuers = []string{
 	ServiceNameServer,
@@ -533,9 +534,6 @@ var trustedIssuers = []string{
 	"analytics-processor",
 	"outbox-relay",
 }
-
-// Gateway tokens are scoped per destination service, never broad.
-// Adding a new gRPC service requires updating trustedIssuers.
 
 // TrustedIssuer reports whether iss is a known platform service identity.
 func TrustedIssuer(iss string) bool {

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -534,21 +534,8 @@ var trustedIssuers = []string{
 	"outbox-relay",
 }
 
-// GatewayAudiences returns the audience set stamped into tokens the
-// gateway (server) mints or forwards. Every service the gateway may
-// forward a call to is included so the receiver can ValidateToken with
-// its own service name and the JWT remains valid. Adding a new gRPC
-// service requires updating trustedIssuers and GatewayAudiences.
-func GatewayAudiences() []string {
-	return []string{
-		ServiceNameServer,
-		ServiceNameUsers,
-		ServiceNameWorkflows,
-		ServiceNameJobs,
-		ServiceNameNotifications,
-		ServiceNameAnalytics,
-	}
-}
+// Gateway tokens are scoped per destination service, never broad.
+// Adding a new gRPC service requires updating trustedIssuers.
 
 // TrustedIssuer reports whether iss is a known platform service identity.
 func TrustedIssuer(iss string) bool {

--- a/internal/pkg/auth/auth_test.go
+++ b/internal/pkg/auth/auth_test.go
@@ -323,14 +323,10 @@ func TestTrustedIssuerKnownService(t *testing.T) {
 	}
 }
 
-func TestGatewayAudiencesIncludesEveryForwardedService(t *testing.T) {
-	got := map[string]struct{}{}
-	for _, a := range GatewayAudiences() {
-		got[a] = struct{}{}
-	}
+func TestServiceNameConstants(t *testing.T) {
 	for _, want := range []string{"server", "users-service", "workflows-service", "jobs-service", "notifications-service", "analytics-service"} {
-		if _, ok := got[want]; !ok {
-			t.Fatalf("GatewayAudiences missing %q", want)
+		if !TrustedIssuer(want) {
+			t.Fatalf("missing service %q", want)
 		}
 	}
 }

--- a/internal/repository/users/users.go
+++ b/internal/repository/users/users.go
@@ -116,7 +116,7 @@ func (r *Repository) RegisterUser(ctx context.Context, email, password, idempote
 		if err = tx.Commit(ctx); err != nil {
 			return nil, "", status.Errorf(codes.Internal, "failed to commit registration replay: %v", err)
 		}
-		authToken, err = r.auth.IssueToken(ctx, res.ID, auth.GatewayAudiences()...)
+		authToken, err = r.auth.IssueToken(ctx, res.ID, auth.ServiceNameServer)
 		return res, authToken, err
 	}
 
@@ -173,7 +173,7 @@ func (r *Repository) RegisterUser(ctx context.Context, email, password, idempote
 	}
 
 	// Authentication material is issued only after the account and ledger commit.
-	authToken, err = r.auth.IssueToken(ctx, res.ID, auth.GatewayAudiences()...)
+	authToken, err = r.auth.IssueToken(ctx, res.ID, auth.ServiceNameServer)
 	if err != nil {
 		return nil, "", err
 	}
@@ -239,7 +239,7 @@ func (r *Repository) LoginUser(ctx context.Context, email, pass string) (res *us
 	}
 
 	// Issue authToken
-	authToken, err = r.auth.IssueToken(ctx, loginUserResponse.ID, auth.GatewayAudiences()...)
+	authToken, err = r.auth.IssueToken(ctx, loginUserResponse.ID, auth.ServiceNameServer)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/server/csrf_test.go
+++ b/internal/server/csrf_test.go
@@ -2,6 +2,10 @@
 package server
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -26,5 +30,43 @@ func TestVerifyCSRFToken(t *testing.T) {
 	tamperedToken := strings.Repeat("0", len(parts[0])) + delimiter + parts[1]
 	if err := verifyCSRFToken(tamperedToken, session, hmacKey, time.Hour); err == nil {
 		t.Fatal("verifyCSRFToken() accepted a tampered token")
+	}
+}
+
+func TestHandleGetCSRFToken(t *testing.T) {
+	s := &Server{
+		validationCfg: &ValidationConfig{CSRFHMACSecret: "test-secret-0123456789abcdef", CSRFExpiry: time.Hour},
+		hostConfig:    &HostConfig{Host: "api.example.com", Secure: true, SameSite: http.SameSiteNoneMode},
+	}
+
+	unauth := httptest.NewRecorder()
+	s.handleGetCSRFToken(unauth, httptest.NewRequest(http.MethodGet, "/auth/csrf", http.NoBody))
+	if unauth.Code != http.StatusUnauthorized {
+		t.Fatalf("missing session: got %d, want 401", unauth.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/csrf", http.NoBody)
+	req = req.WithContext(context.WithValue(req.Context(), sessionKey{}, "sess"))
+	res := httptest.NewRecorder()
+	s.handleGetCSRFToken(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", res.Code)
+	}
+
+	var body struct {
+		CSRFToken string `json:"csrfToken"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil || body.CSRFToken == "" {
+		t.Fatalf("missing csrfToken in body: %v", err)
+	}
+	if err := verifyCSRFToken(body.CSRFToken, "sess", "test-secret-0123456789abcdef", time.Hour); err != nil {
+		t.Fatalf("returned token does not verify: %v", err)
+	}
+	setCookieHeader := res.Header().Get("Set-Cookie")
+	if !strings.Contains(setCookieHeader, csrfCookieName+"=") {
+		t.Fatalf("expected refreshed csrf cookie, got %q", setCookieHeader)
+	}
+	if strings.Contains(setCookieHeader, "HttpOnly") {
+		t.Fatalf("csrf cookie must stay readable, got %q", setCookieHeader)
 	}
 }

--- a/internal/server/csrf_test.go
+++ b/internal/server/csrf_test.go
@@ -70,3 +70,37 @@ func TestHandleGetCSRFToken(t *testing.T) {
 		t.Fatalf("csrf cookie must stay readable, got %q", setCookieHeader)
 	}
 }
+
+func TestHandleGetCSRFTokenReusesValidCookie(t *testing.T) {
+	s := &Server{
+		validationCfg: &ValidationConfig{CSRFHMACSecret: "test-secret-0123456789abcdef", CSRFExpiry: time.Hour},
+		hostConfig:    &HostConfig{Host: "api.example.com", Secure: true, SameSite: http.SameSiteNoneMode},
+	}
+
+	token, err := generateCSRFToken("sess", "test-secret-0123456789abcdef")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/csrf", http.NoBody)
+	req = req.WithContext(context.WithValue(req.Context(), sessionKey{}, "sess"))
+	req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: token, Secure: true, HttpOnly: true, SameSite: http.SameSiteStrictMode})
+	res := httptest.NewRecorder()
+	s.handleGetCSRFToken(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", res.Code)
+	}
+
+	var body struct {
+		CSRFToken string `json:"csrfToken"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.CSRFToken != token {
+		t.Fatal("valid presented token must be reused, not rotated")
+	}
+	if setCookie := res.Header().Get("Set-Cookie"); setCookie != "" {
+		t.Fatalf("reused token must not overwrite the cookie, got %q", setCookie)
+	}
+}

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -91,9 +91,8 @@ func sessionFromContext(ctx context.Context) (string, error) {
 	return session, nil
 }
 
-// setCookie sets a host-only cookie. Domain is omitted so subdomains
-// never receive session material. The csrf cookie stays readable so
-// browser JS can echo it in X-CSRF-Token; session stays HttpOnly.
+// Host-only cookie (no Domain). csrf is JS-readable for header echo,
+// session stays HttpOnly.
 func setCookie(w http.ResponseWriter, name, value, _ string, secure bool, httpOnly bool, expires time.Duration, sameSite http.SameSite) {
 	cookie := &http.Cookie{ //nolint:gosec // Secure is configurable so local HTTP development remains supported.
 		Name:     name,
@@ -109,7 +108,6 @@ func setCookie(w http.ResponseWriter, name, value, _ string, secure bool, httpOn
 		cookie.Expires = time.Unix(0, 0).UTC()
 	}
 
-	// Set the cookie in the response
 	http.SetCookie(w, cookie)
 }
 

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -91,13 +91,14 @@ func sessionFromContext(ctx context.Context) (string, error) {
 	return session, nil
 }
 
-// Host-only cookie (no Domain). csrf is JS-readable for header echo,
-// session stays HttpOnly.
-func setCookie(w http.ResponseWriter, name, value, _ string, secure, httpOnly bool, expires time.Duration, sameSite http.SameSite) {
+// Host-only cookie unless CookieDomain is set for subdomain sharing.
+// csrf is JS-readable for header echo, session stays HttpOnly.
+func setCookie(w http.ResponseWriter, name, value, cookieDomain string, secure, httpOnly bool, expires time.Duration, sameSite http.SameSite) {
 	cookie := &http.Cookie{ //nolint:gosec // Secure is configurable so local HTTP development remains supported.
 		Name:     name,
 		Value:    value,
 		Path:     "/",
+		Domain:   cookieDomain,
 		HttpOnly: httpOnly,
 		Secure:   secure,
 		MaxAge:   int(expires.Seconds()),

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -91,8 +91,9 @@ func sessionFromContext(ctx context.Context) (string, error) {
 	return session, nil
 }
 
-// setCookie sets a cookie in the response.
-func setCookie(w http.ResponseWriter, name, value, host string, secure bool, expires time.Duration, sameSite http.SameSite) {
+// setCookie sets a host-only cookie. Domain is omitted so subdomains
+// never receive session material.
+func setCookie(w http.ResponseWriter, name, value, _ string, secure bool, expires time.Duration, sameSite http.SameSite) {
 	cookie := &http.Cookie{ //nolint:gosec // Secure is configurable so local HTTP development remains supported.
 		Name:     name,
 		Value:    value,
@@ -105,11 +106,6 @@ func setCookie(w http.ResponseWriter, name, value, host string, secure bool, exp
 	if expires < 0 {
 		cookie.MaxAge = -1
 		cookie.Expires = time.Unix(0, 0).UTC()
-	}
-
-	// Only set Domain for non-localhost and non-127.0.0.1
-	if !strings.Contains(host, "localhost") && !strings.Contains(host, "127.0.0.1") {
-		cookie.Domain = host
 	}
 
 	// Set the cookie in the response

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -93,7 +93,7 @@ func sessionFromContext(ctx context.Context) (string, error) {
 
 // Host-only cookie (no Domain). csrf is JS-readable for header echo,
 // session stays HttpOnly.
-func setCookie(w http.ResponseWriter, name, value, _ string, secure bool, httpOnly bool, expires time.Duration, sameSite http.SameSite) {
+func setCookie(w http.ResponseWriter, name, value, _ string, secure, httpOnly bool, expires time.Duration, sameSite http.SameSite) {
 	cookie := &http.Cookie{ //nolint:gosec // Secure is configurable so local HTTP development remains supported.
 		Name:     name,
 		Value:    value,

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -21,6 +21,7 @@ const (
 	serverShutdownTimeout = 10 * time.Second
 	csrfCookieName        = "csrf"
 	sessionCookieName     = "session"
+	csrfHeaderName        = "X-CSRF-Token"
 	idempotencyKeyHeader  = "Idempotency-Key"
 	logStreamStdout       = "stdout"
 	workflowKindHeartbeat = "HEARTBEAT"

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -92,13 +92,14 @@ func sessionFromContext(ctx context.Context) (string, error) {
 }
 
 // setCookie sets a host-only cookie. Domain is omitted so subdomains
-// never receive session material.
-func setCookie(w http.ResponseWriter, name, value, _ string, secure bool, expires time.Duration, sameSite http.SameSite) {
+// never receive session material. The csrf cookie stays readable so
+// browser JS can echo it in X-CSRF-Token; session stays HttpOnly.
+func setCookie(w http.ResponseWriter, name, value, _ string, secure bool, httpOnly bool, expires time.Duration, sameSite http.SameSite) {
 	cookie := &http.Cookie{ //nolint:gosec // Secure is configurable so local HTTP development remains supported.
 		Name:     name,
 		Value:    value,
 		Path:     "/",
-		HttpOnly: true,
+		HttpOnly: httpOnly,
 		Secure:   secure,
 		MaxAge:   int(expires.Seconds()),
 		SameSite: sameSite,

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -12,7 +12,7 @@ import (
 func TestSetCookieDeletesExpiredCookie(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
-	setCookie(recorder, sessionCookieName, "", "localhost", false, -1, http.SameSiteStrictMode)
+	setCookie(recorder, sessionCookieName, "", "localhost", false, true, -1, http.SameSiteStrictMode)
 
 	cookies := recorder.Result().Cookies()
 	if len(cookies) != 1 {
@@ -58,7 +58,7 @@ func TestDecodeJSONRequestRequiresJSONContentType(t *testing.T) {
 func TestSetCookieKeepsPositiveDuration(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
-	setCookie(recorder, sessionCookieName, "value", "localhost", false, time.Hour, http.SameSiteStrictMode)
+	setCookie(recorder, sessionCookieName, "value", "localhost", false, true, time.Hour, http.SameSiteStrictMode)
 
 	cookies := recorder.Result().Cookies()
 	if len(cookies) != 1 {

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -248,9 +248,10 @@ func (s *Server) withVerifySessionMiddleware(next http.HandlerFunc) http.Handler
 	}
 }
 
-// withAttachAuthorizationTokenInMetadataHeaderMiddleware is a middleware that attaches the authorization token to the context.
-// This middleware should only be called after the withVerifySessionMiddleware middleware.
-func (s *Server) withAttachAuthorizationTokenInMetadataHeaderMiddleware(next http.HandlerFunc) http.HandlerFunc {
+// Attaches a short-lived JWT scoped to one destination service.
+// Call only after withVerifySessionMiddleware. Redis holds the session;
+// logout revokes it while outstanding JWTs expire in 15m.
+func (s *Server) withAttachAuthorizationTokenInMetadataHeaderMiddleware(audience string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// There might be chances that the auth token is expired but the session is still valid, since the auth token is short-lived and the session is long-lived.
 		// So, we need to re-issue the auth token.
@@ -260,12 +261,9 @@ func (s *Server) withAttachAuthorizationTokenInMetadataHeaderMiddleware(next htt
 			return
 		}
 
-		// Issue a fresh token whose aud claim names every service the
-		// gateway may forward to. Each receiver validates its own name
-		// is in the list. Metadata Role/Audience are intentionally NOT
-		// populated; the JWT claim is the sole authority.
+		// Fresh token scoped to the destination service only.
 		ctx := auth.WithRole(r.Context(), auth.RoleUser.String())
-		authToken, err := s.auth.IssueToken(ctx, userID, auth.GatewayAudiences()...)
+		authToken, err := s.auth.IssueToken(ctx, userID, audience)
 		if err != nil {
 			http.Error(w, "failed to issue token", http.StatusInternalServerError)
 			return

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -3,6 +3,7 @@ package server
 import (
 	"compress/gzip"
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"net/http"
 	"strings"
@@ -85,7 +86,7 @@ func (s *Server) withCORSMiddleware(next http.Handler) http.Handler {
 			if _, ok := s.allowedOrigins[origin]; ok {
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Idempotency-Key")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Idempotency-Key, X-CSRF-Token")
 				w.Header().Set("Access-Control-Allow-Credentials", "true") // Critical for cookies
 				w.Header().Set("Access-Control-Max-Age", "86400")          // 24 hours
 
@@ -181,6 +182,13 @@ func (s *Server) withVerifyCSRFMiddleware(next http.HandlerFunc) http.HandlerFun
 		// Verify the CSRF token
 		if err := verifyCSRFToken(csrfToken, sessionToken, s.validationCfg.CSRFHMACSecret, s.validationCfg.CSRFExpiry); err != nil {
 			handleError(w, err, "failed to verify csrf token")
+			return
+		}
+
+		// Bind cookie to header; browsers attach cookies cross-site but
+		// attacker pages cannot set custom headers without preflight.
+		if subtle.ConstantTimeCompare([]byte(r.Header.Get(csrfHeaderName)), []byte(csrfToken)) != 1 {
+			http.Error(w, "csrf mismatch", http.StatusForbidden)
 			return
 		}
 

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -74,6 +74,9 @@ func (s *Server) withSecurityHeadersMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Referrer-Policy", "no-referrer")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
+		if s.hostConfig != nil && s.hostConfig.Secure {
+			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -91,7 +91,7 @@ func (s *Server) withCORSMiddleware(next http.Handler) http.Handler {
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Idempotency-Key, X-CSRF-Token")
 				w.Header().Set("Access-Control-Allow-Credentials", "true") // Critical for cookies
-				w.Header().Set("Access-Control-Max-Age", "86400")          // 24 hours
+				w.Header().Set("Access-Control-Max-Age", "86400")
 
 				// Handle preflight requests
 				if r.Method == http.MethodOptions {
@@ -188,8 +188,7 @@ func (s *Server) withVerifyCSRFMiddleware(next http.HandlerFunc) http.HandlerFun
 			return
 		}
 
-		// Bind cookie to header; browsers attach cookies cross-site but
-		// attacker pages cannot set custom headers without preflight.
+		// Cookie-to-header bind; cross-site pages can't set headers.
 		if subtle.ConstantTimeCompare([]byte(r.Header.Get(csrfHeaderName)), []byte(csrfToken)) != 1 {
 			http.Error(w, "csrf mismatch", http.StatusForbidden)
 			return
@@ -220,13 +219,8 @@ func (s *Server) withVerifySessionMiddleware(next http.HandlerFunc) http.Handler
 		// Attach the token to the context
 		ctx := auth.WithAuthorizationToken(r.Context(), authToken)
 
-		// The cookie stores a token issued by users-service at
-		// login/register; its aud claim is "users-service". We accept it
-		// here so the session is recognized, but the middleware does NOT
-		// stamp audience/role into the per-request downstream context —
-		// each forwarded call re-issues a fresh token with the correct
-		// audience for the destination service (see
-		// withAttachAuthorizationTokenInMetadataHeaderMiddleware).
+		// The cookie holds a server-audience token minted at login/register.
+		// Role/audience for downstream calls are re-issued per service below.
 		if _, _, err = s.auth.ValidateToken(ctx, svcpkg.Info().GetName()); err != nil && status.Code(err) != codes.DeadlineExceeded {
 			http.Error(w, "invalid token", http.StatusUnauthorized)
 			return
@@ -248,20 +242,17 @@ func (s *Server) withVerifySessionMiddleware(next http.HandlerFunc) http.Handler
 	}
 }
 
-// Attaches a short-lived JWT scoped to one destination service.
-// Call only after withVerifySessionMiddleware. Redis holds the session;
-// logout revokes it while outstanding JWTs expire in 15m.
+// Issues a short-lived JWT for one service; call after session check.
+// Redis is the session truth, JWTs expire in 15m.
 func (s *Server) withAttachAuthorizationTokenInMetadataHeaderMiddleware(audience string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// There might be chances that the auth token is expired but the session is still valid, since the auth token is short-lived and the session is long-lived.
-		// So, we need to re-issue the auth token.
+		// Session outlives the token, so re-issue here.
 		userID, ok := r.Context().Value(userIDKey{}).(string)
 		if !ok {
 			http.Error(w, "user ID not found in context", http.StatusUnauthorized)
 			return
 		}
 
-		// Fresh token scoped to the destination service only.
 		ctx := auth.WithRole(r.Context(), auth.RoleUser.String())
 		authToken, err := s.auth.IssueToken(ctx, userID, audience)
 		if err != nil {
@@ -269,7 +260,7 @@ func (s *Server) withAttachAuthorizationTokenInMetadataHeaderMiddleware(audience
 			return
 		}
 
-		// Attach the token to the metadata for outgoing requests and call the next handler
+		// Forward as bearer metadata.
 		ctx = auth.WithAuthorizationTokenInMetadata(ctx, authToken)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	}

--- a/internal/server/middlewares_test.go
+++ b/internal/server/middlewares_test.go
@@ -221,9 +221,17 @@ func TestSecurityHeadersHSTSOnlyWhenSecure(t *testing.T) {
 
 func TestSetCookieIsHostOnly(t *testing.T) {
 	recorder := httptest.NewRecorder()
-	setCookie(recorder, sessionCookieName, "v", "example.com", true, true, time.Hour, http.SameSiteStrictMode)
+	setCookie(recorder, sessionCookieName, "v", "", true, true, time.Hour, http.SameSiteStrictMode)
 	if d := recorder.Result().Cookies()[0].Domain; d != "" {
 		t.Fatalf("expected empty Domain, got %q", d)
+	}
+}
+
+func TestSetCookieSharedDomain(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	setCookie(recorder, sessionCookieName, "v", "example.com", true, true, time.Hour, http.SameSiteStrictMode)
+	if d := recorder.Result().Cookies()[0].Domain; d != "example.com" {
+		t.Fatalf("expected Domain example.com, got %q", d)
 	}
 }
 

--- a/internal/server/middlewares_test.go
+++ b/internal/server/middlewares_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -26,12 +27,7 @@ func TestAttachAuthorizationTokenSeedsUserRole(t *testing.T) {
 	authService := authmock.NewMockIAuth(gomock.NewController(t))
 	authService.EXPECT().IssueToken(
 		gomock.Any(), "user-42",
-		auth.ServiceNameServer,
-		auth.ServiceNameUsers,
-		auth.ServiceNameWorkflows,
 		auth.ServiceNameJobs,
-		auth.ServiceNameNotifications,
-		auth.ServiceNameAnalytics,
 	).DoAndReturn(func(ctx context.Context, _ string, _ ...string) (string, error) {
 		role, err := auth.ExtractRoleFromContext(ctx)
 		if err != nil || role != auth.RoleUser.String() {
@@ -41,7 +37,7 @@ func TestAttachAuthorizationTokenSeedsUserRole(t *testing.T) {
 	})
 
 	s := &Server{auth: authService}
-	handler := s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(http.HandlerFunc(
+	handler := s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameJobs, http.HandlerFunc(
 		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusAccepted) },
 	))
 	req := httptest.NewRequest(http.MethodGet, "/jobs", http.NoBody)
@@ -80,6 +76,9 @@ func TestCORSMiddlewareAllowsIdempotencyKeyHeader(t *testing.T) {
 	allowedHeaders := strings.ToLower(res.Header().Get("Access-Control-Allow-Headers"))
 	if !strings.Contains(allowedHeaders, "idempotency-key") {
 		t.Fatalf("expected idempotency-key in CORS allowed headers, got %q", allowedHeaders)
+	}
+	if !strings.Contains(allowedHeaders, "x-csrf-token") {
+		t.Fatalf("expected x-csrf-token in CORS allowed headers, got %q", allowedHeaders)
 	}
 }
 
@@ -165,6 +164,66 @@ func TestRequestLoggingMiddlewarePreservesFlusher(t *testing.T) {
 
 	if !flusherAvailable {
 		t.Fatal("expected request logging middleware to preserve http.Flusher")
+	}
+}
+
+func TestVerifyCSRFMiddlewareRequiresHeader(t *testing.T) {
+	s := &Server{validationCfg: &ValidationConfig{CSRFHMACSecret: "test-secret-0123456789abcdef", CSRFExpiry: time.Hour}}
+	next := s.withVerifyCSRFMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token, err := generateCSRFToken("sess", "test-secret-0123456789abcdef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	newReq := func(header string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/workflows", http.NoBody)
+		req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: token})
+		req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "sess"})
+		if header != "" {
+			req.Header.Set(csrfHeaderName, header)
+		}
+		return req
+	}
+
+	res := httptest.NewRecorder()
+	next.ServeHTTP(res, newReq(""))
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("missing header: got %d, want 403", res.Code)
+	}
+	res = httptest.NewRecorder()
+	next.ServeHTTP(res, newReq("wrong"))
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("wrong header: got %d, want 403", res.Code)
+	}
+	res = httptest.NewRecorder()
+	next.ServeHTTP(res, newReq(token))
+	if res.Code != http.StatusOK {
+		t.Fatalf("matching header: got %d, want 200", res.Code)
+	}
+}
+
+func TestSecurityHeadersHSTSOnlyWhenSecure(t *testing.T) {
+	for _, tc := range []struct {
+		secure bool
+		want   bool
+	}{{false, false}, {true, true}} {
+		s := &Server{hostConfig: &HostConfig{Secure: tc.secure}}
+		h := s.withSecurityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+		res := httptest.NewRecorder()
+		h.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+		if got := res.Header().Get("Strict-Transport-Security") != ""; got != tc.want {
+			t.Fatalf("secure=%v: hsts present=%v", tc.secure, got)
+		}
+	}
+}
+
+func TestSetCookieIsHostOnly(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	setCookie(recorder, sessionCookieName, "v", "example.com", true, time.Hour, http.SameSiteStrictMode)
+	if d := recorder.Result().Cookies()[0].Domain; d != "" {
+		t.Fatalf("expected empty Domain, got %q", d)
 	}
 }
 

--- a/internal/server/middlewares_test.go
+++ b/internal/server/middlewares_test.go
@@ -179,8 +179,8 @@ func TestVerifyCSRFMiddlewareRequiresHeader(t *testing.T) {
 	}
 	newReq := func(header string) *http.Request {
 		req := httptest.NewRequest(http.MethodPost, "/workflows", http.NoBody)
-		req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: token})
-		req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "sess"})
+		req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: token, Secure: true, HttpOnly: true, SameSite: http.SameSiteStrictMode})
+		req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "sess", Secure: true, HttpOnly: true, SameSite: http.SameSiteStrictMode})
 		if header != "" {
 			req.Header.Set(csrfHeaderName, header)
 		}
@@ -210,7 +210,7 @@ func TestSecurityHeadersHSTSOnlyWhenSecure(t *testing.T) {
 		want   bool
 	}{{false, false}, {true, true}} {
 		s := &Server{hostConfig: &HostConfig{Secure: tc.secure}}
-		h := s.withSecurityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+		h := s.withSecurityHeadersMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 		res := httptest.NewRecorder()
 		h.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
 		if got := res.Header().Get("Strict-Transport-Security") != ""; got != tc.want {

--- a/internal/server/middlewares_test.go
+++ b/internal/server/middlewares_test.go
@@ -221,9 +221,22 @@ func TestSecurityHeadersHSTSOnlyWhenSecure(t *testing.T) {
 
 func TestSetCookieIsHostOnly(t *testing.T) {
 	recorder := httptest.NewRecorder()
-	setCookie(recorder, sessionCookieName, "v", "example.com", true, time.Hour, http.SameSiteStrictMode)
+	setCookie(recorder, sessionCookieName, "v", "example.com", true, true, time.Hour, http.SameSiteStrictMode)
 	if d := recorder.Result().Cookies()[0].Domain; d != "" {
 		t.Fatalf("expected empty Domain, got %q", d)
+	}
+}
+
+func TestCsrfCookieReadableSessionNot(t *testing.T) {
+	csrf := httptest.NewRecorder()
+	setCookie(csrf, csrfCookieName, "v", "example.com", true, false, time.Hour, http.SameSiteStrictMode)
+	if strings.Contains(csrf.Header().Get("Set-Cookie"), "HttpOnly") {
+		t.Fatal("csrf cookie must be readable by JS for header binding")
+	}
+	sess := httptest.NewRecorder()
+	setCookie(sess, sessionCookieName, "v", "example.com", true, true, time.Hour, http.SameSiteStrictMode)
+	if !strings.Contains(sess.Header().Get("Set-Cookie"), "HttpOnly") {
+		t.Fatal("session cookie must stay HttpOnly")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -200,7 +200,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 				s.withAllowedMethodMiddleware(
 					http.MethodGet,
 					s.withVerifySessionMiddleware(
-						s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+						s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameUsers,
 							s.handleGetUser,
 						),
 					),
@@ -210,7 +210,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 					http.MethodPut,
 					s.withVerifyCSRFMiddleware(
 						s.withVerifySessionMiddleware(
-							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameUsers,
 								s.handleUpdateUser,
 							),
 						),
@@ -231,7 +231,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 				s.withAllowedMethodMiddleware(
 					http.MethodGet,
 					s.withVerifySessionMiddleware(
-						s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+						s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameWorkflows,
 							s.handleListWorkflows,
 						),
 					),
@@ -241,7 +241,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 					http.MethodPost,
 					s.withVerifyCSRFMiddleware(
 						s.withVerifySessionMiddleware(
-							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameWorkflows,
 								s.handleCreateWorkflow,
 							),
 						),
@@ -259,7 +259,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 				s.withAllowedMethodMiddleware(
 					http.MethodGet,
 					s.withVerifySessionMiddleware(
-						s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+						s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameWorkflows,
 							s.handleGetWorkflow,
 						),
 					),
@@ -269,7 +269,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 					http.MethodPut,
 					s.withVerifyCSRFMiddleware(
 						s.withVerifySessionMiddleware(
-							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameWorkflows,
 								s.handleUpdateWorkflow,
 							),
 						),
@@ -280,7 +280,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 					http.MethodPatch,
 					s.withVerifyCSRFMiddleware(
 						s.withVerifySessionMiddleware(
-							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameWorkflows,
 								s.handleTerminateWorkflow,
 							),
 						),
@@ -291,7 +291,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 					http.MethodDelete,
 					s.withVerifyCSRFMiddleware(
 						s.withVerifySessionMiddleware(
-							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameWorkflows,
 								s.handleDeleteWorkflow,
 							),
 						),
@@ -309,7 +309,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 		s.withAllowedMethodMiddleware(
 			http.MethodGet,
 			s.withVerifySessionMiddleware(
-				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameJobs,
 					s.handleListJobs,
 				),
 			),
@@ -321,7 +321,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 			http.MethodPost,
 			s.withVerifyCSRFMiddleware(
 				s.withVerifySessionMiddleware(
-					s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+					s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameJobs,
 						s.handleManualScheduleJob,
 					),
 				),
@@ -333,7 +333,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 		s.withAllowedMethodMiddleware(
 			http.MethodGet,
 			s.withVerifySessionMiddleware(
-				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameJobs,
 					s.handleGetJob,
 				),
 			),
@@ -344,7 +344,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 		s.withAllowedMethodMiddleware(
 			http.MethodGet,
 			s.withVerifySessionMiddleware(
-				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameJobs,
 					s.handleGetJobLogs,
 				),
 			),
@@ -355,7 +355,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 		s.withAllowedMethodMiddleware(
 			http.MethodGet,
 			s.withVerifySessionMiddleware(
-				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameJobs,
 					s.handleSearchJobLogs,
 				),
 			),
@@ -366,7 +366,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 		s.withAllowedMethodMiddleware(
 			http.MethodGet,
 			s.withVerifySessionMiddleware(
-				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameJobs,
 					s.handleDownloadJobLogs,
 				),
 			),
@@ -377,7 +377,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 		s.withAllowedMethodMiddleware(
 			http.MethodGet,
 			s.withVerifySessionMiddleware(
-				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameJobs,
 					s.handleJobEvents,
 				),
 			),
@@ -393,7 +393,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 				s.withAllowedMethodMiddleware(
 					http.MethodGet,
 					s.withVerifySessionMiddleware(
-						s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+						s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameNotifications,
 							s.handleListNotifications,
 						),
 					),
@@ -403,7 +403,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 					http.MethodPut,
 					s.withVerifyCSRFMiddleware(
 						s.withVerifySessionMiddleware(
-							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+							s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameNotifications,
 								s.handleMarkNotificationsRead,
 							),
 						),
@@ -419,7 +419,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 		s.withAllowedMethodMiddleware(
 			http.MethodGet,
 			s.withVerifySessionMiddleware(
-				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameAnalytics,
 					s.handleGetUserAnalytics,
 				),
 			),
@@ -431,7 +431,7 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 		s.withAllowedMethodMiddleware(
 			http.MethodGet,
 			s.withVerifySessionMiddleware(
-				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(
+				s.withAttachAuthorizationTokenInMetadataHeaderMiddleware(auth.ServiceNameAnalytics,
 					s.handleGetWorkflowAnalytics,
 				),
 			),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,10 +53,11 @@ type ValidationConfig struct {
 
 // HostConfig represents the configuration of the backend host.
 type HostConfig struct {
-	URL      string
-	Host     string
-	Secure   bool
-	SameSite http.SameSite
+	URL          string
+	Host         string
+	Secure       bool
+	SameSite     http.SameSite
+	CookieDomain string
 }
 
 // Config represents the configuration of the HTTP server.
@@ -72,6 +73,7 @@ type Config struct {
 	HostURL           string
 	AllowedOrigins    []string
 	SameSiteMode      string
+	CookieDomain      string
 }
 
 // New creates a new HTTP server.
@@ -126,10 +128,11 @@ func New(
 		},
 		validationCfg: cfg.ValidationConfig,
 		hostConfig: &HostConfig{
-			URL:      cfg.HostURL,
-			Host:     host.Hostname(),
-			Secure:   host.Scheme == "https",
-			SameSite: sameSite,
+			URL:          cfg.HostURL,
+			Host:         host.Hostname(),
+			Secure:       host.Scheme == "https",
+			SameSite:     sameSite,
+			CookieDomain: cfg.CookieDomain,
 		},
 		allowedOrigins: allowedOrigins,
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -190,6 +190,15 @@ func (s *Server) registerRoutes(router *http.ServeMux) {
 			),
 		),
 	)
+	router.HandleFunc(
+		"/auth/csrf",
+		s.withAllowedMethodMiddleware(
+			http.MethodGet,
+			s.withVerifySessionMiddleware(
+				s.handleGetCSRFToken,
+			),
+		),
+	)
 
 	// Users routes
 	router.HandleFunc(

--- a/internal/server/users_handlers.go
+++ b/internal/server/users_handlers.go
@@ -63,8 +63,8 @@ func (s *Server) handleRegisterUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.Host, s.hostConfig.Secure, false, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
-	setCookie(w, sessionCookieName, session, s.hostConfig.Host, s.hostConfig.Secure, true, s.validationCfg.SessionExpiry, s.hostConfig.SameSite)
+	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.CookieDomain, s.hostConfig.Secure, false, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
+	setCookie(w, sessionCookieName, session, s.hostConfig.CookieDomain, s.hostConfig.Secure, true, s.validationCfg.SessionExpiry, s.hostConfig.SameSite)
 
 	w.WriteHeader(http.StatusCreated)
 }
@@ -114,16 +114,16 @@ func (s *Server) handleLoginUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.Host, s.hostConfig.Secure, false, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
-	setCookie(w, sessionCookieName, session, s.hostConfig.Host, s.hostConfig.Secure, true, s.validationCfg.SessionExpiry, s.hostConfig.SameSite)
+	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.CookieDomain, s.hostConfig.Secure, false, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
+	setCookie(w, sessionCookieName, session, s.hostConfig.CookieDomain, s.hostConfig.Secure, true, s.validationCfg.SessionExpiry, s.hostConfig.SameSite)
 
 	w.WriteHeader(http.StatusCreated)
 }
 
 func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	// Delete the csrf and session cookies
-	setCookie(w, csrfCookieName, "", s.hostConfig.Host, s.hostConfig.Secure, false, -1, s.hostConfig.SameSite)
-	setCookie(w, sessionCookieName, "", s.hostConfig.Host, s.hostConfig.Secure, true, -1, s.hostConfig.SameSite)
+	setCookie(w, csrfCookieName, "", s.hostConfig.CookieDomain, s.hostConfig.Secure, false, -1, s.hostConfig.SameSite)
+	setCookie(w, sessionCookieName, "", s.hostConfig.CookieDomain, s.hostConfig.Secure, true, -1, s.hostConfig.SameSite)
 
 	session, err := sessionFromContext(r.Context())
 	if err != nil {
@@ -175,7 +175,7 @@ func (s *Server) handleGetCSRFToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.Host, s.hostConfig.Secure, false, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
+	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.CookieDomain, s.hostConfig.Secure, false, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/internal/server/users_handlers.go
+++ b/internal/server/users_handlers.go
@@ -159,7 +159,7 @@ func (s *Server) handleGetCSRFToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Reuse the presented token while valid so concurrent tabs share one value.
-	if csrfCookie, err := r.Cookie(csrfCookieName); err == nil {
+	if csrfCookie, cookieErr := r.Cookie(csrfCookieName); cookieErr == nil {
 		if verifyCSRFToken(csrfCookie.Value, session, s.validationCfg.CSRFHMACSecret, s.validationCfg.CSRFExpiry) == nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)

--- a/internal/server/users_handlers.go
+++ b/internal/server/users_handlers.go
@@ -144,6 +144,34 @@ func (s *Server) handleValidate(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+type csrfTokenResponse struct {
+	CSRFToken string `json:"csrfToken"`
+}
+
+// Issues a readable CSRF token for the current session. Lets dashboards
+// that cannot read the API-host cookie (cross-host) fetch the header value
+// over CORS instead.
+func (s *Server) handleGetCSRFToken(w http.ResponseWriter, r *http.Request) {
+	session, err := sessionFromContext(r.Context())
+	if err != nil {
+		http.Error(w, "session not found in context", http.StatusUnauthorized)
+		return
+	}
+
+	csrfToken, err := generateCSRFToken(session, s.validationCfg.CSRFHMACSecret)
+	if err != nil {
+		handleError(w, err, "failed to generate CSRF token")
+		return
+	}
+
+	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.Host, s.hostConfig.Secure, false, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	//nolint:errcheck // The error is always nil
+	json.NewEncoder(w).Encode(csrfTokenResponse{CSRFToken: csrfToken})
+}
+
 func (s *Server) handleGetUser(w http.ResponseWriter, r *http.Request) {
 	value := r.Context().Value(userIDKey{})
 	if value == nil {

--- a/internal/server/users_handlers.go
+++ b/internal/server/users_handlers.go
@@ -63,8 +63,8 @@ func (s *Server) handleRegisterUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.Host, s.hostConfig.Secure, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
-	setCookie(w, sessionCookieName, session, s.hostConfig.Host, s.hostConfig.Secure, s.validationCfg.SessionExpiry, s.hostConfig.SameSite)
+	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.Host, s.hostConfig.Secure, false, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
+	setCookie(w, sessionCookieName, session, s.hostConfig.Host, s.hostConfig.Secure, true, s.validationCfg.SessionExpiry, s.hostConfig.SameSite)
 
 	w.WriteHeader(http.StatusCreated)
 }
@@ -114,16 +114,16 @@ func (s *Server) handleLoginUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.Host, s.hostConfig.Secure, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
-	setCookie(w, sessionCookieName, session, s.hostConfig.Host, s.hostConfig.Secure, s.validationCfg.SessionExpiry, s.hostConfig.SameSite)
+	setCookie(w, csrfCookieName, csrfToken, s.hostConfig.Host, s.hostConfig.Secure, false, s.validationCfg.CSRFExpiry, s.hostConfig.SameSite)
+	setCookie(w, sessionCookieName, session, s.hostConfig.Host, s.hostConfig.Secure, true, s.validationCfg.SessionExpiry, s.hostConfig.SameSite)
 
 	w.WriteHeader(http.StatusCreated)
 }
 
 func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	// Delete the csrf and session cookies
-	setCookie(w, csrfCookieName, "", s.hostConfig.Host, s.hostConfig.Secure, -1, s.hostConfig.SameSite)
-	setCookie(w, sessionCookieName, "", s.hostConfig.Host, s.hostConfig.Secure, -1, s.hostConfig.SameSite)
+	setCookie(w, csrfCookieName, "", s.hostConfig.Host, s.hostConfig.Secure, false, -1, s.hostConfig.SameSite)
+	setCookie(w, sessionCookieName, "", s.hostConfig.Host, s.hostConfig.Secure, true, -1, s.hostConfig.SameSite)
 
 	session, err := sessionFromContext(r.Context())
 	if err != nil {

--- a/internal/server/users_handlers.go
+++ b/internal/server/users_handlers.go
@@ -158,6 +158,17 @@ func (s *Server) handleGetCSRFToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reuse the presented token while valid so concurrent tabs share one value.
+	if csrfCookie, err := r.Cookie(csrfCookieName); err == nil {
+		if verifyCSRFToken(csrfCookie.Value, session, s.validationCfg.CSRFHMACSecret, s.validationCfg.CSRFExpiry) == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			//nolint:errcheck // The error is always nil
+			json.NewEncoder(w).Encode(csrfTokenResponse{CSRFToken: csrfCookie.Value})
+			return
+		}
+	}
+
 	csrfToken, err := generateCSRFToken(session, s.validationCfg.CSRFHMACSecret)
 	if err != nil {
 		handleError(w, err, "failed to generate CSRF token")

--- a/static/content/docs/api/request-safety.mdx
+++ b/static/content/docs/api/request-safety.mdx
@@ -4,7 +4,7 @@ Chronoverse uses separate mechanisms for browser request authenticity and retry 
 
 ## CSRF validation
 
-Authenticated mutations require CSRF validation in addition to the session cookie. Login and registration establish the browser cookie state used by later requests.
+Authenticated mutations require CSRF validation in addition to the session cookie. Login and registration establish the browser cookie state used by later requests. Mutating requests must echo the readable `csrf` cookie in the `X-CSRF-Token` header; the `session` cookie stays `HttpOnly` and is never exposed to JavaScript.
 
 ## Idempotency keys
 

--- a/static/content/docs/api/request-safety.mdx
+++ b/static/content/docs/api/request-safety.mdx
@@ -4,7 +4,7 @@ Chronoverse uses separate mechanisms for browser request authenticity and retry 
 
 ## CSRF validation
 
-Authenticated mutations require CSRF validation in addition to the session cookie. Login and registration establish the browser cookie state used by later requests. Mutating requests must echo the readable `csrf` cookie in the `X-CSRF-Token` header; the `session` cookie stays `HttpOnly` and is never exposed to JavaScript.
+Authenticated mutations require CSRF validation in addition to the session cookie. Login and registration establish the browser cookie state used by later requests. Mutating requests must echo the readable `csrf` cookie in the `X-CSRF-Token` header; the `session` cookie stays `HttpOnly` and is never exposed to JavaScript. Dashboards served from a different host than the API cannot read that cookie, so they fetch the token from `GET /auth/csrf` (session-authenticated) instead.
 
 ## Idempotency keys
 

--- a/static/content/docs/deployment/configuration.mdx
+++ b/static/content/docs/deployment/configuration.mdx
@@ -8,7 +8,7 @@ All Go processes accept `ENV` as the runtime mode label. It defaults to `develop
 
 ## HTTP server
 
-Host and timeouts use `SERVER_HOST`, `SERVER_PORT`, request/read/header/idle timeout values, request body limit, session and CSRF expiry, host URL, allowed origins, same-site mode, `SERVER_CSRF_HMAC_SECRET`, and `CRYPTO_SECRET`.
+Host and timeouts use `SERVER_HOST`, `SERVER_PORT`, request/read/header/idle timeout values, request body limit, session and CSRF expiry, host URL, allowed origins, same-site mode, optional cookie domain for subdomain sharing, `SERVER_CSRF_HMAC_SECRET`, and `CRYPTO_SECRET`.
 
 Startup requires persistent, distinct values for `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET` in any environment. Startup rejects empty values and reuse of one value for both purposes. Both Compose profiles require both variables explicitly; the Kubernetes setup workflow validates `chronoverse-server-security`.
 

--- a/static/public/llms-full.txt
+++ b/static/public/llms-full.txt
@@ -1487,7 +1487,7 @@ All Go processes accept `ENV` as the runtime mode label. It defaults to `develop
 
 ## HTTP server
 
-Host and timeouts use `SERVER_HOST`, `SERVER_PORT`, request/read/header/idle timeout values, request body limit, session and CSRF expiry, host URL, allowed origins, same-site mode, `SERVER_CSRF_HMAC_SECRET`, and `CRYPTO_SECRET`.
+Host and timeouts use `SERVER_HOST`, `SERVER_PORT`, request/read/header/idle timeout values, request body limit, session and CSRF expiry, host URL, allowed origins, same-site mode, optional cookie domain for subdomain sharing, `SERVER_CSRF_HMAC_SECRET`, and `CRYPTO_SECRET`.
 
 Startup requires persistent, distinct values for `CRYPTO_SECRET` and `SERVER_CSRF_HMAC_SECRET` in any environment. Startup rejects empty values and reuse of one value for both purposes. Both Compose profiles require both variables explicitly; the Kubernetes setup workflow validates `chronoverse-server-security`.
 

--- a/static/public/llms-full.txt
+++ b/static/public/llms-full.txt
@@ -983,7 +983,7 @@ Chronoverse uses separate mechanisms for browser request authenticity and retry 
 
 ## CSRF validation
 
-Authenticated mutations require CSRF validation in addition to the session cookie. Login and registration establish the browser cookie state used by later requests.
+Authenticated mutations require CSRF validation in addition to the session cookie. Login and registration establish the browser cookie state used by later requests. Mutating requests must echo the readable `csrf` cookie in the `X-CSRF-Token` header; the `session` cookie stays `HttpOnly` and is never exposed to JavaScript.
 
 ## Idempotency keys
 

--- a/static/public/llms-full.txt
+++ b/static/public/llms-full.txt
@@ -983,7 +983,7 @@ Chronoverse uses separate mechanisms for browser request authenticity and retry 
 
 ## CSRF validation
 
-Authenticated mutations require CSRF validation in addition to the session cookie. Login and registration establish the browser cookie state used by later requests. Mutating requests must echo the readable `csrf` cookie in the `X-CSRF-Token` header; the `session` cookie stays `HttpOnly` and is never exposed to JavaScript.
+Authenticated mutations require CSRF validation in addition to the session cookie. Login and registration establish the browser cookie state used by later requests. Mutating requests must echo the readable `csrf` cookie in the `X-CSRF-Token` header; the `session` cookie stays `HttpOnly` and is never exposed to JavaScript. Dashboards served from a different host than the API cannot read that cookie, so they fetch the token from `GET /auth/csrf` (session-authenticated) instead.
 
 ## Idempotency keys
 


### PR DESCRIPTION
## Summary

- Bind the CSRF cookie to the X-CSRF-Token header (constant-time compare); allow the header in CORS; dashboard sends it on mutations.
- csrf cookie readable (HttpOnly off) so browser JS can echo it; session stays HttpOnly, host-only by default with opt-in SERVER_COOKIE_DOMAIN for subdomain sharing (validated at startup).
- Send HSTS on https responses.
- Add session-authenticated GET /auth/csrf returning a readable token for dashboards on a different host than the API; reuses the presented token while valid so tabs share one value. Dashboard uses the configured API base (keeps edge path prefixes) with cookie fast-path, fetched per mutation otherwise.
- Scope gateway JWTs per destination service; session tokens carry the server audience only; remove the broad-audience helper.
- Make init-certs idempotent for Kafka credential files (recreate instead of overwriting read-only files).
- Document the X-CSRF-Token echo rule, the /auth/csrf fallback, and the cookie domain; regenerate the llms bundle.

## Verification

- make lint OK; go build ./... OK.
- go test ./internal/server/... ./internal/pkg/auth/... ./internal/repository/users/... ./internal/config/... OK.
- init-certs run twice consecutively OK.
- Dashboard: tsc --noEmit OK, eslint OK, vitest src/lib/api 11 passed; validate:llms + validate:docs OK.